### PR TITLE
docs(AGENTS): clarify rustup default stable gotcha for Cloud agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,7 +165,9 @@ script is idempotent (skips download when files are already verified).
 
 - Rust 1.85+ is required. The `time` crate dependency needs edition2024 support,
   which is not available in Rust <1.85. Use `rustup update stable` if the
-  pre-installed version is too old.
+  pre-installed version is too old. If `rustc --version` still shows the old
+  version after updating, run `rustup default stable` — the default toolchain
+  may be pinned to a specific version instead of the `stable` channel.
 - `pnpm tauri dev` needs a display (X11/Wayland) to open the WebView window.
 
 ## Why This Exists


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Added a clarifying note to `AGENTS.md` under the Gotchas section: when the VM's default Rust toolchain is pinned to a specific version (e.g. `1.83.0`) rather than the `stable` channel, running `rustup update stable` alone does not update the active toolchain. Agents must also run `rustup default stable` to switch the default.

This was discovered during environment setup — `rustup update stable` installed Rust 1.94 but `rustc --version` still showed 1.83 because the default was pinned.

## Verification

- ✅ `pnpm format` — all files pass
- ✅ `pnpm lint` — zero warnings
- ✅ `pnpm build` — frontend builds successfully
- ✅ `pnpm test` — 242/242 Vitest tests pass
- ✅ `cd src-tauri && cargo test -q` — 178 Rust tests pass
- ✅ `pnpm tauri dev` — app launches, onboarding flow completed

<a href="https://cursor.com/agents/bc-48a84731-128a-48ae-b970-96a7ad1b6dc6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopenkara-demo-app-interaction.mp4"><img src="https://cursor.com/artifacts/c/art-e4965b16-63a3-4322-b178-197352091df7" alt="openkara-demo-app-interaction.mp4" /></a>

## Scope

Docs-only change to `AGENTS.md`. No code modified.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48a84731-128a-48ae-b970-96a7ad1b6dc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48a84731-128a-48ae-b970-96a7ad1b6dc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

