### PR TITLE
Potential fix for code scanning alert no. 56: Cleartext logging of sensitive information

### DIFF
--- a/src-tauri/src/commands/remote_library/mod.rs
+++ b/src-tauri/src/commands/remote_library/mod.rs
@@ -32,8 +32,8 @@ impl RequestSendExt for reqwest::blocking::RequestBuilder {
         op: &'static str,
     ) -> std::result::Result<reqwest::blocking::Response, crate::commands::error::CommandError>
     {
-        self.send().map_err(|error| {
-            tracing::trace!("{op} request failed: {error:?}");
+        self.send().map_err(|_error| {
+            tracing::trace!("{op} request failed");
             crate::commands::error::library_error(format!("{op} could not be completed"))
         })
     }


### PR DESCRIPTION
Potential fix for [https://github.com/thedavidweng/OpenKara/security/code-scanning/56](https://github.com/thedavidweng/OpenKara/security/code-scanning/56)

General fix: never log raw network error objects (`{error:?}` / `{error}`) when requests can carry credentials. Log only a static/sanitized message (optionally with non-sensitive metadata like operation name).

Best single fix without changing functionality: in `src-tauri/src/commands/remote_library/mod.rs`, update `RequestSendExt::send_network` so its trace log does not include the `error` value at all. Keep returning the same user-facing `library_error(format!("{op} could not be completed"))`. This central change covers all alert variants because Dropbox/Google Drive requests use this helper (`send_network(...)`), so tainted request failures can no longer be serialized into logs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
