### PR TITLE
refactor: replace error string-matching with typed error enums

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2748,6 +2748,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tempfile",
+ "thiserror 2.0.18",
  "tiny_http",
  "tracing",
  "uuid",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,6 +24,7 @@ tauri-build = { version = "2.6.0", features = [] }
 
 [dependencies]
 anyhow = "1.0.102"
+thiserror = "2"
 audioadapter-buffers = "3.0.0"
 base64 = "0.22.1"
 cpal = "0.17.3"

--- a/src-tauri/src/audio/decode.rs
+++ b/src-tauri/src/audio/decode.rs
@@ -1,4 +1,3 @@
-use anyhow::{anyhow, bail, Context, Result};
 use std::{
     fs::File,
     io::{Cursor, Read, Seek},
@@ -13,6 +12,7 @@ use symphonia::core::{
     meta::MetadataOptions,
     probe::Hint,
 };
+use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct DecodedAudio {
@@ -22,9 +22,45 @@ pub struct DecodedAudio {
     pub samples: Vec<f32>,
 }
 
-pub fn decode_file(path: &Path) -> Result<DecodedAudio> {
+#[derive(Error, Debug)]
+pub enum DecodeError {
+    #[error("failed to open audio file: {0}")]
+    FileOpenFailed(String),
+
+    #[error("failed to probe audio format: {0}")]
+    ProbeFailed(String),
+
+    #[error("audio container does not expose a default track")]
+    NoDefaultTrack,
+
+    #[error("failed to create audio decoder: {0}")]
+    DecoderCreationFailed(String),
+
+    #[error("failed while reading audio packets: {0}")]
+    PacketReadFailed(String),
+
+    #[error("failed to decode audio: {0}")]
+    DecodeFailed(String),
+
+    #[error("decoded audio contained no PCM samples")]
+    NoSamples,
+
+    #[error("audio track is missing sample rate metadata")]
+    MissingSampleRate,
+
+    #[error("audio track is missing channel metadata")]
+    MissingChannels,
+
+    #[error("decoder reset is not supported")]
+    ResetNotSupported,
+
+    #[error("internal decode error: {0}")]
+    Internal(String),
+}
+
+pub fn decode_file(path: &Path) -> Result<DecodedAudio, DecodeError> {
     let file = File::open(path)
-        .with_context(|| format!("failed to open audio file at {}", path.display()))?;
+        .map_err(|e| DecodeError::FileOpenFailed(format!("{}: {}", path.display(), e)))?;
     decode_source(
         file,
         path.extension().and_then(|value| value.to_str()),
@@ -32,7 +68,7 @@ pub fn decode_file(path: &Path) -> Result<DecodedAudio> {
     )
 }
 
-pub fn decode_bytes(bytes: Vec<u8>, extension: &str) -> Result<DecodedAudio> {
+pub fn decode_bytes(bytes: Vec<u8>, extension: &str) -> Result<DecodedAudio, DecodeError> {
     decode_source(
         Cursor::new(bytes),
         Some(extension),
@@ -40,9 +76,9 @@ pub fn decode_bytes(bytes: Vec<u8>, extension: &str) -> Result<DecodedAudio> {
     )
 }
 
-pub fn probe_file(path: &Path) -> Result<()> {
+pub fn probe_file(path: &Path) -> Result<(), DecodeError> {
     let file = File::open(path)
-        .with_context(|| format!("failed to open audio file at {}", path.display()))?;
+        .map_err(|e| DecodeError::FileOpenFailed(format!("{}: {}", path.display(), e)))?;
     probe_source(
         file,
         path.extension().and_then(|value| value.to_str()),
@@ -50,7 +86,7 @@ pub fn probe_file(path: &Path) -> Result<()> {
     )
 }
 
-pub fn probe_bytes(bytes: Vec<u8>, extension: &str) -> Result<()> {
+pub fn probe_bytes(bytes: Vec<u8>, extension: &str) -> Result<(), DecodeError> {
     probe_source(
         Cursor::new(bytes),
         Some(extension),
@@ -64,7 +100,7 @@ fn extend_interleaved_samples(samples: &mut Vec<f32>, decoded: AudioBufferRef<'_
     samples.extend_from_slice(sample_buffer.samples());
 }
 
-fn probe_source<R>(source: R, extension: Option<&str>, source_label: &str) -> Result<()>
+fn probe_source<R>(source: R, extension: Option<&str>, source_label: &str) -> Result<(), DecodeError>
 where
     R: Read + Seek + MediaSource + Send + Sync + 'static,
 {
@@ -82,17 +118,17 @@ where
             &FormatOptions::default(),
             &MetadataOptions::default(),
         )
-        .with_context(|| format!("failed to probe audio format for {source_label}"))?;
+        .map_err(|e| DecodeError::ProbeFailed(format!("for {source_label}: {e}")))?;
 
     probed
         .format
         .default_track()
-        .context("audio container does not expose a default track")?;
+        .ok_or(DecodeError::NoDefaultTrack)?;
 
     Ok(())
 }
 
-fn decode_source<R>(source: R, extension: Option<&str>, source_label: &str) -> Result<DecodedAudio>
+fn decode_source<R>(source: R, extension: Option<&str>, source_label: &str) -> Result<DecodedAudio, DecodeError>
 where
     R: Read + Seek + MediaSource + Send + Sync + 'static,
 {
@@ -110,19 +146,19 @@ where
             &FormatOptions::default(),
             &MetadataOptions::default(),
         )
-        .with_context(|| format!("failed to probe audio format for {source_label}"))?;
+        .map_err(|e| DecodeError::ProbeFailed(format!("for {source_label}: {e}")))?;
     let mut format = probed.format;
 
     let track = format
         .default_track()
-        .context("audio container does not expose a default track")?;
+        .ok_or(DecodeError::NoDefaultTrack)?;
     let codec_params = &track.codec_params;
     let mut sample_rate = codec_params.sample_rate;
     let mut channels = codec_params.channels.map(|layout| layout.count());
 
     let mut decoder = symphonia::default::get_codecs()
         .make(codec_params, &DecoderOptions::default())
-        .context("failed to create audio decoder")?;
+        .map_err(|e| DecodeError::DecoderCreationFailed(e.to_string()))?;
     let track_id = track.id;
     let mut samples = Vec::new();
 
@@ -135,9 +171,9 @@ where
                 break;
             }
             Err(SymphoniaError::ResetRequired) => {
-                bail!("decoder reset is not supported by the Phase 2 decode pipeline");
+                return Err(DecodeError::ResetNotSupported);
             }
-            Err(error) => return Err(error).context("failed while reading audio packets"),
+            Err(error) => return Err(DecodeError::PacketReadFailed(error.to_string())),
         };
 
         if packet.track_id() != track_id {
@@ -146,7 +182,7 @@ where
 
         let decoded = decoder
             .decode(&packet)
-            .with_context(|| format!("failed to decode audio packet from {source_label}"))?;
+            .map_err(|e| DecodeError::DecodeFailed(format!("from {source_label}: {e}")))?;
 
         let spec = *decoded.spec();
         sample_rate.get_or_insert(spec.rate);
@@ -155,11 +191,11 @@ where
     }
 
     if samples.is_empty() {
-        return Err(anyhow!("decoded audio contained no PCM samples"));
+        return Err(DecodeError::NoSamples);
     }
 
-    let sample_rate = sample_rate.context("audio track is missing sample rate metadata")?;
-    let channels = channels.context("audio track is missing channel metadata")?;
+    let sample_rate = sample_rate.ok_or(DecodeError::MissingSampleRate)?;
+    let channels = channels.ok_or(DecodeError::MissingChannels)?;
     let frame_count = samples.len() / channels;
     let duration_ms = ((frame_count as f64 / sample_rate as f64) * 1000.0).round() as u64;
 

--- a/src-tauri/src/audio/error.rs
+++ b/src-tauri/src/audio/error.rs
@@ -1,0 +1,22 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum PlaybackError {
+    #[error("song {0} was not found in the library")]
+    SongNotFound(String),
+
+    #[error("failed to decode audio: {0}")]
+    AudioDecodeFailed(String),
+
+    #[error("audio output unavailable: {0}")]
+    AudioOutputUnavailable(String),
+
+    #[error("karaoke not ready: {0}")]
+    KaraokeNotReady(String),
+
+    #[error("invalid playback state: {0}")]
+    InvalidPlaybackState(String),
+
+    #[error("playback failed: {0}")]
+    Internal(String),
+}

--- a/src-tauri/src/audio/error.rs
+++ b/src-tauri/src/audio/error.rs
@@ -1,5 +1,7 @@
 use thiserror::Error;
 
+use super::decode::DecodeError;
+
 #[derive(Error, Debug)]
 pub enum PlaybackError {
     #[error("song {0} was not found in the library")]
@@ -19,4 +21,24 @@ pub enum PlaybackError {
 
     #[error("playback failed: {0}")]
     Internal(String),
+}
+
+impl From<DecodeError> for PlaybackError {
+    fn from(err: DecodeError) -> Self {
+        match err {
+            DecodeError::FileOpenFailed(msg)
+            | DecodeError::ProbeFailed(msg)
+            | DecodeError::DecoderCreationFailed(msg)
+            | DecodeError::PacketReadFailed(msg)
+            | DecodeError::DecodeFailed(msg) => PlaybackError::AudioDecodeFailed(msg),
+            DecodeError::NoDefaultTrack
+            | DecodeError::NoSamples
+            | DecodeError::MissingSampleRate
+            | DecodeError::MissingChannels
+            | DecodeError::ResetNotSupported => {
+                PlaybackError::AudioDecodeFailed(err.to_string())
+            }
+            DecodeError::Internal(msg) => PlaybackError::Internal(msg),
+        }
+    }
 }

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,4 +1,5 @@
 pub mod decode;
 pub mod encode;
+pub mod error;
 pub mod output;
 pub mod playback;

--- a/src-tauri/src/audio/output.rs
+++ b/src-tauri/src/audio/output.rs
@@ -1,7 +1,7 @@
 use crate::airplay_stream::AirPlayAudioTap;
 use crate::audio::decode::DecodedAudio;
+use crate::audio::error::PlaybackError;
 use crate::audio::playback::{monotonic_now_ms, LoadedStems, PlaybackController};
-use anyhow::{Context, Result};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{Sample, SampleFormat, SizedSample, Stream};
 use std::{
@@ -20,14 +20,14 @@ pub fn ensure_output_thread(
     airplay_audio_tap: Arc<AirPlayAudioTap>,
     airplay_local_output_suppressed: Arc<AtomicBool>,
     shutdown: Arc<AtomicBool>,
-) -> Result<()> {
+) -> Result<(), PlaybackError> {
     if started.load(Ordering::SeqCst) {
         return Ok(());
     }
 
     let _guard = start_lock
         .lock()
-        .map_err(|_| anyhow::anyhow!("audio output start lock was poisoned"))?;
+        .map_err(|_| PlaybackError::AudioOutputUnavailable("audio output start lock was poisoned".to_owned()))?;
     if started.load(Ordering::SeqCst) {
         return Ok(());
     }
@@ -47,7 +47,8 @@ pub fn ensure_output_thread(
 
     startup_rx
         .recv_timeout(Duration::from_secs(5))
-        .context("timed out while waiting for audio output thread startup")??;
+        .map_err(|_| PlaybackError::AudioOutputUnavailable("timed out while waiting for audio output thread startup".to_owned()))?
+        .map_err(|e| PlaybackError::AudioOutputUnavailable(e.to_string()))?;
     started.store(true, Ordering::SeqCst);
 
     Ok(())
@@ -307,7 +308,7 @@ fn build_output_stream<T>(
     playback: Arc<Mutex<PlaybackController>>,
     airplay_audio_tap: Arc<AirPlayAudioTap>,
     airplay_local_output_suppressed: Arc<AtomicBool>,
-) -> Result<Stream>
+) -> Result<Stream, PlaybackError>
 where
     T: SizedSample + Sample + cpal::FromSample<f32>,
 {
@@ -354,7 +355,7 @@ where
             eprintln!("audio output stream error: {error}");
         },
         None,
-    )?;
+    ).map_err(|e| PlaybackError::AudioOutputUnavailable(format!("failed to build audio output stream: {e}")))?;
 
     Ok(stream)
 }
@@ -363,16 +364,16 @@ fn start_output_thread(
     playback: Arc<Mutex<PlaybackController>>,
     airplay_audio_tap: Arc<AirPlayAudioTap>,
     airplay_local_output_suppressed: Arc<AtomicBool>,
-    startup_tx: mpsc::SyncSender<Result<()>>,
+    startup_tx: mpsc::SyncSender<Result<(), PlaybackError>>,
     shutdown: Arc<AtomicBool>,
-) -> Result<()> {
+) -> Result<(), PlaybackError> {
     let host = cpal::default_host();
     let device = host
         .default_output_device()
-        .context("no default output audio device is available")?;
+        .ok_or_else(|| PlaybackError::AudioOutputUnavailable("no default output audio device is available".to_owned()))?;
     let config = device
         .default_output_config()
-        .context("failed to read default audio output config")?;
+        .map_err(|e| PlaybackError::AudioOutputUnavailable(format!("failed to read default audio output config: {e}")))?;
     let stream = match config.sample_format() {
         SampleFormat::F32 => build_output_stream::<f32>(
             &device,
@@ -396,13 +397,15 @@ fn start_output_thread(
             airplay_local_output_suppressed,
         )?,
         sample_format => {
-            anyhow::bail!("unsupported audio output sample format: {sample_format:?}");
+            return Err(PlaybackError::AudioOutputUnavailable(
+                format!("unsupported audio output sample format: {sample_format:?}")
+            ));
         }
     };
 
     stream
         .play()
-        .context("failed to start audio output stream")?;
+        .map_err(|e| PlaybackError::AudioOutputUnavailable(format!("failed to start audio output stream: {e}")))?;
     let _ = startup_tx.send(Ok(()));
 
     while !shutdown.load(Ordering::Relaxed) {

--- a/src-tauri/src/audio/playback.rs
+++ b/src-tauri/src/audio/playback.rs
@@ -1,5 +1,5 @@
 use crate::audio::decode::DecodedAudio;
-use anyhow::{bail, Result};
+use crate::audio::error::PlaybackError;
 use serde::{Deserialize, Serialize};
 use std::sync::OnceLock;
 use std::time::Instant;
@@ -145,11 +145,11 @@ impl PlaybackController {
         self.snapshot(monotonic_now_ms())
     }
 
-    pub fn play(&mut self, now_ms: u64) -> Result<PlaybackStateSnapshot> {
+    pub fn play(&mut self, now_ms: u64) -> Result<PlaybackStateSnapshot, PlaybackError> {
         let track = self
             .current_track
             .as_mut()
-            .ok_or_else(|| anyhow::anyhow!("no track is loaded"))?;
+            .ok_or_else(|| PlaybackError::InvalidPlaybackState("no track is loaded".to_owned()))?;
         let position_ms = track.position_ms(now_ms);
         track.base_position_ms = position_ms;
         track.started_at_ms = Some(now_ms);
@@ -157,11 +157,11 @@ impl PlaybackController {
         Ok(self.snapshot(now_ms))
     }
 
-    pub fn pause(&mut self, now_ms: u64) -> Result<PlaybackStateSnapshot> {
+    pub fn pause(&mut self, now_ms: u64) -> Result<PlaybackStateSnapshot, PlaybackError> {
         let track = self
             .current_track
             .as_mut()
-            .ok_or_else(|| anyhow::anyhow!("no track is loaded"))?;
+            .ok_or_else(|| PlaybackError::InvalidPlaybackState("no track is loaded".to_owned()))?;
         let position_ms = track.position_ms(now_ms);
         track.base_position_ms = position_ms;
         track.started_at_ms = None;
@@ -169,11 +169,11 @@ impl PlaybackController {
         Ok(self.snapshot(now_ms))
     }
 
-    pub fn seek(&mut self, target_ms: u64, now_ms: u64) -> Result<PlaybackStateSnapshot> {
+    pub fn seek(&mut self, target_ms: u64, now_ms: u64) -> Result<PlaybackStateSnapshot, PlaybackError> {
         let track = self
             .current_track
             .as_mut()
-            .ok_or_else(|| anyhow::anyhow!("no track is loaded"))?;
+            .ok_or_else(|| PlaybackError::InvalidPlaybackState("no track is loaded".to_owned()))?;
         let clamped_ms = target_ms.min(track.duration_ms());
         track.base_position_ms = clamped_ms;
         if track.started_at_ms.is_some() {
@@ -186,12 +186,12 @@ impl PlaybackController {
         Ok(self.snapshot(now_ms))
     }
 
-    pub fn set_volume(&mut self, level: f32) -> Result<PlaybackStateSnapshot> {
+    pub fn set_volume(&mut self, level: f32) -> Result<PlaybackStateSnapshot, PlaybackError> {
         self.volume = level.clamp(0.0, 1.0);
         Ok(self.snapshot(monotonic_now_ms()))
     }
 
-    pub fn set_stem_volume(&mut self, stem: StemName, level: f32) -> Result<PlaybackStateSnapshot> {
+    pub fn set_stem_volume(&mut self, stem: StemName, level: f32) -> Result<PlaybackStateSnapshot, PlaybackError> {
         let level = level.clamp(0.0, 1.0);
         match stem {
             StemName::Vocals => self.stem_volumes.vocals = level,
@@ -202,17 +202,15 @@ impl PlaybackController {
         Ok(self.snapshot(monotonic_now_ms()))
     }
 
-    pub fn attach_stems(&mut self, song_id: &str, stems: LoadedStems) -> Result<()> {
+    pub fn attach_stems(&mut self, song_id: &str, stems: LoadedStems) -> Result<(), PlaybackError> {
         let track = self
             .current_track
             .as_mut()
-            .ok_or_else(|| anyhow::anyhow!("no track is loaded"))?;
+            .ok_or_else(|| PlaybackError::InvalidPlaybackState("no track is loaded".to_owned()))?;
         if track.song_id != song_id {
-            bail!(
-                "cannot attach stems for song {} while {} is loaded",
-                song_id,
-                track.song_id
-            );
+            return Err(PlaybackError::InvalidPlaybackState(
+                format!("cannot attach stems for song {} while {} is loaded", song_id, track.song_id)
+            ));
         }
         track.stems = Some(stems);
         Ok(())

--- a/src-tauri/src/cache/stems.rs
+++ b/src-tauri/src/cache/stems.rs
@@ -455,11 +455,11 @@ pub fn downgrade_to_two_stem(
 
     // Decode each stem file.
     let drums_audio =
-        crate::audio::decode::decode_file(&drums_abs).context("failed to decode drums.ogg")?;
+        crate::audio::decode::decode_file(&drums_abs).map_err(|e| anyhow::anyhow!("failed to decode drums.ogg: {e}"))?;
     let bass_audio =
-        crate::audio::decode::decode_file(&bass_abs).context("failed to decode bass.ogg")?;
+        crate::audio::decode::decode_file(&bass_abs).map_err(|e| anyhow::anyhow!("failed to decode bass.ogg: {e}"))?;
     let other_audio =
-        crate::audio::decode::decode_file(&other_abs).context("failed to decode other.ogg")?;
+        crate::audio::decode::decode_file(&other_abs).map_err(|e| anyhow::anyhow!("failed to decode other.ogg: {e}"))?;
 
     // Mix by summing samples element-wise.
     let len = drums_audio.samples.len();

--- a/src-tauri/src/commands/batch_separation.rs
+++ b/src-tauri/src/commands/batch_separation.rs
@@ -1,6 +1,6 @@
 use crate::{
     cache,
-    commands::error::{database_error, separation_error, CommandResult},
+    commands::error::{database_error, CommandError, CommandResult},
     commands::remote_library,
     commands::separation::{
         completed_status, failed_status, running_status, SeparationCompleteEvent,
@@ -8,7 +8,7 @@ use crate::{
         SEPARATION_ERROR_EVENT, SEPARATION_PROGRESS_EVENT,
     },
     config::{self, StemMode},
-    separator::{self, model::LoadedModel, model_cache::ModelCache},
+    separator::{self, error::SeparationError, model::LoadedModel, model_cache::ModelCache},
     AppState,
 };
 use serde::Serialize;
@@ -41,9 +41,9 @@ pub fn batch_separate(
 
     // Prevent concurrent batch operations.
     if state.separation.batch_running.load(Ordering::Relaxed) {
-        return Err(separation_error(
+        return Err(SeparationError::Failed(
             "A batch separation is already running".to_owned(),
-        ));
+        ).into());
     }
 
     let library_root = state.library_root()?;
@@ -257,7 +257,7 @@ pub fn batch_separate(
                     completed += 1;
                 }
                 Ok(Err(error)) => {
-                    let cmd_error = separation_error(error.to_string());
+                    let cmd_error: CommandError = SeparationError::Failed(error.to_string()).into();
                     let status = failed_status(song_id, cmd_error.clone());
                     if let Ok(mut statuses) = separation_statuses.lock() {
                         statuses.insert(song_id.clone(), status);
@@ -272,7 +272,7 @@ pub fn batch_separate(
                     failed_count += 1;
                 }
                 Err(error) => {
-                    let cmd_error = separation_error(error.to_string());
+                    let cmd_error: CommandError = SeparationError::Failed(error.to_string()).into();
                     let status = failed_status(song_id, cmd_error.clone());
                     if let Ok(mut statuses) = separation_statuses.lock() {
                         statuses.insert(song_id.clone(), status);
@@ -310,9 +310,9 @@ pub fn batch_separate(
 #[tauri::command]
 pub fn cancel_batch_separation(state: State<'_, AppState>) -> CommandResult<()> {
     if !state.separation.batch_running.load(Ordering::Relaxed) {
-        return Err(separation_error(
+        return Err(SeparationError::Failed(
             "No batch separation is currently running".to_owned(),
-        ));
+        ).into());
     }
     state.separation.batch_cancel.store(true, Ordering::Relaxed);
     Ok(())

--- a/src-tauri/src/commands/error.rs
+++ b/src-tauri/src/commands/error.rs
@@ -93,7 +93,8 @@ pub fn model_bootstrap_error(message: impl ToString) -> CommandError {
     )
 }
 
-// --- Typed error conversions ---
+// Typed error conversions — each domain error maps to a CommandError with
+// the appropriate ErrorCode and FallbackAction for the frontend.
 
 impl From<crate::separator::error::SeparationError> for CommandError {
     fn from(err: crate::separator::error::SeparationError) -> Self {

--- a/src-tauri/src/commands/error.rs
+++ b/src-tauri/src/commands/error.rs
@@ -98,22 +98,22 @@ pub fn model_bootstrap_error(message: impl ToString) -> CommandError {
 impl From<crate::separator::error::SeparationError> for CommandError {
     fn from(err: crate::separator::error::SeparationError) -> Self {
         use crate::separator::error::SeparationError::*;
-        match err {
-            SongNotFound(id) => CommandError::new(
+        match &err {
+            SongNotFound(_) => CommandError::new(
                 ErrorCode::SongNotFound,
-                format!("song {id} was not found in the library"),
+                err.to_string(),
                 false,
                 FallbackAction::RefreshLibrary,
             ),
-            AudioDecodeFailed(msg) => CommandError::new(
+            AudioDecodeFailed(_) => CommandError::new(
                 ErrorCode::AudioDecodeFailed,
-                msg,
+                err.to_string(),
                 false,
                 FallbackAction::ReimportSong,
             ),
-            Failed(msg) => CommandError::new(
+            Failed(_) => CommandError::new(
                 ErrorCode::SeparationFailed,
-                msg,
+                err.to_string(),
                 true,
                 FallbackAction::Retry,
             ),
@@ -124,40 +124,40 @@ impl From<crate::separator::error::SeparationError> for CommandError {
 impl From<crate::audio::error::PlaybackError> for CommandError {
     fn from(err: crate::audio::error::PlaybackError) -> Self {
         use crate::audio::error::PlaybackError::*;
-        match err {
-            SongNotFound(id) => CommandError::new(
+        match &err {
+            SongNotFound(_) => CommandError::new(
                 ErrorCode::SongNotFound,
-                format!("song {id} was not found in the library"),
+                err.to_string(),
                 false,
                 FallbackAction::RefreshLibrary,
             ),
-            AudioDecodeFailed(msg) => CommandError::new(
+            AudioDecodeFailed(_) => CommandError::new(
                 ErrorCode::AudioDecodeFailed,
-                msg,
+                err.to_string(),
                 false,
                 FallbackAction::ReimportSong,
             ),
-            AudioOutputUnavailable(msg) => CommandError::new(
+            AudioOutputUnavailable(_) => CommandError::new(
                 ErrorCode::AudioOutputUnavailable,
-                msg,
+                err.to_string(),
                 true,
                 FallbackAction::CheckAudioOutputDevice,
             ),
-            KaraokeNotReady(msg) => CommandError::new(
+            KaraokeNotReady(_) => CommandError::new(
                 ErrorCode::KaraokeNotReady,
-                msg,
+                err.to_string(),
                 true,
                 FallbackAction::StayInOriginalMode,
             ),
-            InvalidPlaybackState(msg) => CommandError::new(
+            InvalidPlaybackState(_) => CommandError::new(
                 ErrorCode::InvalidPlaybackState,
-                msg,
+                err.to_string(),
                 false,
                 FallbackAction::KeepCurrentState,
             ),
-            Internal(msg) => CommandError::new(
+            Internal(_) => CommandError::new(
                 ErrorCode::Internal,
-                msg,
+                err.to_string(),
                 true,
                 FallbackAction::Retry,
             ),
@@ -184,27 +184,27 @@ impl From<crate::library::error::LibraryError> for CommandError {
 impl From<crate::lyrics::error::LyricsError> for CommandError {
     fn from(err: crate::lyrics::error::LyricsError) -> Self {
         use crate::lyrics::error::LyricsError::*;
-        match err {
-            SongNotFound(id) => CommandError::new(
+        match &err {
+            SongNotFound(_) => CommandError::new(
                 ErrorCode::SongNotFound,
-                format!("song {id} was not found in the library"),
+                err.to_string(),
                 false,
                 FallbackAction::RefreshLibrary,
             ),
-            LyricsNotReady(msg) => CommandError::new(
+            LyricsNotReady(_) => CommandError::new(
                 ErrorCode::LyricsNotReady,
-                msg,
+                err.to_string(),
                 true,
                 FallbackAction::ShowEmptyState,
             ),
-            NetworkUnavailable(msg) => CommandError::new(
+            NetworkUnavailable(_) => CommandError::new(
                 ErrorCode::NetworkUnavailable,
-                msg,
+                err.to_string(),
                 true,
                 FallbackAction::Retry,
             ),
-            DatabaseUnavailable(msg) => database_error(msg),
-            Internal(msg) => internal_error(msg),
+            DatabaseUnavailable(_) => database_error(err.to_string()),
+            Internal(_) => internal_error(err.to_string()),
         }
     }
 }

--- a/src-tauri/src/commands/error.rs
+++ b/src-tauri/src/commands/error.rs
@@ -66,29 +66,6 @@ pub fn database_error(message: impl ToString) -> CommandError {
     )
 }
 
-pub fn library_error(message: impl ToString) -> CommandError {
-    let message = message.to_string();
-
-    if message.contains("failed to open audio file")
-        || message.contains("failed to read audio metadata")
-        || message.contains("failed to read audio file")
-        || message.contains("failed to canonicalize path")
-    {
-        return CommandError::new(
-            ErrorCode::MediaReadFailed,
-            message,
-            false,
-            FallbackAction::ReimportSong,
-        );
-    }
-
-    if message.contains("failed to open SQLite database") {
-        return database_error(message);
-    }
-
-    internal_error(message)
-}
-
 pub fn state_lock_error(message: impl ToString) -> CommandError {
     CommandError::new(
         ErrorCode::Internal,
@@ -107,68 +84,6 @@ pub fn internal_error(message: impl ToString) -> CommandError {
     )
 }
 
-pub fn playback_error(message: impl ToString) -> CommandError {
-    let message = message.to_string();
-
-    if message.contains("was not found in the library") {
-        return CommandError::new(
-            ErrorCode::SongNotFound,
-            message,
-            false,
-            FallbackAction::RefreshLibrary,
-        );
-    }
-
-    if message.contains("does not have cached stems")
-        || message.contains("karaoke audio is not loaded")
-    {
-        return CommandError::new(
-            ErrorCode::KaraokeNotReady,
-            message,
-            true,
-            FallbackAction::StayInOriginalMode,
-        );
-    }
-
-    if message.contains("failed to decode audio")
-        || message.contains("failed to open audio file")
-        || message.contains("failed to probe audio format")
-        || message.contains("audio container does not expose a default track")
-        || message.contains("failed to create audio decoder")
-        || message.contains("failed while reading audio packets")
-    {
-        return CommandError::new(
-            ErrorCode::AudioDecodeFailed,
-            message,
-            false,
-            FallbackAction::ReimportSong,
-        );
-    }
-
-    if message.contains("no default output audio device is available")
-        || message.contains("failed to read default audio output config")
-        || message.contains("failed to start audio output stream")
-    {
-        return CommandError::new(
-            ErrorCode::AudioOutputUnavailable,
-            message,
-            true,
-            FallbackAction::CheckAudioOutputDevice,
-        );
-    }
-
-    if message.contains("no track is loaded") {
-        return CommandError::new(
-            ErrorCode::InvalidPlaybackState,
-            message,
-            false,
-            FallbackAction::KeepCurrentState,
-        );
-    }
-
-    internal_error(message)
-}
-
 pub fn model_bootstrap_error(message: impl ToString) -> CommandError {
     CommandError::new(
         ErrorCode::ModelUnavailable,
@@ -178,87 +93,120 @@ pub fn model_bootstrap_error(message: impl ToString) -> CommandError {
     )
 }
 
-pub fn lyrics_error(message: impl ToString) -> CommandError {
-    let message = message.to_string();
+// --- Typed error conversions ---
 
-    if message.contains("was not found in the library") {
-        return CommandError::new(
-            ErrorCode::SongNotFound,
-            message,
-            false,
-            FallbackAction::RefreshLibrary,
-        );
+impl From<crate::separator::error::SeparationError> for CommandError {
+    fn from(err: crate::separator::error::SeparationError) -> Self {
+        use crate::separator::error::SeparationError::*;
+        match err {
+            SongNotFound(id) => CommandError::new(
+                ErrorCode::SongNotFound,
+                format!("song {id} was not found in the library"),
+                false,
+                FallbackAction::RefreshLibrary,
+            ),
+            AudioDecodeFailed(msg) => CommandError::new(
+                ErrorCode::AudioDecodeFailed,
+                msg,
+                false,
+                FallbackAction::ReimportSong,
+            ),
+            Failed(msg) => CommandError::new(
+                ErrorCode::SeparationFailed,
+                msg,
+                true,
+                FallbackAction::Retry,
+            ),
+        }
     }
-
-    if message.contains("does not have cached lyrics")
-        || message.contains("failed to parse synced lyrics")
-        || message.contains("failed to parse cached synced lyrics")
-    {
-        return CommandError::new(
-            ErrorCode::LyricsNotReady,
-            message,
-            true,
-            FallbackAction::ShowEmptyState,
-        );
-    }
-
-    if message.contains("failed to request timed lyrics")
-        || message.contains("timed lyrics provider returned a non-success response")
-        || message.contains("failed to deserialize timed lyrics response")
-        || message.contains("timed lyrics provider returned an unexpected response")
-        || message.contains("failed to request lyrics from LRCLIB")
-        || message.contains("LRCLIB returned a non-success response")
-        || message.contains("failed to deserialize LRCLIB lyrics response")
-    {
-        return CommandError::new(
-            ErrorCode::NetworkUnavailable,
-            message,
-            true,
-            FallbackAction::Retry,
-        );
-    }
-
-    if message.contains("failed to cache fetched lyrics")
-        || message.contains("failed to persist lyrics offset")
-    {
-        return CommandError::new(
-            ErrorCode::DatabaseUnavailable,
-            message,
-            true,
-            FallbackAction::Retry,
-        );
-    }
-
-    internal_error(message)
 }
 
-pub fn separation_error(message: impl ToString) -> CommandError {
-    let message = message.to_string();
-
-    if message.contains("was not found in the library") {
-        return CommandError::new(
-            ErrorCode::SongNotFound,
-            message,
-            false,
-            FallbackAction::RefreshLibrary,
-        );
+impl From<crate::audio::error::PlaybackError> for CommandError {
+    fn from(err: crate::audio::error::PlaybackError) -> Self {
+        use crate::audio::error::PlaybackError::*;
+        match err {
+            SongNotFound(id) => CommandError::new(
+                ErrorCode::SongNotFound,
+                format!("song {id} was not found in the library"),
+                false,
+                FallbackAction::RefreshLibrary,
+            ),
+            AudioDecodeFailed(msg) => CommandError::new(
+                ErrorCode::AudioDecodeFailed,
+                msg,
+                false,
+                FallbackAction::ReimportSong,
+            ),
+            AudioOutputUnavailable(msg) => CommandError::new(
+                ErrorCode::AudioOutputUnavailable,
+                msg,
+                true,
+                FallbackAction::CheckAudioOutputDevice,
+            ),
+            KaraokeNotReady(msg) => CommandError::new(
+                ErrorCode::KaraokeNotReady,
+                msg,
+                true,
+                FallbackAction::StayInOriginalMode,
+            ),
+            InvalidPlaybackState(msg) => CommandError::new(
+                ErrorCode::InvalidPlaybackState,
+                msg,
+                false,
+                FallbackAction::KeepCurrentState,
+            ),
+            Internal(msg) => CommandError::new(
+                ErrorCode::Internal,
+                msg,
+                true,
+                FallbackAction::Retry,
+            ),
+        }
     }
+}
 
-    if message.contains("failed to decode audio") {
-        return CommandError::new(
-            ErrorCode::AudioDecodeFailed,
-            message,
-            false,
-            FallbackAction::ReimportSong,
-        );
+impl From<crate::library::error::LibraryError> for CommandError {
+    fn from(err: crate::library::error::LibraryError) -> Self {
+        use crate::library::error::LibraryError::*;
+        match err {
+            MediaReadFailed(msg) => CommandError::new(
+                ErrorCode::MediaReadFailed,
+                msg,
+                false,
+                FallbackAction::ReimportSong,
+            ),
+            DatabaseUnavailable(msg) => database_error(msg),
+            Internal(msg) => internal_error(msg),
+        }
     }
+}
 
-    CommandError::new(
-        ErrorCode::SeparationFailed,
-        message,
-        true,
-        FallbackAction::Retry,
-    )
+impl From<crate::lyrics::error::LyricsError> for CommandError {
+    fn from(err: crate::lyrics::error::LyricsError) -> Self {
+        use crate::lyrics::error::LyricsError::*;
+        match err {
+            SongNotFound(id) => CommandError::new(
+                ErrorCode::SongNotFound,
+                format!("song {id} was not found in the library"),
+                false,
+                FallbackAction::RefreshLibrary,
+            ),
+            LyricsNotReady(msg) => CommandError::new(
+                ErrorCode::LyricsNotReady,
+                msg,
+                true,
+                FallbackAction::ShowEmptyState,
+            ),
+            NetworkUnavailable(msg) => CommandError::new(
+                ErrorCode::NetworkUnavailable,
+                msg,
+                true,
+                FallbackAction::Retry,
+            ),
+            DatabaseUnavailable(msg) => database_error(msg),
+            Internal(msg) => internal_error(msg),
+        }
+    }
 }
 
 pub fn current_unix_timestamp() -> Result<i64> {

--- a/src-tauri/src/commands/import/cover.rs
+++ b/src-tauri/src/commands/import/cover.rs
@@ -1,7 +1,7 @@
 use crate::{
     cache,
     commands::error::{database_error, CommandError, ErrorCode, FallbackAction},
-    library::Song,
+    library::{error::LibraryError, Song},
     library_root::LibraryRoot,
     media_g::{self, MEDIA_G_ZIP},
     metadata,
@@ -38,7 +38,7 @@ pub(super) fn extract_embedded_cover_art_for_song(
             );
         }
 
-        crate::commands::error::library_error(message)
+        CommandError::from(LibraryError::Internal(message))
     })?;
 
     cache::update_song_cover_art(connection, &song.hash, Some(&cover_art))

--- a/src-tauri/src/commands/import/mod.rs
+++ b/src-tauri/src/commands/import/mod.rs
@@ -15,10 +15,10 @@ use crate::{
     audio::decode,
     cache,
     commands::error::{
-        database_error, internal_error, library_error, state_lock_error, CommandResult,
+        database_error, internal_error, state_lock_error, CommandError, CommandResult,
     },
     commands::remote_library,
-    library::{ImportFailure, ImportSongsResult, Song},
+    library::{error::LibraryError, ImportFailure, ImportSongsResult, Song},
     library_root::LibraryRoot,
     media_g::{self, MEDIA_G_PAIRED, MEDIA_G_ZIP},
     AppState,
@@ -62,7 +62,7 @@ pub fn get_import_candidate_details(
     paths
         .into_iter()
         .map(|raw_path| {
-            inspect_import_candidate(&raw_path).map_err(|error| library_error(error.to_string()))
+            inspect_import_candidate(&raw_path).map_err(|error| CommandError::from(LibraryError::MediaReadFailed(error.to_string())))
         })
         .collect()
 }
@@ -89,7 +89,7 @@ pub fn pick_import_paths(default_path: Option<String>) -> CommandResult<Vec<Stri
             .as_deref()
             .map(CString::new)
             .transpose()
-            .map_err(|error| library_error(error.to_string()))?;
+            .map_err(|error| CommandError::from(LibraryError::Internal(error.to_string())))?;
         let mut count = 0usize;
         let raw_paths = unsafe {
             openkara_pick_import_paths(
@@ -127,9 +127,7 @@ pub fn pick_import_paths(default_path: Option<String>) -> CommandResult<Vec<Stri
     #[cfg(not(target_os = "macos"))]
     {
         let _ = default_path;
-        Err(library_error(
-            "mixed file and folder selection is only available on macOS".to_string(),
-        ))
+        Err(CommandError::from(LibraryError::Internal("mixed file and folder selection is only available on macOS".to_string(),)))
     }
 }
 
@@ -172,7 +170,7 @@ pub fn delete_songs(
             Ok(()) => deleted_song_ids.push(song_id),
             Err(error) => failed.push(DeleteSongsFailure {
                 song_id,
-                error: library_error(error.to_string()),
+                error: CommandError::from(LibraryError::Internal(error.to_string())),
             }),
         }
     }
@@ -265,7 +263,7 @@ pub fn import_songs_from_paths_with_options(
             },
             Err(error) => failed.push(ImportFailure {
                 path: audio_path.display().to_string(),
-                error: library_error(error.to_string()),
+                error: CommandError::from(LibraryError::MediaReadFailed(error.to_string())),
             }),
         }
     }
@@ -281,7 +279,7 @@ pub fn import_songs_from_paths_with_options(
             },
             Err(error) => failed.push(ImportFailure {
                 path: zip_path.display().to_string(),
-                error: library_error(error.to_string()),
+                error: CommandError::from(LibraryError::MediaReadFailed(error.to_string())),
             }),
         }
     }
@@ -293,10 +291,10 @@ pub fn import_songs_from_paths_with_options(
 
         failed.push(ImportFailure {
             path: cdg_path.display().to_string(),
-            error: library_error(format!(
+            error: CommandError::from(LibraryError::Internal(format!(
                 "standalone .cdg file {} does not have a matching audio track",
                 cdg_path.display()
-            )),
+            ))),
         });
     }
 
@@ -421,10 +419,10 @@ pub fn get_song_properties(
         .ok_or_else(|| database_error(format!("song with hash {song_id} not found")))?;
 
     let Some(song_path) = song.file_path.as_deref() else {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "song {} does not have a local file path",
             song_id
-        )));
+        ))));
     };
     if song.is_remote() {
         remote_library::ensure_remote_file_cached(&state.shell.app_data_dir, song_path)?;
@@ -441,17 +439,17 @@ pub fn get_song_properties(
 
     let (decoded, file_size, format) = if song.media_g_container.as_deref() == Some(MEDIA_G_ZIP) {
         let asset = media_g::inspect_zip_for_media_g(&file_path)
-            .map_err(|error| library_error(error.to_string()))?;
+            .map_err(|error| CommandError::from(LibraryError::MediaReadFailed(error.to_string())))?;
         let decoded = decode::decode_bytes(asset.audio_bytes, ext).map_err(|e| {
             internal_error(format!("failed to decode audio for {}: {}", song_id, e))
         })?;
         let file_size = std::fs::metadata(&file_path)
             .map_err(|e| {
-                library_error(format!(
+                CommandError::from(LibraryError::MediaReadFailed(format!(
                     "failed to open Media+G ZIP at {}: {}",
                     file_path.display(),
                     e
-                ))
+                )))
             })?
             .len();
         (
@@ -469,11 +467,11 @@ pub fn get_song_properties(
         })?;
         let file_size = std::fs::metadata(&file_path)
             .map_err(|e| {
-                library_error(format!(
+                CommandError::from(LibraryError::MediaReadFailed(format!(
                     "failed to open audio file at {}: {}",
                     file_path.display(),
                     e
-                ))
+                )))
             })?
             .len();
         let format = if song.media_g_container.as_deref() == Some(MEDIA_G_PAIRED) {

--- a/src-tauri/src/commands/library_setup.rs
+++ b/src-tauri/src/commands/library_setup.rs
@@ -1,6 +1,7 @@
 use crate::{
     cache,
-    commands::error::{library_error, state_lock_error, CommandResult},
+    commands::error::{CommandError, state_lock_error, CommandResult},
+    library::error::LibraryError,
     config::{self, AppConfig, RegisteredLibrary},
     library_root::LibraryRoot,
     AppState,
@@ -27,12 +28,12 @@ fn canonical_path_string(path: &Path) -> String {
 
 fn load_app_config(app_data_dir: &Path) -> CommandResult<AppConfig> {
     Ok(config::load_config(app_data_dir)
-        .map_err(library_error)?
+        .map_err(|e| CommandError::from(LibraryError::Internal(e.to_string())))?
         .unwrap_or_default())
 }
 
 fn persist_app_config(app_data_dir: &Path, config: &AppConfig) -> CommandResult<()> {
-    config::save_config(app_data_dir, config).map_err(library_error)
+    config::save_config(app_data_dir, config).map_err(|e| CommandError::from(LibraryError::Internal(e.to_string())))
 }
 
 fn update_library_display_name(
@@ -46,7 +47,7 @@ fn update_library_display_name(
         .iter_mut()
         .find(|entry| entry.id() == library_id)
     else {
-        return Err(library_error(format!("library {library_id} was not found")));
+        return Err(CommandError::from(LibraryError::Internal(format!("library {library_id} was not found"))));
     };
 
     match library {
@@ -73,7 +74,7 @@ fn delete_library_data(app_data_dir: &Path, library: &RegisteredLibrary) -> Comm
         RegisteredLibrary::Local { root_path, .. } => {
             if Path::new(root_path).exists() {
                 fs::remove_dir_all(root_path).map_err(|error| {
-                    library_error(format!("failed to delete {root_path}: {error}"))
+                    CommandError::from(LibraryError::Internal(format!("failed to delete {root_path}: {error}")))
                 })?;
             }
         }
@@ -82,10 +83,10 @@ fn delete_library_data(app_data_dir: &Path, library: &RegisteredLibrary) -> Comm
             if let Some(working_copy_root) = library.working_copy_root() {
                 if working_copy_root.exists() {
                     fs::remove_dir_all(&working_copy_root).map_err(|error| {
-                        library_error(format!(
+                        CommandError::from(LibraryError::Internal(format!(
                             "failed to delete {}: {error}",
                             working_copy_root.display()
-                        ))
+                        )))
                     })?;
                 }
             }
@@ -133,7 +134,7 @@ fn register_library(
     root: LibraryRoot,
 ) -> CommandResult<LibraryRegistrySnapshot> {
     let db_path = root.database_path();
-    cache::initialize_library_database(&db_path).map_err(library_error)?;
+    cache::initialize_library_database(&db_path).map_err(|e| CommandError::from(LibraryError::DatabaseUnavailable(e.to_string())))?;
 
     let mut config = load_app_config(app_data_dir)?;
     upsert_library(&mut config, library.clone());
@@ -166,14 +167,14 @@ fn activate_library(
         .iter()
         .find(|entry| entry.id() == library_id)
         .cloned()
-        .ok_or_else(|| library_error(format!("library {library_id} was not found")))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal(format!("library {library_id} was not found"))))?;
 
     let root_path = library
         .working_copy_root()
-        .ok_or_else(|| library_error("remote repository is missing a cached working copy"))?;
-    let lib = LibraryRoot::open(&root_path).map_err(library_error)?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal("remote repository is missing a cached working copy".to_string())))?;
+    let lib = LibraryRoot::open(&root_path).map_err(|e| CommandError::from(LibraryError::Internal(e.to_string())))?;
     let db_path = lib.database_path();
-    cache::initialize_library_database(&db_path).map_err(library_error)?;
+    cache::initialize_library_database(&db_path).map_err(|e| CommandError::from(LibraryError::DatabaseUnavailable(e.to_string())))?;
 
     {
         let mut playback = state
@@ -214,7 +215,7 @@ pub fn create_library(
 ) -> CommandResult<LibraryRegistrySnapshot> {
     let lib_path = PathBuf::from(&path);
 
-    let lib = LibraryRoot::create(&lib_path).map_err(library_error)?;
+    let lib = LibraryRoot::create(&lib_path).map_err(|e| CommandError::from(LibraryError::Internal(e.to_string())))?;
     let canonical_root = canonical_path_string(lib.root());
     let library = RegisteredLibrary::local(
         canonical_root.clone(),
@@ -231,7 +232,7 @@ pub fn open_library(
 ) -> CommandResult<LibraryRegistrySnapshot> {
     let lib_path = PathBuf::from(&path);
 
-    let lib = LibraryRoot::open(&lib_path).map_err(library_error)?;
+    let lib = LibraryRoot::open(&lib_path).map_err(|e| CommandError::from(LibraryError::Internal(e.to_string())))?;
     let canonical_root = canonical_path_string(lib.root());
     let library = RegisteredLibrary::local(
         canonical_root.clone(),
@@ -264,7 +265,7 @@ pub fn get_library_registry(app_handle: AppHandle) -> CommandResult<LibraryRegis
     let app_data_dir = app_handle
         .path()
         .app_data_dir()
-        .map_err(|error| library_error(error.to_string()))?;
+        .map_err(|error| CommandError::from(LibraryError::Internal(error.to_string())))?;
     let config = load_app_config(&app_data_dir)?;
 
     Ok(LibraryRegistrySnapshot {
@@ -278,7 +279,7 @@ pub fn get_active_library(app_handle: AppHandle) -> CommandResult<Option<Registe
     let app_data_dir = app_handle
         .path()
         .app_data_dir()
-        .map_err(|error| library_error(error.to_string()))?;
+        .map_err(|error| CommandError::from(LibraryError::Internal(error.to_string())))?;
     let config = load_app_config(&app_data_dir)?;
 
     Ok(config.active_library().cloned())
@@ -293,7 +294,7 @@ pub fn remove_library(
     let app_data_dir = app_handle
         .path()
         .app_data_dir()
-        .map_err(|error| library_error(error.to_string()))?;
+        .map_err(|error| CommandError::from(LibraryError::Internal(error.to_string())))?;
     let mut config = load_app_config(&app_data_dir)?;
     let removed_active = config.active_library_id.as_deref() == Some(library_id.as_str());
     let removed_libraries: Vec<_> = config
@@ -369,7 +370,7 @@ pub fn rename_library(
     let app_data_dir = app_handle
         .path()
         .app_data_dir()
-        .map_err(|error| library_error(error.to_string()))?;
+        .map_err(|error| CommandError::from(LibraryError::Internal(error.to_string())))?;
     update_library_display_name(&app_data_dir, &library_id, &display_name)
 }
 
@@ -382,7 +383,7 @@ pub fn delete_library(
     let app_data_dir = app_handle
         .path()
         .app_data_dir()
-        .map_err(|error| library_error(error.to_string()))?;
+        .map_err(|error| CommandError::from(LibraryError::Internal(error.to_string())))?;
     let config = load_app_config(&app_data_dir)?;
     let Some(library) = config
         .libraries
@@ -390,7 +391,7 @@ pub fn delete_library(
         .find(|entry| entry.id() == library_id)
         .cloned()
     else {
-        return Err(library_error(format!("library {library_id} was not found")));
+        return Err(CommandError::from(LibraryError::Internal(format!("library {library_id} was not found"))));
     };
 
     delete_library_data(&app_data_dir, &library)?;

--- a/src-tauri/src/commands/lyrics.rs
+++ b/src-tauri/src/commands/lyrics.rs
@@ -1,12 +1,13 @@
 use crate::{
     cache,
     cache::lyrics::LyricsCacheEntry,
-    commands::error::{database_error, lyrics_error, CommandResult},
+    commands::error::{database_error, CommandResult},
     commands::remote_library,
     library::Song,
     library_root::LibraryRoot,
     lyrics::{
         self,
+        error::LyricsError,
         fetch::{
             fetch_online_timed_lyrics, lookup_query_from_song, LyricsSource, TimedLyricsProvider,
         },
@@ -16,7 +17,6 @@ use crate::{
     },
     AppState,
 };
-use anyhow::{bail, Context, Result};
 use rusqlite::Connection;
 use serde::Serialize;
 use std::path::Path;
@@ -50,12 +50,7 @@ pub fn fetch_lyrics(
             &lrcapi_client,
             &song_id,
         )
-        .map_err(|error| {
-            // Lower-level lyrics modules still return anyhow errors. Classify them
-            // here so UI-facing commands expose stable error codes and fallback hints
-            // before the internal modules are fully migrated to typed domain errors.
-            lyrics_error(error.to_string())
-        })
+        .map_err(Into::into)
     })
 }
 
@@ -70,8 +65,7 @@ pub fn set_lyrics_offset(
     let connection = cache::open_database(&library.database_path()).map_err(database_error)?;
 
     remote_library::run_song_database_mutation(&state, &app_handle, &song_id, || {
-        set_lyrics_offset_in_connection(&connection, &song_id, ms)
-            .map_err(|error| lyrics_error(error.to_string()))
+        set_lyrics_offset_in_connection(&connection, &song_id, ms).map_err(Into::into)
     })
 }
 
@@ -81,14 +75,16 @@ pub fn fetch_lyrics_from_connection(
     lrclib_client: &LrcLibClient,
     lrcapi_client: &LrcApiClient,
     song_id: &str,
-) -> Result<LyricsPayload> {
+) -> Result<LyricsPayload, LyricsError> {
     let song = cache::get_song_by_hash(connection, song_id)
-        .context("failed to load song from library")?
-        .with_context(|| format!("song with hash {song_id} was not found in the library"))?;
+        .map_err(|e| LyricsError::DatabaseUnavailable(e.to_string()))?
+        .ok_or(LyricsError::SongNotFound(song_id.to_string()))?;
 
     // Lyrics are cached by the stable song hash so repeat fetches can skip both
     // network and filesystem fallbacks once a synced source has been resolved.
-    if let Some(cached) = cache::lyrics::get_lyrics_cache_entry(connection, song_id)? {
+    if let Some(cached) = cache::lyrics::get_lyrics_cache_entry(connection, song_id)
+        .map_err(|e| LyricsError::DatabaseUnavailable(e.to_string()))?
+    {
         return payload_from_cached_entry(song.hash, cached);
     }
 
@@ -109,7 +105,8 @@ pub fn fetch_lyrics_from_connection(
 
     // Online requests are opportunistic: if they fail, we still want embedded
     // and sidecar sources to rescue the fetch instead of failing the whole song.
-    let Some(fetched) = lyrics::fetch::fetch_lyrics_for_song(&providers, &song, &resolved_path)?
+    let Some(fetched) = lyrics::fetch::fetch_lyrics_for_song(&providers, &song, &resolved_path)
+        .map_err(|e| LyricsError::Internal(e.to_string()))?
     else {
         return Ok(LyricsPayload {
             song_id: song.hash,
@@ -121,7 +118,7 @@ pub fn fetch_lyrics_from_connection(
     };
 
     let lines = lyrics::parser::parse_lrc(&fetched.raw_lrc)
-        .with_context(|| format!("failed to parse synced lyrics for song {song_id}"))?;
+        .map_err(|e| LyricsError::LyricsNotReady(e.to_string()))?;
     let source = fetched.source;
     let raw_lrc = fetched.raw_lrc.clone();
     cache::lyrics::upsert_lyrics_cache_entry(
@@ -131,10 +128,11 @@ pub fn fetch_lyrics_from_connection(
             lrc: fetched.raw_lrc,
             source: source.clone(),
             offset_ms: 0,
-            fetched_at: current_unix_timestamp()?,
+            fetched_at: current_unix_timestamp()
+                .map_err(|e| LyricsError::Internal(e.to_string()))?,
         },
     )
-    .context("failed to cache fetched lyrics")?;
+    .map_err(|e| LyricsError::DatabaseUnavailable(e.to_string()))?;
 
     Ok(LyricsPayload {
         song_id: song.hash,
@@ -149,27 +147,29 @@ pub fn set_lyrics_offset_in_connection(
     connection: &Connection,
     song_id: &str,
     ms: i64,
-) -> Result<()> {
-    let song_exists = cache::get_song_by_hash(connection, song_id)
-        .context("failed to load song from library")?
-        .is_some();
-    if !song_exists {
-        bail!("song with hash {song_id} was not found in the library");
-    }
+) -> Result<(), LyricsError> {
+    cache::get_song_by_hash(connection, song_id)
+        .map_err(|e| LyricsError::DatabaseUnavailable(e.to_string()))?
+        .ok_or(LyricsError::SongNotFound(song_id.to_string()))?;
 
-    if cache::lyrics::get_lyrics_cache_entry(connection, song_id)?.is_none() {
-        bail!("song with hash {song_id} does not have cached lyrics");
-    }
+    cache::lyrics::get_lyrics_cache_entry(connection, song_id)
+        .map_err(|e| LyricsError::DatabaseUnavailable(e.to_string()))?
+        .ok_or(LyricsError::LyricsNotReady(format!(
+            "song {song_id} does not have cached lyrics"
+        )))?;
 
     cache::lyrics::set_lyrics_offset(connection, song_id, ms)
-        .context("failed to persist lyrics offset")?;
+        .map_err(|e| LyricsError::DatabaseUnavailable(e.to_string()))?;
 
     Ok(())
 }
 
-fn payload_from_cached_entry(song_id: String, cached: LyricsCacheEntry) -> Result<LyricsPayload> {
+fn payload_from_cached_entry(
+    song_id: String,
+    cached: LyricsCacheEntry,
+) -> Result<LyricsPayload, LyricsError> {
     let mut lines = lyrics::parser::parse_lrc(&cached.lrc)
-        .with_context(|| format!("failed to parse cached synced lyrics for song {song_id}"))?;
+        .map_err(|e| LyricsError::LyricsNotReady(e.to_string()))?;
 
     if lines.is_empty() {
         lines = plain_text_to_lines(&cached.lrc);
@@ -204,7 +204,8 @@ pub fn save_manual_lyrics(
 
         let raw_lrc = text.clone();
 
-        let fetched_at = current_unix_timestamp().map_err(|e| lyrics_error(e.to_string()))?;
+        let fetched_at = current_unix_timestamp()
+            .map_err(|e| LyricsError::Internal(e.to_string()))?;
 
         cache::lyrics::upsert_lyrics_cache_entry(
             &connection,
@@ -312,8 +313,8 @@ pub fn import_lyrics_files(
                         .offset_ms
                         .unwrap_or(0);
 
-                    let fetched_at =
-                        current_unix_timestamp().map_err(|e| lyrics_error(e.to_string()))?;
+                    let fetched_at = current_unix_timestamp()
+                        .map_err(|e| LyricsError::Internal(e.to_string()))?;
 
                     let entry = LyricsCacheEntry {
                         song_hash: song.hash.clone(),
@@ -358,19 +359,22 @@ pub fn extract_embedded_lyrics(
     let publish_song_id = song_id.clone();
     remote_library::run_song_database_mutation(&state, &app_handle, &song_id, || {
         let song = cache::get_song_by_hash(&connection, &publish_song_id)
-            .map_err(|e| lyrics_error(e.to_string()))?
-            .ok_or_else(|| lyrics_error(format!("song {publish_song_id} not found")))?;
+            .map_err(|e| LyricsError::DatabaseUnavailable(e.to_string()))?
+            .ok_or(LyricsError::SongNotFound(publish_song_id.clone()))?;
 
         let Some(song_path) = song.file_path.as_deref() else {
-            return Err(lyrics_error(format!(
+            return Err(LyricsError::Internal(format!(
                 "song {} does not have a local file path",
                 publish_song_id
-            )));
+            ))
+            .into());
         };
         let resolved_path = library_root.resolve(song_path);
         let embedded = lyrics::fetch::read_embedded_lyrics(&resolved_path)
-            .map_err(|e| lyrics_error(e.to_string()))?
-            .ok_or_else(|| lyrics_error("No embedded lyrics found in this file".to_owned()))?;
+            .map_err(|e| LyricsError::Internal(e.to_string()))?
+            .ok_or(LyricsError::LyricsNotReady(
+                "No embedded lyrics found in this file".to_owned(),
+            ))?;
 
         // Parse and cache
         let lines = match lyrics::parser::parse_lrc(&embedded) {
@@ -380,7 +384,8 @@ pub fn extract_embedded_lyrics(
 
         let raw_lrc = embedded.clone();
 
-        let fetched_at = current_unix_timestamp().map_err(|e| lyrics_error(e.to_string()))?;
+        let fetched_at = current_unix_timestamp()
+            .map_err(|e| LyricsError::Internal(e.to_string()))?;
 
         cache::lyrics::upsert_lyrics_cache_entry(
             &connection,
@@ -418,8 +423,8 @@ pub fn fetch_lyrics_online(
         &app_handle,
         || {
             let song = cache::get_song_by_hash(&connection, &song_id)
-                .map_err(|e| lyrics_error(e.to_string()))?
-                .ok_or_else(|| lyrics_error(format!("song {song_id} not found")))?;
+                .map_err(|e| LyricsError::DatabaseUnavailable(e.to_string()))?
+                .ok_or(LyricsError::SongNotFound(song_id.clone()))?;
 
             let lrclib_client = LrcLibClient::new_default();
             let lrcapi_client = LrcApiClient::new_default();
@@ -441,7 +446,7 @@ pub fn fetch_lyrics_online(
             };
 
             let Some(fetched) = fetch_online_timed_lyrics(&providers, &query)
-                .map_err(|e| lyrics_error(e.to_string()))?
+                .map_err(|e| LyricsError::NetworkUnavailable(e.to_string()))?
             else {
                 return Ok(LyricsPayload {
                     song_id: song.hash,
@@ -453,9 +458,10 @@ pub fn fetch_lyrics_online(
             };
 
             let lines = lyrics::parser::parse_lrc(&fetched.raw_lrc)
-                .map_err(|e| lyrics_error(e.to_string()))?;
+                .map_err(|e| LyricsError::LyricsNotReady(e.to_string()))?;
 
-            let fetched_at = current_unix_timestamp().map_err(|e| lyrics_error(e.to_string()))?;
+            let fetched_at = current_unix_timestamp()
+            .map_err(|e| LyricsError::Internal(e.to_string()))?;
 
             cache::lyrics::upsert_lyrics_cache_entry(
                 &connection,

--- a/src-tauri/src/commands/playback.rs
+++ b/src-tauri/src/commands/playback.rs
@@ -1,6 +1,6 @@
 use crate::{
     audio::playback::{PlaybackStateSnapshot, StemName},
-    commands::error::{playback_error, CommandResult},
+    commands::error::{internal_error, CommandResult},
     services,
     state::AppState,
 };
@@ -16,12 +16,11 @@ pub async fn play(
 ) -> CommandResult<PlaybackStateSnapshot> {
     let background_state = state.inner().clone();
     let background_handle = app_handle.clone();
-    tauri::async_runtime::spawn_blocking(move || {
+    Ok(tauri::async_runtime::spawn_blocking(move || {
         services::playback::play(&background_state, &background_handle, &song_id)
     })
     .await
-    .map_err(|error| playback_error(format!("playback task failed: {error}")))?
-    .map_err(playback_error)
+    .map_err(|error| internal_error(format!("playback task failed: {error}")))??)
 }
 
 #[tauri::command]
@@ -29,7 +28,7 @@ pub fn resume(
     state: State<'_, AppState>,
     app_handle: AppHandle,
 ) -> CommandResult<PlaybackStateSnapshot> {
-    services::playback::resume(&state, &app_handle).map_err(playback_error)
+    Ok(services::playback::resume(&state, &app_handle)?)
 }
 
 #[tauri::command]
@@ -37,7 +36,7 @@ pub fn pause(
     state: State<'_, AppState>,
     app_handle: AppHandle,
 ) -> CommandResult<PlaybackStateSnapshot> {
-    services::playback::pause(&state, &app_handle).map_err(playback_error)
+    Ok(services::playback::pause(&state, &app_handle)?)
 }
 
 #[tauri::command]
@@ -46,12 +45,12 @@ pub fn seek(
     app_handle: AppHandle,
     ms: u64,
 ) -> CommandResult<PlaybackStateSnapshot> {
-    services::playback::seek(&state, &app_handle, ms).map_err(playback_error)
+    Ok(services::playback::seek(&state, &app_handle, ms)?)
 }
 
 #[tauri::command]
 pub fn set_volume(state: State<'_, AppState>, level: f32) -> CommandResult<PlaybackStateSnapshot> {
-    services::playback::set_volume(&state, level).map_err(playback_error)
+    Ok(services::playback::set_volume(&state, level)?)
 }
 
 #[tauri::command]
@@ -60,19 +59,20 @@ pub fn set_stem_volume(
     stem: StemName,
     level: f32,
 ) -> CommandResult<PlaybackStateSnapshot> {
-    services::playback::set_stem_volume(&state, stem, level).map_err(playback_error)
+    Ok(services::playback::set_stem_volume(&state, stem, level)?)
 }
 
 #[tauri::command]
 pub async fn load_stems(state: State<'_, AppState>) -> CommandResult<PlaybackStateSnapshot> {
     let background_state = state.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || services::playback::load_stems(&background_state))
-        .await
-        .map_err(|error| playback_error(format!("load stems task failed: {error}")))?
-        .map_err(playback_error)
+    Ok(tauri::async_runtime::spawn_blocking(move || {
+        services::playback::load_stems(&background_state)
+    })
+    .await
+    .map_err(|error| internal_error(format!("load stems task failed: {error}")))??)
 }
 
 #[tauri::command]
 pub fn get_playback_state(state: State<'_, AppState>) -> CommandResult<PlaybackStateSnapshot> {
-    services::playback::get_state(&state).map_err(playback_error)
+    Ok(services::playback::get_state(&state)?)
 }

--- a/src-tauri/src/commands/remote_library/auth.rs
+++ b/src-tauri/src/commands/remote_library/auth.rs
@@ -1,5 +1,6 @@
 use crate::{
-    commands::error::{library_error, state_lock_error, CommandResult},
+    commands::error::{CommandError, state_lock_error, CommandResult},
+    library::error::LibraryError,
     config::RemoteLibraryProvider,
     AppState,
 };
@@ -70,15 +71,13 @@ pub(crate) fn begin_remote_auth(
                 | StatusCode::FOUND
                 | StatusCode::MOVED_PERMANENTLY => Some(session),
                 StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
-                    return Err(library_error(
-                        "WebDAV authentication failed. Double-check the server URL, username, and password."
-                            .to_owned(),
-                    ))
+                    return Err(CommandError::from(LibraryError::Internal("WebDAV authentication failed. Double-check the server URL, username, and password."
+                            .to_owned(),)))
                 }
                 status => {
-                    return Err(library_error(format!(
+                    return Err(CommandError::from(LibraryError::Internal(format!(
                         "WebDAV server check failed with status {status}"
-                    )))
+                    ))))
                 }
             }
         }
@@ -87,7 +86,7 @@ pub(crate) fn begin_remote_auth(
     if provider == RemoteLibraryProvider::GoogleDrive {
         let google = google_drive_session
             .clone()
-            .ok_or_else(|| library_error("missing Google Drive session state".to_owned()))?;
+            .ok_or_else(|| CommandError::from(LibraryError::Internal("missing Google Drive session state".to_owned())))?;
         let session = RemoteAuthSession {
             provider,
             state: RemoteAuthState::Pending,
@@ -116,7 +115,7 @@ pub(crate) fn begin_remote_auth(
     if provider == RemoteLibraryProvider::Dropbox {
         let dropbox = dropbox_session
             .clone()
-            .ok_or_else(|| library_error("missing Dropbox session state".to_owned()))?;
+            .ok_or_else(|| CommandError::from(LibraryError::Internal("missing Dropbox session state".to_owned())))?;
         let session = RemoteAuthSession {
             provider,
             state: RemoteAuthState::Pending,
@@ -189,7 +188,7 @@ pub(crate) fn poll_remote_auth(
         .map_err(|_| state_lock_error("remote auth session lock was poisoned"))?;
     let session = sessions
         .get(&session_id)
-        .ok_or_else(|| library_error(format!("remote auth session {session_id} was not found")))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal(format!("remote auth session {session_id} was not found"))))?;
 
     Ok(RemoteAuthStatus {
         session_id,
@@ -213,7 +212,7 @@ pub(crate) fn cancel_remote_auth(state: &AppState, session_id: String) -> Comman
 pub(crate) fn open_external_url(url: String) -> CommandResult<()> {
     open::that_detached(url.clone()).map_err(|_error| {
         tracing::trace!("failed to open external URL {url}");
-        library_error("Failed to open browser for authentication.".to_owned())
+        CommandError::from(LibraryError::Internal("Failed to open browser for authentication.".to_owned()))
     })
 }
 
@@ -228,7 +227,7 @@ pub(crate) fn oauth_pkce_code_challenge(code_verifier: &str) -> String {
 
 pub(crate) fn form_urlencoded_body(params: &[(&str, String)]) -> CommandResult<String> {
     let mut encoded = Url::parse("https://example.invalid")
-        .map_err(|error| library_error(format!("failed to build token body: {error}")))?;
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to build token body: {error}"))))?;
     {
         let mut pairs = encoded.query_pairs_mut();
         for (key, value) in params {

--- a/src-tauri/src/commands/remote_library/dropbox.rs
+++ b/src-tauri/src/commands/remote_library/dropbox.rs
@@ -1,6 +1,7 @@
 use crate::{
     cache,
-    commands::error::{library_error, CommandResult},
+    commands::error::{CommandError, CommandResult},
+    library::error::LibraryError,
     config::RegisteredLibrary,
     library_root::LibraryRoot,
 };
@@ -40,7 +41,7 @@ pub(crate) fn build_dropbox_authorization_url(
     session: &DropboxSessionData,
 ) -> CommandResult<String> {
     let mut url = Url::parse("https://www.dropbox.com/oauth2/authorize")
-        .map_err(|error| library_error(format!("failed to build Dropbox auth URL: {error}")))?;
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to build Dropbox auth URL: {error}"))))?;
     url.query_pairs_mut()
         .append_pair("client_id", &session.app_key)
         .append_pair("redirect_uri", &session.redirect_uri)
@@ -61,9 +62,9 @@ pub(crate) fn dropbox_provider_credentials_from_env(
     app_secret: Option<String>,
 ) -> CommandResult<DropboxProviderCredentials> {
     let Some(app_key) = app_key.filter(|value| !value.trim().is_empty()) else {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "Dropbox is not available because the official app credential is missing. Set {DROPBOX_APP_KEY_ENV} before starting OpenKara."
-        )));
+        ))));
     };
 
     Ok(DropboxProviderCredentials {
@@ -81,16 +82,16 @@ fn load_dropbox_provider_credentials_from_resource_dir(
     }
 
     let raw = fs::read_to_string(&path).map_err(|error| {
-        library_error(format!(
+        CommandError::from(LibraryError::Internal(format!(
             "failed to read bundled Dropbox OAuth client metadata at {}: {error}",
             path.display()
-        ))
+        )))
     })?;
     let bundled: BundledDropboxOAuthClientFile = serde_json::from_str(&raw).map_err(|error| {
-        library_error(format!(
+        CommandError::from(LibraryError::Internal(format!(
             "failed to parse bundled Dropbox OAuth client metadata at {}: {error}",
             path.display()
-        ))
+        )))
     })?;
 
     dropbox_provider_credentials_from_env(Some(bundled.app_key), bundled.app_secret).map(Some)
@@ -159,19 +160,17 @@ pub(crate) fn load_dropbox_secret(
             access_token_expires_at_ms: secret.access_token_expires_at_ms,
         });
     }
-    Err(library_error(
-        "missing stored credentials for the remote repository".to_owned(),
-    ))
+    Err(CommandError::from(LibraryError::Internal("missing stored credentials for the remote repository".to_owned(),)))
 }
 
 fn dropbox_api_url(path: &str) -> CommandResult<Url> {
     Url::parse(&format!("https://api.dropboxapi.com{path}"))
-        .map_err(|error| library_error(format!("failed to build Dropbox URL: {error}")))
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to build Dropbox URL: {error}"))))
 }
 
 fn dropbox_content_url(path: &str) -> CommandResult<Url> {
     Url::parse(&format!("https://content.dropboxapi.com{path}"))
-        .map_err(|error| library_error(format!("failed to build Dropbox content URL: {error}")))
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to build Dropbox content URL: {error}"))))
 }
 
 fn dropbox_refresh_access_token(
@@ -203,20 +202,20 @@ fn dropbox_refresh_access_token(
         .body(body)
         .send()
         .map_err(|e| {
-            library_error(format!(
+            CommandError::from(LibraryError::Internal(format!(
                 "failed to refresh Dropbox access token: {}",
                 e.without_url()
-            ))
+            )))
         })?;
     if !response.status().is_success() {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "Dropbox token refresh failed with status {}",
             response.status()
-        )));
+        ))));
     }
 
     let body: DropboxTokenResponse = response.json().map_err(|error| {
-        library_error(format!("failed to parse Dropbox token response: {error}"))
+        CommandError::from(LibraryError::Internal(format!("failed to parse Dropbox token response: {error}")))
     })?;
     secret.access_token = body.access_token;
     secret.access_token_expires_at_ms = body
@@ -270,16 +269,16 @@ fn dropbox_exchange_code_for_tokens(
         .header("Content-Type", "application/x-www-form-urlencoded")
         .body(body)
         .send()
-        .map_err(|error| library_error(format!("failed to exchange Dropbox auth code: {error}")))?;
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to exchange Dropbox auth code: {error}"))))?;
     if !response.status().is_success() {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "Dropbox auth code exchange failed with status {}",
             response.status()
-        )));
+        ))));
     }
     response
         .json()
-        .map_err(|error| library_error(format!("failed to parse Dropbox token response: {error}")))
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to parse Dropbox token response: {error}"))))
 }
 
 pub(crate) fn spawn_dropbox_auth_worker(
@@ -292,12 +291,12 @@ pub(crate) fn spawn_dropbox_auth_worker(
         DROPBOX_FIXED_REDIRECT_PORT,
     ))
     .map_err(|error| {
-        library_error(format!(
+        CommandError::from(LibraryError::Internal(format!(
             "failed to bind Dropbox OAuth listener on {DROPBOX_FIXED_REDIRECT_URI}: {error}"
-        ))
+        )))
     })?;
     let server = Server::from_listener(listener, None).map_err(|error| {
-        library_error(format!("failed to start Dropbox OAuth listener: {error}"))
+        CommandError::from(LibraryError::Internal(format!("failed to start Dropbox OAuth listener: {error}")))
     })?;
 
     let mut session = session;
@@ -317,10 +316,8 @@ pub(crate) fn spawn_dropbox_auth_worker(
                     if started_at.elapsed() >= std::time::Duration::from_secs(300) {
                         update_remote_auth_session(&sessions, &session_id, |state| {
                             state.state = RemoteAuthState::Failed;
-                            state.error = Some(library_error(
-                                "Dropbox sign-in timed out before the browser returned to OpenKara."
-                                    .to_owned(),
-                            ));
+                            state.error = Some(CommandError::from(LibraryError::Internal("Dropbox sign-in timed out before the browser returned to OpenKara."
+                                    .to_owned(),)));
                         });
                         return;
                     }
@@ -328,9 +325,9 @@ pub(crate) fn spawn_dropbox_auth_worker(
                 Err(error) => {
                     update_remote_auth_session(&sessions, &session_id, |state| {
                         state.state = RemoteAuthState::Failed;
-                        state.error = Some(library_error(format!(
+                        state.error = Some(CommandError::from(LibraryError::Internal(format!(
                             "Dropbox sign-in listener failed: {error}"
-                        )));
+                        ))));
                     });
                     return;
                 }
@@ -348,9 +345,9 @@ pub(crate) fn spawn_dropbox_auth_worker(
                 let _ = request.respond(oauth_callback_response("Invalid OAuth callback."));
                 update_remote_auth_session(&sessions, &session_id, |state| {
                     state.state = RemoteAuthState::Failed;
-                    state.error = Some(library_error(format!(
+                    state.error = Some(CommandError::from(LibraryError::Internal(format!(
                         "failed to parse Dropbox OAuth callback: {error}"
-                    )));
+                    ))));
                 });
                 return;
             }
@@ -361,10 +358,8 @@ pub(crate) fn spawn_dropbox_auth_worker(
             let _ = request.respond(oauth_callback_response("OAuth state mismatch."));
             update_remote_auth_session(&sessions, &session_id, |state| {
                 state.state = RemoteAuthState::Failed;
-                state.error = Some(library_error(
-                    "Dropbox sign-in failed because the OAuth state token did not match."
-                        .to_owned(),
-                ));
+                state.error = Some(CommandError::from(LibraryError::Internal("Dropbox sign-in failed because the OAuth state token did not match."
+                        .to_owned(),)));
             });
             return;
         }
@@ -375,7 +370,7 @@ pub(crate) fn spawn_dropbox_auth_worker(
             ));
             update_remote_auth_session(&sessions, &session_id, |state| {
                 state.state = RemoteAuthState::Failed;
-                state.error = Some(library_error(format!("Dropbox sign-in failed: {error}")));
+                state.error = Some(CommandError::from(LibraryError::Internal(format!("Dropbox sign-in failed: {error}"))));
             });
             return;
         }
@@ -386,16 +381,14 @@ pub(crate) fn spawn_dropbox_auth_worker(
             ));
             update_remote_auth_session(&sessions, &session_id, |state| {
                 state.state = RemoteAuthState::Failed;
-                state.error = Some(library_error(
-                    "Dropbox sign-in did not return an authorization code.".to_owned(),
-                ));
+                state.error = Some(CommandError::from(LibraryError::Internal("Dropbox sign-in did not return an authorization code.".to_owned(),)));
             });
             return;
         };
 
         match dropbox_exchange_code_for_tokens(&worker_session, code).and_then(|tokens| {
             let account_id = tokens.account_id.clone().ok_or_else(|| {
-                library_error("Dropbox token response did not include an account ID.".to_owned())
+                CommandError::from(LibraryError::Internal("Dropbox token response did not include an account ID.".to_owned()))
             })?;
             Ok((tokens, account_id))
         }) {
@@ -471,12 +464,12 @@ pub(crate) fn dropbox_get_metadata(
         StatusCode::OK => response
             .json()
             .map(Some)
-            .map_err(|error| library_error(format!("failed to parse Dropbox metadata: {error}"))),
+            .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to parse Dropbox metadata: {error}")))),
         StatusCode::CONFLICT => Ok(None),
-        status => Err(library_error(format!(
+        status => Err(CommandError::from(LibraryError::Internal(format!(
             "Dropbox metadata lookup failed with status {}",
             status
-        ))),
+        )))),
     }
 }
 
@@ -492,12 +485,12 @@ fn dropbox_get_metadata_with_token(
         StatusCode::OK => response
             .json()
             .map(Some)
-            .map_err(|error| library_error(format!("failed to parse Dropbox metadata: {error}"))),
+            .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to parse Dropbox metadata: {error}")))),
         StatusCode::CONFLICT => Ok(None),
-        status => Err(library_error(format!(
+        status => Err(CommandError::from(LibraryError::Internal(format!(
             "Dropbox metadata lookup failed with status {}",
             status
-        ))),
+        )))),
     }
 }
 
@@ -511,18 +504,18 @@ fn dropbox_create_folder(
         .json(&serde_json::json!({ "path": path, "autorename": false }))
         .send_network("create Dropbox folder")?;
     if !response.status().is_success() {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "Dropbox folder creation failed with status {}",
             response.status()
-        )));
+        ))));
     }
     response
         .json::<DropboxCreateFolderResponse>()
         .map(|body| body.metadata)
         .map_err(|error| {
-            library_error(format!(
+            CommandError::from(LibraryError::Internal(format!(
                 "failed to parse Dropbox folder creation response: {error}"
-            ))
+            )))
         })
 }
 
@@ -535,18 +528,18 @@ fn dropbox_create_folder_with_token(
         .json(&serde_json::json!({ "path": path, "autorename": false }))
         .send_network("create Dropbox folder")?;
     if !response.status().is_success() {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "Dropbox folder creation failed with status {}",
             response.status()
-        )));
+        ))));
     }
     response
         .json::<DropboxCreateFolderResponse>()
         .map(|body| body.metadata)
         .map_err(|error| {
-            library_error(format!(
+            CommandError::from(LibraryError::Internal(format!(
                 "failed to parse Dropbox folder creation response: {error}"
-            ))
+            )))
         })
 }
 
@@ -612,14 +605,14 @@ fn dropbox_upload_file_bytes(
         .body(bytes)
         .send_network("upload Dropbox file bytes")?;
     if !response.status().is_success() {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "Dropbox file upload failed with status {}",
             response.status()
-        )));
+        ))));
     }
     response
         .json()
-        .map_err(|error| library_error(format!("failed to parse Dropbox upload response: {error}")))
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to parse Dropbox upload response: {error}"))))
 }
 
 pub(crate) fn dropbox_download_file(
@@ -636,31 +629,31 @@ pub(crate) fn dropbox_download_file(
         )
         .send_network("download Dropbox file")?;
     if !response.status().is_success() {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "Dropbox download failed with status {}",
             response.status()
-        )));
+        ))));
     }
 
     if let Some(parent) = destination.parent() {
         fs::create_dir_all(parent).map_err(|error| {
-            library_error(format!("failed to create {}: {error}", parent.display()))
+            CommandError::from(LibraryError::Internal(format!("failed to create {}: {error}", parent.display())))
         })?;
     }
     let bytes = response
         .bytes()
-        .map_err(|error| library_error(format!("failed to read Dropbox response: {error}")))?;
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to read Dropbox response: {error}"))))?;
     let mut file = fs::File::create(destination).map_err(|error| {
-        library_error(format!(
+        CommandError::from(LibraryError::Internal(format!(
             "failed to create {}: {error}",
             destination.display()
-        ))
+        )))
     })?;
     file.write_all(bytes.as_ref()).map_err(|error| {
-        library_error(format!(
+        CommandError::from(LibraryError::Internal(format!(
             "failed to write {}: {error}",
             destination.display()
-        ))
+        )))
     })?;
     Ok(())
 }
@@ -674,10 +667,10 @@ pub(crate) fn dropbox_upload_relative_file_to_remote(
 ) -> CommandResult<()> {
     let local_root = library
         .working_copy_root()
-        .ok_or_else(|| library_error("remote repository is missing a cached working copy"))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal("remote repository is missing a cached working copy".to_string())))?;
     let source = local_root.join(relative_path);
     let bytes = fs::read(&source)
-        .map_err(|error| library_error(format!("failed to read {}: {error}", source.display())))?;
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to read {}: {error}", source.display()))))?;
     let mut secret = secret.clone();
     if let Some(parent) = Path::new(relative_path).parent() {
         let parent_path = parent.to_string_lossy().replace('\\', "/");
@@ -703,19 +696,19 @@ pub(crate) fn dropbox_upload_directory_to_remote(
 ) -> CommandResult<()> {
     let local_root = library
         .working_copy_root()
-        .ok_or_else(|| library_error("remote repository is missing a cached working copy"))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal("remote repository is missing a cached working copy".to_string())))?;
     let base = local_root.join(relative_directory);
     if !base.exists() {
         return Ok(());
     }
     for entry in fs::read_dir(&base)
-        .map_err(|error| library_error(format!("failed to read {}: {error}", base.display())))?
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to read {}: {error}", base.display()))))?
     {
-        let entry = entry.map_err(|error| library_error(error.to_string()))?;
+        let entry = entry.map_err(|error| CommandError::from(LibraryError::Internal(error.to_string())))?;
         let path = entry.path();
         let relative = path
             .strip_prefix(&local_root)
-            .map_err(|error| library_error(error.to_string()))?
+            .map_err(|error| CommandError::from(LibraryError::Internal(error.to_string())))?
             .to_string_lossy()
             .replace('\\', "/");
         if path.is_dir() {
@@ -746,17 +739,17 @@ pub(crate) fn initialize_or_sync_dropbox_library(
 ) -> CommandResult<Option<String>> {
     let root_path = library
         .working_copy_root()
-        .ok_or_else(|| library_error("remote repository is missing a cached working copy"))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal("remote repository is missing a cached working copy".to_string())))?;
     let root = if root_path.join(".openkara-library").exists() {
-        LibraryRoot::open(&root_path).map_err(library_error)?
+        LibraryRoot::open(&root_path).map_err(|e| CommandError::from(LibraryError::Internal(e.to_string())))?
     } else {
-        LibraryRoot::create(&root_path).map_err(library_error)?
+        LibraryRoot::create(&root_path).map_err(|e| CommandError::from(LibraryError::Internal(e.to_string())))?
     };
-    cache::initialize_library_database(&root.database_path()).map_err(library_error)?;
+    cache::initialize_library_database(&root.database_path()).map_err(|e| CommandError::from(LibraryError::DatabaseUnavailable(e.to_string())))?;
 
     let remote_root_path = library
         .remote_root_locator()
-        .ok_or_else(|| library_error("remote repository is missing a remote locator".to_owned()))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal("remote repository is missing a remote locator".to_owned())))?;
     let mut secret = secret.clone();
     dropbox_ensure_folder(app_data_dir, &mut secret, remote_root_path)?;
     for directory in ["media", "media-g", "stems"] {
@@ -771,10 +764,10 @@ pub(crate) fn initialize_or_sync_dropbox_library(
     if dropbox_get_metadata(app_data_dir, &mut secret, &marker_remote_path)?.is_none() {
         let marker_path = root.resolve(".openkara-library");
         fs::write(&marker_path, b"openkara remote repository\n").map_err(|error| {
-            library_error(format!(
+            CommandError::from(LibraryError::Internal(format!(
                 "failed to write {}: {error}",
                 marker_path.display()
-            ))
+            )))
         })?;
         dropbox_upload_relative_file_to_remote(
             app_data_dir,
@@ -806,10 +799,8 @@ pub(crate) fn initialize_or_sync_dropbox_library(
         )?;
         let metadata = dropbox_get_metadata(app_data_dir, &mut secret, &database_remote_path)?
             .ok_or_else(|| {
-                library_error(
-                    "Dropbox database upload succeeded but the file was not found afterwards"
-                        .to_owned(),
-                )
+                CommandError::from(LibraryError::Internal("Dropbox database upload succeeded but the file was not found afterwards"
+                        .to_owned(),))
             })?;
         dropbox_metadata_revision(&metadata)
     };
@@ -824,28 +815,26 @@ pub(crate) fn refresh_existing_dropbox_library(
 ) -> CommandResult<Option<String>> {
     let root_path = library
         .working_copy_root()
-        .ok_or_else(|| library_error("remote repository is missing a cached working copy"))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal("remote repository is missing a cached working copy".to_string())))?;
     let root = if root_path.join(".openkara-library").exists() {
-        LibraryRoot::open(&root_path).map_err(library_error)?
+        LibraryRoot::open(&root_path).map_err(|e| CommandError::from(LibraryError::Internal(e.to_string())))?
     } else {
-        LibraryRoot::create(&root_path).map_err(library_error)?
+        LibraryRoot::create(&root_path).map_err(|e| CommandError::from(LibraryError::Internal(e.to_string())))?
     };
-    cache::initialize_library_database(&root.database_path()).map_err(library_error)?;
+    cache::initialize_library_database(&root.database_path()).map_err(|e| CommandError::from(LibraryError::DatabaseUnavailable(e.to_string())))?;
 
     let remote_root_path = library
         .remote_root_locator()
-        .ok_or_else(|| library_error("remote repository is missing a remote locator".to_owned()))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal("remote repository is missing a remote locator".to_owned())))?;
     let mut secret = secret.clone();
     let marker_remote_path = dropbox_join_path(remote_root_path, ".openkara-library");
     if dropbox_get_metadata(app_data_dir, &mut secret, &marker_remote_path)?.is_none() {
-        return Err(library_error(
-            "The selected Dropbox folder is not an OpenKara remote repository.".to_owned(),
-        ));
+        return Err(CommandError::from(LibraryError::Internal("The selected Dropbox folder is not an OpenKara remote repository.".to_owned(),)));
     }
     let database_remote_path = dropbox_join_path(remote_root_path, "openkara.db");
     let metadata = dropbox_get_metadata(app_data_dir, &mut secret, &database_remote_path)?
         .ok_or_else(|| {
-            library_error("The selected Dropbox folder is missing openkara.db.".to_owned())
+            CommandError::from(LibraryError::Internal("The selected Dropbox folder is missing openkara.db.".to_owned()))
         })?;
     dropbox_download_file(
         app_data_dir,
@@ -867,9 +856,9 @@ fn dropbox_delete_path(
         .send_network("delete Dropbox path")?;
     match response.status() {
         StatusCode::OK | StatusCode::CONFLICT => Ok(()),
-        status => Err(library_error(format!(
+        status => Err(CommandError::from(LibraryError::Internal(format!(
             "Dropbox delete failed with status {status}"
-        ))),
+        )))),
     }
 }
 
@@ -881,7 +870,7 @@ pub(crate) fn delete_relative_path_from_remote(
     let mut secret = load_dropbox_secret(app_data_dir, library)?;
     let root_path = library
         .remote_root_locator()
-        .ok_or_else(|| library_error("remote repository is missing a remote locator".to_owned()))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal("remote repository is missing a remote locator".to_owned())))?;
     dropbox_delete_path(
         app_data_dir,
         &mut secret,

--- a/src-tauri/src/commands/remote_library/google_drive.rs
+++ b/src-tauri/src/commands/remote_library/google_drive.rs
@@ -1,6 +1,7 @@
 use crate::{
     cache,
-    commands::error::{library_error, CommandResult},
+    commands::error::{CommandError, CommandResult},
+    library::error::LibraryError,
     config::RegisteredLibrary,
     library_root::LibraryRoot,
 };
@@ -40,7 +41,7 @@ pub(crate) fn build_google_drive_authorization_url(
     session: &GoogleDriveSessionData,
 ) -> CommandResult<String> {
     let mut url = Url::parse("https://accounts.google.com/o/oauth2/v2/auth")
-        .map_err(|error| library_error(format!("failed to build Google auth URL: {error}")))?;
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to build Google auth URL: {error}"))))?;
     url.query_pairs_mut()
         .append_pair("client_id", &session.client_id)
         .append_pair("redirect_uri", &session.redirect_uri)
@@ -62,9 +63,9 @@ pub(crate) fn google_drive_provider_credentials_from_env(
     client_secret: Option<String>,
 ) -> CommandResult<GoogleDriveProviderCredentials> {
     let Some(client_id) = client_id.filter(|value| !value.trim().is_empty()) else {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "Google Drive is not available because the official app credential is missing. Set {GOOGLE_DRIVE_CLIENT_ID_ENV} before starting OpenKara."
-        )));
+        ))));
     };
 
     Ok(GoogleDriveProviderCredentials {
@@ -82,17 +83,17 @@ fn load_google_drive_provider_credentials_from_resource_dir(
     }
 
     let raw = fs::read_to_string(&path).map_err(|error| {
-        library_error(format!(
+        CommandError::from(LibraryError::Internal(format!(
             "failed to read bundled Google Drive OAuth client metadata at {}: {error}",
             path.display()
-        ))
+        )))
     })?;
     let bundled: BundledGoogleDriveOAuthClientFile =
         serde_json::from_str(&raw).map_err(|error| {
-            library_error(format!(
+            CommandError::from(LibraryError::Internal(format!(
                 "failed to parse bundled Google Drive OAuth client metadata at {}: {error}",
                 path.display()
-            ))
+            )))
         })?;
 
     Ok(Some(GoogleDriveProviderCredentials {
@@ -168,14 +169,12 @@ pub(crate) fn load_google_drive_secret(
             access_token_expires_at_ms: secret.access_token_expires_at_ms,
         });
     }
-    Err(library_error(
-        "missing stored credentials for the remote repository".to_owned(),
-    ))
+    Err(CommandError::from(LibraryError::Internal("missing stored credentials for the remote repository".to_owned(),)))
 }
 
 fn google_drive_api_url(path: &str) -> CommandResult<Url> {
     Url::parse(&format!("https://www.googleapis.com{path}"))
-        .map_err(|error| library_error(format!("failed to build Google Drive URL: {error}")))
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to build Google Drive URL: {error}"))))
 }
 
 fn google_drive_refresh_access_token(
@@ -207,21 +206,21 @@ fn google_drive_refresh_access_token(
         .body(body)
         .send()
         .map_err(|e| {
-            library_error(format!(
+            CommandError::from(LibraryError::Internal(format!(
                 "failed to refresh Google Drive access token: {}",
                 e.without_url()
-            ))
+            )))
         })?;
     if !response.status().is_success() {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "Google Drive token refresh failed with status {}",
             response.status()
-        )));
+        ))));
     }
     let body: GoogleDriveTokenResponse = response.json().map_err(|error| {
-        library_error(format!(
+        CommandError::from(LibraryError::Internal(format!(
             "failed to parse Google Drive token response: {error}"
-        ))
+        )))
     })?;
     secret.access_token = body.access_token.clone();
     secret.access_token_expires_at_ms = body
@@ -283,13 +282,13 @@ fn google_drive_find_child(
     let response = google_drive_authorized_request(app_data_dir, secret, Method::GET, url)?
         .send_network("Google Drive lookup")?;
     if !response.status().is_success() {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "Google Drive lookup failed with status {}",
             response.status()
-        )));
+        ))));
     }
     let body: GoogleDriveFileListResponse = response.json().map_err(|error| {
-        library_error(format!("failed to parse Google Drive file list: {error}"))
+        CommandError::from(LibraryError::Internal(format!("failed to parse Google Drive file list: {error}")))
     })?;
     Ok(body.files.into_iter().next())
 }
@@ -323,13 +322,13 @@ fn google_drive_find_child_with_token(
     let response = google_drive_request_with_access_token(access_token, Method::GET, url)
         .send_network("Google Drive lookup")?;
     if !response.status().is_success() {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "Google Drive lookup failed with status {}",
             response.status()
-        )));
+        ))));
     }
     let body: GoogleDriveFileListResponse = response.json().map_err(|error| {
-        library_error(format!("failed to parse Google Drive file list: {error}"))
+        CommandError::from(LibraryError::Internal(format!("failed to parse Google Drive file list: {error}")))
     })?;
     Ok(body.files.into_iter().next())
 }
@@ -349,13 +348,13 @@ fn google_drive_create_folder(
         }))
         .send_network("create Google Drive folder")?;
     if !response.status().is_success() {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "Google Drive folder creation failed with status {}",
             response.status()
-        )));
+        ))));
     }
     response.json().map_err(|error| {
-        library_error(format!("failed to parse folder creation response: {error}"))
+        CommandError::from(LibraryError::Internal(format!("failed to parse folder creation response: {error}")))
     })
 }
 
@@ -391,13 +390,13 @@ fn google_drive_create_folder_with_token(
         }))
         .send_network("create Google Drive folder")?;
     if !response.status().is_success() {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "Google Drive folder creation failed with status {}",
             response.status()
-        )));
+        ))));
     }
     response.json().map_err(|error| {
-        library_error(format!("failed to parse folder creation response: {error}"))
+        CommandError::from(LibraryError::Internal(format!("failed to parse folder creation response: {error}")))
     })
 }
 
@@ -433,14 +432,14 @@ fn google_drive_create_empty_file(
         }))
         .send_network("create Google Drive file metadata")?;
     if !response.status().is_success() {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "Google Drive file metadata creation failed with status {}",
             response.status()
-        )));
+        ))));
     }
     response
         .json()
-        .map_err(|error| library_error(format!("failed to parse file creation response: {error}")))
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to parse file creation response: {error}"))))
 }
 
 fn google_drive_upload_file_bytes(
@@ -457,14 +456,14 @@ fn google_drive_upload_file_bytes(
         .body(bytes)
         .send_network("upload Google Drive file bytes")?;
     if !response.status().is_success() {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "Google Drive file upload failed with status {}",
             response.status()
-        )));
+        ))));
     }
     response
         .json()
-        .map_err(|error| library_error(format!("failed to parse upload response: {error}")))
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to parse upload response: {error}"))))
 }
 
 pub(crate) fn google_drive_download_file(
@@ -477,30 +476,30 @@ pub(crate) fn google_drive_download_file(
     let response = google_drive_authorized_request(app_data_dir, secret, Method::GET, url)?
         .send_network("download Google Drive file")?;
     if !response.status().is_success() {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "Google Drive download failed with status {}",
             response.status()
-        )));
+        ))));
     }
     if let Some(parent) = destination.parent() {
         fs::create_dir_all(parent).map_err(|error| {
-            library_error(format!("failed to create {}: {error}", parent.display()))
+            CommandError::from(LibraryError::Internal(format!("failed to create {}: {error}", parent.display())))
         })?;
     }
     let bytes = response
         .bytes()
-        .map_err(|error| library_error(format!("failed to read Google Drive response: {error}")))?;
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to read Google Drive response: {error}"))))?;
     let mut file = fs::File::create(destination).map_err(|error| {
-        library_error(format!(
+        CommandError::from(LibraryError::Internal(format!(
             "failed to create {}: {error}",
             destination.display()
-        ))
+        )))
     })?;
     file.write_all(bytes.as_ref()).map_err(|error| {
-        library_error(format!(
+        CommandError::from(LibraryError::Internal(format!(
             "failed to write {}: {error}",
             destination.display()
-        ))
+        )))
     })?;
     Ok(())
 }
@@ -531,40 +530,40 @@ fn google_drive_exchange_code_for_tokens(
         .header("Content-Type", "application/x-www-form-urlencoded")
         .body(body)
         .send()
-        .map_err(|error| library_error(format!("failed to exchange Google auth code: {error}")))?;
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to exchange Google auth code: {error}"))))?;
     if !response.status().is_success() {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "Google auth code exchange failed with status {}",
             response.status()
-        )));
+        ))));
     }
     response
         .json()
-        .map_err(|error| library_error(format!("failed to parse Google token response: {error}")))
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to parse Google token response: {error}"))))
 }
 
 fn google_drive_fetch_account_id(access_token: &str) -> CommandResult<String> {
     let url = Url::parse("https://openidconnect.googleapis.com/v1/userinfo")
-        .map_err(|error| library_error(format!("failed to build Google userinfo URL: {error}")))?;
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to build Google userinfo URL: {error}"))))?;
     let response = Client::new()
         .get(url)
         .bearer_auth(access_token)
         .send()
         .map_err(|error| {
-            library_error(format!(
+            CommandError::from(LibraryError::Internal(format!(
                 "failed to fetch Google Drive account info: {error}"
-            ))
+            )))
         })?;
     if !response.status().is_success() {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "Google Drive account lookup failed with status {}",
             response.status()
-        )));
+        ))));
     }
     let body: GoogleDriveUserInfoResponse = response.json().map_err(|error| {
-        library_error(format!(
+        CommandError::from(LibraryError::Internal(format!(
             "failed to parse Google Drive account info: {error}"
-        ))
+        )))
     })?;
     Ok(body.email.unwrap_or(body.sub))
 }
@@ -576,20 +575,20 @@ pub(crate) fn spawn_google_drive_auth_worker(
 ) -> CommandResult<GoogleDriveSessionData> {
     let listener =
         TcpListener::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)).map_err(|error| {
-            library_error(format!(
+            CommandError::from(LibraryError::Internal(format!(
                 "failed to bind Google OAuth loopback listener: {error}"
-            ))
+            )))
         })?;
     let port = listener
         .local_addr()
         .map_err(|error| {
-            library_error(format!(
+            CommandError::from(LibraryError::Internal(format!(
                 "failed to read Google OAuth listener address: {error}"
-            ))
+            )))
         })?
         .port();
     let server = Server::from_listener(listener, None).map_err(|error| {
-        library_error(format!("failed to start Google OAuth listener: {error}"))
+        CommandError::from(LibraryError::Internal(format!("failed to start Google OAuth listener: {error}")))
     })?;
 
     let mut session = session;
@@ -609,10 +608,8 @@ pub(crate) fn spawn_google_drive_auth_worker(
                     if started_at.elapsed() >= std::time::Duration::from_secs(300) {
                         update_remote_auth_session(&sessions, &session_id, |state| {
                             state.state = RemoteAuthState::Failed;
-                            state.error = Some(library_error(
-                                "Google sign-in timed out before the browser returned to OpenKara."
-                                    .to_owned(),
-                            ));
+                            state.error = Some(CommandError::from(LibraryError::Internal("Google sign-in timed out before the browser returned to OpenKara."
+                                    .to_owned(),)));
                         });
                         return;
                     }
@@ -620,9 +617,9 @@ pub(crate) fn spawn_google_drive_auth_worker(
                 Err(error) => {
                     update_remote_auth_session(&sessions, &session_id, |state| {
                         state.state = RemoteAuthState::Failed;
-                        state.error = Some(library_error(format!(
+                        state.error = Some(CommandError::from(LibraryError::Internal(format!(
                             "Google sign-in listener failed: {error}"
-                        )));
+                        ))));
                     });
                     return;
                 }
@@ -636,9 +633,9 @@ pub(crate) fn spawn_google_drive_auth_worker(
                 let _ = request.respond(oauth_callback_response("Invalid OAuth callback."));
                 update_remote_auth_session(&sessions, &session_id, |state| {
                     state.state = RemoteAuthState::Failed;
-                    state.error = Some(library_error(format!(
+                    state.error = Some(CommandError::from(LibraryError::Internal(format!(
                         "failed to parse Google OAuth callback: {error}"
-                    )));
+                    ))));
                 });
                 return;
             }
@@ -649,9 +646,7 @@ pub(crate) fn spawn_google_drive_auth_worker(
             let _ = request.respond(oauth_callback_response("OAuth state mismatch."));
             update_remote_auth_session(&sessions, &session_id, |state| {
                 state.state = RemoteAuthState::Failed;
-                state.error = Some(library_error(
-                    "Google sign-in failed because the OAuth state token did not match.".to_owned(),
-                ));
+                state.error = Some(CommandError::from(LibraryError::Internal("Google sign-in failed because the OAuth state token did not match.".to_owned(),)));
             });
             return;
         }
@@ -662,7 +657,7 @@ pub(crate) fn spawn_google_drive_auth_worker(
             ));
             update_remote_auth_session(&sessions, &session_id, |state| {
                 state.state = RemoteAuthState::Failed;
-                state.error = Some(library_error(format!("Google sign-in failed: {error}")));
+                state.error = Some(CommandError::from(LibraryError::Internal(format!("Google sign-in failed: {error}"))));
             });
             return;
         }
@@ -673,9 +668,7 @@ pub(crate) fn spawn_google_drive_auth_worker(
             ));
             update_remote_auth_session(&sessions, &session_id, |state| {
                 state.state = RemoteAuthState::Failed;
-                state.error = Some(library_error(
-                    "Google sign-in did not return an authorization code.".to_owned(),
-                ));
+                state.error = Some(CommandError::from(LibraryError::Internal("Google sign-in did not return an authorization code.".to_owned(),)));
             });
             return;
         };
@@ -767,10 +760,10 @@ pub(crate) fn google_drive_upload_relative_file_to_remote(
 ) -> CommandResult<()> {
     let local_root = library
         .working_copy_root()
-        .ok_or_else(|| library_error("remote repository is missing a cached working copy"))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal("remote repository is missing a cached working copy".to_string())))?;
     let source = local_root.join(relative_path);
     let bytes = fs::read(&source)
-        .map_err(|error| library_error(format!("failed to read {}: {error}", source.display())))?;
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to read {}: {error}", source.display()))))?;
     let mut secret = secret.clone();
 
     let segments: Vec<&str> = relative_path
@@ -808,19 +801,19 @@ pub(crate) fn google_drive_upload_directory_to_remote(
 ) -> CommandResult<()> {
     let local_root = library
         .working_copy_root()
-        .ok_or_else(|| library_error("remote repository is missing a cached working copy"))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal("remote repository is missing a cached working copy".to_string())))?;
     let base = local_root.join(relative_directory);
     if !base.exists() {
         return Ok(());
     }
     for entry in fs::read_dir(&base)
-        .map_err(|error| library_error(format!("failed to read {}: {error}", base.display())))?
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to read {}: {error}", base.display()))))?
     {
-        let entry = entry.map_err(|error| library_error(error.to_string()))?;
+        let entry = entry.map_err(|error| CommandError::from(LibraryError::Internal(error.to_string())))?;
         let path = entry.path();
         let relative = path
             .strip_prefix(&local_root)
-            .map_err(|error| library_error(error.to_string()))?
+            .map_err(|error| CommandError::from(LibraryError::Internal(error.to_string())))?
             .to_string_lossy()
             .replace('\\', "/");
         if path.is_dir() {
@@ -851,17 +844,17 @@ pub(crate) fn initialize_or_sync_google_drive_library(
 ) -> CommandResult<Option<String>> {
     let root_path = library
         .working_copy_root()
-        .ok_or_else(|| library_error("remote repository is missing a cached working copy"))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal("remote repository is missing a cached working copy".to_string())))?;
     let root = if root_path.join(".openkara-library").exists() {
-        LibraryRoot::open(&root_path).map_err(library_error)?
+        LibraryRoot::open(&root_path).map_err(|e| CommandError::from(LibraryError::Internal(e.to_string())))?
     } else {
-        LibraryRoot::create(&root_path).map_err(library_error)?
+        LibraryRoot::create(&root_path).map_err(|e| CommandError::from(LibraryError::Internal(e.to_string())))?
     };
-    cache::initialize_library_database(&root.database_path()).map_err(library_error)?;
+    cache::initialize_library_database(&root.database_path()).map_err(|e| CommandError::from(LibraryError::DatabaseUnavailable(e.to_string())))?;
 
     let root_folder_id = library
         .remote_root_locator()
-        .ok_or_else(|| library_error("remote repository is missing a remote locator".to_owned()))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal("remote repository is missing a remote locator".to_owned())))?;
     let mut secret = secret.clone();
     for directory in ["media", "media-g", "stems"] {
         let _ = google_drive_get_or_create_folder(
@@ -882,10 +875,10 @@ pub(crate) fn initialize_or_sync_google_drive_library(
     {
         let marker_path = root.resolve(".openkara-library");
         fs::write(&marker_path, b"openkara remote repository\n").map_err(|error| {
-            library_error(format!(
+            CommandError::from(LibraryError::Internal(format!(
                 "failed to write {}: {error}",
                 marker_path.display()
-            ))
+            )))
         })?;
         google_drive_upload_relative_file_to_remote(
             app_data_dir,
@@ -923,10 +916,8 @@ pub(crate) fn initialize_or_sync_google_drive_library(
             "openkara.db",
         )?
         .ok_or_else(|| {
-            library_error(
-                "Google Drive database upload succeeded but the file was not found afterwards"
-                    .to_owned(),
-            )
+            CommandError::from(LibraryError::Internal("Google Drive database upload succeeded but the file was not found afterwards"
+                    .to_owned(),))
         })?;
         uploaded.head_revision_id.or(uploaded.modified_time)
     };
@@ -941,17 +932,17 @@ pub(crate) fn refresh_existing_google_drive_library(
 ) -> CommandResult<Option<String>> {
     let root_path = library
         .working_copy_root()
-        .ok_or_else(|| library_error("remote repository is missing a cached working copy"))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal("remote repository is missing a cached working copy".to_string())))?;
     let root = if root_path.join(".openkara-library").exists() {
-        LibraryRoot::open(&root_path).map_err(library_error)?
+        LibraryRoot::open(&root_path).map_err(|e| CommandError::from(LibraryError::Internal(e.to_string())))?
     } else {
-        LibraryRoot::create(&root_path).map_err(library_error)?
+        LibraryRoot::create(&root_path).map_err(|e| CommandError::from(LibraryError::Internal(e.to_string())))?
     };
-    cache::initialize_library_database(&root.database_path()).map_err(library_error)?;
+    cache::initialize_library_database(&root.database_path()).map_err(|e| CommandError::from(LibraryError::DatabaseUnavailable(e.to_string())))?;
 
     let root_folder_id = library
         .remote_root_locator()
-        .ok_or_else(|| library_error("remote repository is missing a remote locator".to_owned()))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal("remote repository is missing a remote locator".to_owned())))?;
     let mut secret = secret.clone();
     if google_drive_find_relative_entry(
         app_data_dir,
@@ -961,14 +952,12 @@ pub(crate) fn refresh_existing_google_drive_library(
     )?
     .is_none()
     {
-        return Err(library_error(
-            "The selected Google Drive folder is not an OpenKara remote repository.".to_owned(),
-        ));
+        return Err(CommandError::from(LibraryError::Internal("The selected Google Drive folder is not an OpenKara remote repository.".to_owned(),)));
     }
     let database_entry =
         google_drive_find_relative_entry(app_data_dir, &mut secret, root_folder_id, "openkara.db")?
             .ok_or_else(|| {
-                library_error("The selected Google Drive folder is missing openkara.db.".to_owned())
+                CommandError::from(LibraryError::Internal("The selected Google Drive folder is missing openkara.db.".to_owned()))
             })?;
     google_drive_download_file(
         app_data_dir,
@@ -991,9 +980,9 @@ fn google_drive_delete_entry(
         .send_network("delete Google Drive entry")?;
     match response.status() {
         reqwest::StatusCode::NO_CONTENT | reqwest::StatusCode::NOT_FOUND => Ok(()),
-        status => Err(library_error(format!(
+        status => Err(CommandError::from(LibraryError::Internal(format!(
             "Google Drive delete failed with status {status}"
-        ))),
+        )))),
     }
 }
 
@@ -1005,7 +994,7 @@ pub(crate) fn delete_relative_path_from_remote(
     let mut secret = load_google_drive_secret(app_data_dir, library)?;
     let root_folder_id = library
         .remote_root_locator()
-        .ok_or_else(|| library_error("remote repository is missing a remote locator".to_owned()))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal("remote repository is missing a remote locator".to_owned())))?;
     let Some(entry) =
         google_drive_find_relative_entry(app_data_dir, &mut secret, root_folder_id, relative_path)?
     else {
@@ -1021,7 +1010,7 @@ pub(crate) fn delete_remote_root(
     let mut secret = load_google_drive_secret(app_data_dir, library)?;
     let root_folder_id = library
         .remote_root_locator()
-        .ok_or_else(|| library_error("remote repository is missing a remote locator".to_owned()))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal("remote repository is missing a remote locator".to_owned())))?;
     google_drive_delete_entry(app_data_dir, &mut secret, root_folder_id)
 }
 

--- a/src-tauri/src/commands/remote_library/mod.rs
+++ b/src-tauri/src/commands/remote_library/mod.rs
@@ -8,7 +8,8 @@ mod types;
 mod webdav;
 
 use crate::{
-    commands::error::{library_error, CommandResult},
+    commands::error::{CommandError, CommandResult},
+    library::error::LibraryError,
     config::{RegisteredLibrary, RemoteLibraryProvider},
     AppState,
 };
@@ -34,7 +35,7 @@ impl RequestSendExt for reqwest::blocking::RequestBuilder {
     {
         self.send().map_err(|_error| {
             tracing::trace!("{op} request failed");
-            crate::commands::error::library_error(format!("{op} could not be completed"))
+            crate::commands::error::CommandError::from(LibraryError::Internal(format!("{op} could not be completed")))
         })
     }
 }
@@ -116,7 +117,7 @@ pub fn register_remote_library(
     let app_data_dir = app_handle
         .path()
         .app_data_dir()
-        .map_err(|error| library_error(error.to_string()))?;
+        .map_err(|error| CommandError::from(LibraryError::Internal(error.to_string())))?;
     registry::register_remote_library(
         &state,
         &app_data_dir,
@@ -139,7 +140,7 @@ pub fn reauthorize_remote_library(
     let app_data_dir = app_handle
         .path()
         .app_data_dir()
-        .map_err(|error| library_error(error.to_string()))?;
+        .map_err(|error| CommandError::from(LibraryError::Internal(error.to_string())))?;
     registry::reauthorize_remote_library(
         &state,
         &app_data_dir,
@@ -201,8 +202,6 @@ pub(crate) fn delete_remote_library_root(
         }
         Some(RemoteLibraryProvider::Dropbox) => dropbox::delete_remote_root(app_data_dir, library),
         Some(RemoteLibraryProvider::WebDav) => webdav::delete_remote_root(app_data_dir, library),
-        None => Err(library_error(
-            "the target library must be remote".to_owned(),
-        )),
+        None => Err(CommandError::from(LibraryError::Internal("the target library must be remote".to_owned(),))),
     }
 }

--- a/src-tauri/src/commands/remote_library/registry.rs
+++ b/src-tauri/src/commands/remote_library/registry.rs
@@ -1,10 +1,11 @@
 use crate::{
     cache,
     commands::{
-        error::{library_error, state_lock_error, CommandResult},
+        error::{CommandError, state_lock_error, CommandResult},
         library_setup::LibraryRegistrySnapshot,
     },
     config::{RegisteredLibrary, RemoteLibraryConnectionConfig, RemoteLibraryProvider},
+    library::error::LibraryError,
     library_root::LibraryRoot,
     AppState,
 };
@@ -65,7 +66,7 @@ pub(crate) fn list_remote_library_roots(
         .map_err(|_| state_lock_error("remote auth session lock was poisoned"))?;
     let session = sessions
         .get(&session_id)
-        .ok_or_else(|| library_error(format!("remote auth session {session_id} was not found")))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal(format!("remote auth session {session_id} was not found"))))?;
 
     if let (Some(remote_root_locator), Some(display_name)) = (
         session.remote_root_locator.clone(),
@@ -98,19 +99,17 @@ pub(crate) fn create_remote_library(
         .map_err(|_| state_lock_error("remote auth session lock was poisoned"))?;
     let session = sessions
         .get_mut(&session_id)
-        .ok_or_else(|| library_error(format!("remote auth session {session_id} was not found")))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal(format!("remote auth session {session_id} was not found"))))?;
 
     let remote_root_locator = match session.provider {
         RemoteLibraryProvider::GoogleDrive => {
             let google = session
                 .google_drive
                 .as_mut()
-                .ok_or_else(|| library_error("missing Google Drive session details".to_owned()))?;
+                .ok_or_else(|| CommandError::from(LibraryError::Internal("missing Google Drive session details".to_owned())))?;
             let access_token = google.access_token.clone().ok_or_else(|| {
-                library_error(
-                    "Google Drive sign-in has not completed yet. Finish the browser flow first."
-                        .to_owned(),
-                )
+                CommandError::from(LibraryError::Internal("Google Drive sign-in has not completed yet. Finish the browser flow first."
+                        .to_owned(),))
             })?;
             let root = google_drive_get_or_create_folder_with_token(
                 &access_token,
@@ -124,12 +123,10 @@ pub(crate) fn create_remote_library(
             let dropbox = session
                 .dropbox
                 .as_mut()
-                .ok_or_else(|| library_error("missing Dropbox session details".to_owned()))?;
+                .ok_or_else(|| CommandError::from(LibraryError::Internal("missing Dropbox session details".to_owned())))?;
             let access_token = dropbox.access_token.clone().ok_or_else(|| {
-                library_error(
-                    "Dropbox sign-in has not completed yet. Finish the browser flow first."
-                        .to_owned(),
-                )
+                CommandError::from(LibraryError::Internal("Dropbox sign-in has not completed yet. Finish the browser flow first."
+                        .to_owned(),))
             })?;
             let root_path = normalize_dropbox_root_path(None, &display_name);
             dropbox_ensure_folder_with_token(&access_token, &root_path)?;
@@ -139,7 +136,7 @@ pub(crate) fn create_remote_library(
             let webdav = session
                 .webdav
                 .as_ref()
-                .ok_or_else(|| library_error("missing WebDAV session details".to_owned()))?;
+                .ok_or_else(|| CommandError::from(LibraryError::Internal("missing WebDAV session details".to_owned())))?;
             let root_path = normalize_webdav_root_path(webdav.root_path.as_deref(), &display_name);
             join_url(&webdav.server_url, &format!("{root_path}/"))?
         }
@@ -162,19 +159,17 @@ pub(crate) fn resolve_remote_library_candidate(
         .map_err(|_| state_lock_error("remote auth session lock was poisoned"))?;
     let session = sessions
         .get_mut(&session_id)
-        .ok_or_else(|| library_error(format!("remote auth session {session_id} was not found")))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal(format!("remote auth session {session_id} was not found"))))?;
 
     let remote_root_locator = match session.provider {
         RemoteLibraryProvider::GoogleDrive => {
             let google = session
                 .google_drive
                 .as_ref()
-                .ok_or_else(|| library_error("missing Google Drive session details".to_owned()))?;
+                .ok_or_else(|| CommandError::from(LibraryError::Internal("missing Google Drive session details".to_owned())))?;
             google.root_folder_id.clone().ok_or_else(|| {
-                library_error(
-                    "Google Drive reauthorization did not resolve a remote repository folder."
-                        .to_owned(),
-                )
+                CommandError::from(LibraryError::Internal("Google Drive reauthorization did not resolve a remote repository folder."
+                        .to_owned(),))
             })?
         }
         RemoteLibraryProvider::Dropbox => session
@@ -185,7 +180,7 @@ pub(crate) fn resolve_remote_library_candidate(
             let webdav = session
                 .webdav
                 .as_ref()
-                .ok_or_else(|| library_error("missing WebDAV session details".to_owned()))?;
+                .ok_or_else(|| CommandError::from(LibraryError::Internal("missing WebDAV session details".to_owned())))?;
             let root_path = normalize_webdav_root_path(webdav.root_path.as_deref(), &display_name);
             join_url(&webdav.server_url, &format!("{root_path}/"))?
         }
@@ -210,7 +205,7 @@ pub(crate) fn register_remote_library(
         .map_err(|_| state_lock_error("remote auth session lock was poisoned"))?;
     let (default_display_name, account_id, provider, webdav, google_drive, dropbox) = {
         let session = sessions.get(&session_id).ok_or_else(|| {
-            library_error(format!("remote auth session {session_id} was not found"))
+            CommandError::from(LibraryError::Internal(format!("remote auth session {session_id} was not found")))
         })?;
         (
             session.display_name.clone(),
@@ -233,20 +228,20 @@ pub(crate) fn register_remote_library(
     drop(sessions);
 
     fs::create_dir_all(remote_libraries_dir(app_data_dir)).map_err(|error| {
-        library_error(format!(
+        CommandError::from(LibraryError::Internal(format!(
             "failed to create remote repository root at {}: {error}",
             remote_libraries_dir(app_data_dir).display()
-        ))
+        )))
     })?;
 
     let library_id = remote_library_id(provider, &account_id, &remote_root_locator);
     let root_path = remote_library_root(app_data_dir, &library_id);
     let library_root = if root_path.join(".openkara-library").exists() {
-        LibraryRoot::open(&root_path).map_err(library_error)?
+        LibraryRoot::open(&root_path).map_err(|e| CommandError::from(LibraryError::Internal(e.to_string())))?
     } else {
-        LibraryRoot::create(&root_path).map_err(library_error)?
+        LibraryRoot::create(&root_path).map_err(|e| CommandError::from(LibraryError::Internal(e.to_string())))?
     };
-    cache::initialize_library_database(&library_root.database_path()).map_err(library_error)?;
+    cache::initialize_library_database(&library_root.database_path()).map_err(|e| CommandError::from(LibraryError::DatabaseUnavailable(e.to_string())))?;
 
     let remote_path_display = if provider == RemoteLibraryProvider::WebDav {
         remote_path_display_from_url(&remote_root_locator)
@@ -261,9 +256,7 @@ pub(crate) fn register_remote_library(
                 .as_ref()
                 .map(|session| session.client_id.clone())
                 .ok_or_else(|| {
-                    library_error(
-                        "missing Google Drive session details during registration".to_owned(),
-                    )
+                    CommandError::from(LibraryError::Internal("missing Google Drive session details during registration".to_owned(),))
                 })?,
         }),
         RemoteLibraryProvider::Dropbox => Some(RemoteLibraryConnectionConfig::Dropbox {
@@ -271,7 +264,7 @@ pub(crate) fn register_remote_library(
                 .as_ref()
                 .map(|session| session.app_key.clone())
                 .ok_or_else(|| {
-                    library_error("missing Dropbox session details during registration".to_owned())
+                    CommandError::from(LibraryError::Internal("missing Dropbox session details during registration".to_owned()))
                 })?,
         }),
         RemoteLibraryProvider::WebDav => Some(RemoteLibraryConnectionConfig::WebDav {
@@ -279,7 +272,7 @@ pub(crate) fn register_remote_library(
                 .as_ref()
                 .map(|session| session.server_url.clone())
                 .ok_or_else(|| {
-                    library_error("missing WebDAV session details during registration".to_owned())
+                    CommandError::from(LibraryError::Internal("missing WebDAV session details during registration".to_owned()))
                 })?,
         }),
     };
@@ -297,19 +290,15 @@ pub(crate) fn register_remote_library(
     let remote_revision = match provider {
         RemoteLibraryProvider::GoogleDrive => {
             let google = google_drive.clone().ok_or_else(|| {
-                library_error("missing Google Drive session details during registration".to_owned())
+                CommandError::from(LibraryError::Internal("missing Google Drive session details during registration".to_owned()))
             })?;
             let access_token = google.access_token.clone().ok_or_else(|| {
-                library_error(
-                    "Google Drive sign-in has not completed yet. Finish the browser flow first."
-                        .to_owned(),
-                )
+                CommandError::from(LibraryError::Internal("Google Drive sign-in has not completed yet. Finish the browser flow first."
+                        .to_owned(),))
             })?;
             let refresh_token = google.refresh_token.clone().ok_or_else(|| {
-                library_error(
-                    "Google Drive did not return a refresh token. Reconnect and ensure consent was granted."
-                        .to_owned(),
-                )
+                CommandError::from(LibraryError::Internal("Google Drive did not return a refresh token. Reconnect and ensure consent was granted."
+                        .to_owned(),))
             })?;
             store_google_drive_secret(
                 app_data_dir,
@@ -327,19 +316,15 @@ pub(crate) fn register_remote_library(
         }
         RemoteLibraryProvider::Dropbox => {
             let dropbox = dropbox.clone().ok_or_else(|| {
-                library_error("missing Dropbox session details during registration".to_owned())
+                CommandError::from(LibraryError::Internal("missing Dropbox session details during registration".to_owned()))
             })?;
             let access_token = dropbox.access_token.clone().ok_or_else(|| {
-                library_error(
-                    "Dropbox sign-in has not completed yet. Finish the browser flow first."
-                        .to_owned(),
-                )
+                CommandError::from(LibraryError::Internal("Dropbox sign-in has not completed yet. Finish the browser flow first."
+                        .to_owned(),))
             })?;
             let refresh_token = dropbox.refresh_token.clone().ok_or_else(|| {
-                library_error(
-                    "Dropbox did not return a refresh token. Reconnect and ensure consent was granted."
-                        .to_owned(),
-                )
+                CommandError::from(LibraryError::Internal("Dropbox did not return a refresh token. Reconnect and ensure consent was granted."
+                        .to_owned(),))
             })?;
             store_dropbox_secret(
                 app_data_dir,
@@ -357,7 +342,7 @@ pub(crate) fn register_remote_library(
         }
         RemoteLibraryProvider::WebDav => {
             let webdav = webdav.ok_or_else(|| {
-                library_error("missing WebDAV session details during registration".to_owned())
+                CommandError::from(LibraryError::Internal("missing WebDAV session details during registration".to_owned()))
             })?;
             store_webdav_secret(app_data_dir, &library_id, webdav.username, webdav.password)?;
             let secret = load_webdav_secret(app_data_dir, &provisional_library)?;
@@ -423,11 +408,11 @@ pub(crate) fn reauthorize_remote_library(
         .iter()
         .find(|entry| entry.id() == library_id)
         .cloned()
-        .ok_or_else(|| library_error(format!("remote repository {library_id} was not found")))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal(format!("remote repository {library_id} was not found"))))?;
     if !matches!(existing, RegisteredLibrary::Remote { .. }) {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "repository {library_id} is not a remote repository"
-        )));
+        ))));
     }
 
     let mut sessions = state
@@ -436,7 +421,7 @@ pub(crate) fn reauthorize_remote_library(
         .map_err(|_| state_lock_error("remote auth session lock was poisoned"))?;
     let (account_id, provider, webdav, google_drive, dropbox) = {
         let session = sessions.get(&session_id).ok_or_else(|| {
-            library_error(format!("remote auth session {session_id} was not found"))
+            CommandError::from(LibraryError::Internal(format!("remote auth session {session_id} was not found")))
         })?;
         (
             session.account_id.clone(),
@@ -448,23 +433,17 @@ pub(crate) fn reauthorize_remote_library(
     };
 
     if existing.provider() != Some(provider) {
-        return Err(library_error(
-            "reauthorization provider does not match the remote repository".to_owned(),
-        ));
+        return Err(CommandError::from(LibraryError::Internal("reauthorization provider does not match the remote repository".to_owned(),)));
     }
     if provider != RemoteLibraryProvider::WebDav
         && existing.account_id() != Some(account_id.as_str())
     {
-        return Err(library_error(
-            "reauthorization account does not match the remote repository".to_owned(),
-        ));
+        return Err(CommandError::from(LibraryError::Internal("reauthorization account does not match the remote repository".to_owned(),)));
     }
     let is_relocation = existing.remote_root_locator() != Some(remote_root_locator.as_str());
     if is_relocation && !allow_relocation {
-        return Err(library_error(
-            "The selected location is different from the saved remote repository location."
-                .to_owned(),
-        ));
+        return Err(CommandError::from(LibraryError::Internal("The selected location is different from the saved remote repository location."
+                .to_owned(),)));
     }
 
     if let Some(session) = sessions.get_mut(&session_id) {
@@ -476,7 +455,7 @@ pub(crate) fn reauthorize_remote_library(
 
     let root_path = existing
         .working_copy_root()
-        .ok_or_else(|| library_error("remote repository is missing a local working copy"))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal("remote repository is missing a local working copy".to_string())))?;
     let remote_path_display = if provider == RemoteLibraryProvider::WebDav {
         remote_path_display_from_url(&remote_root_locator)
     } else if provider == RemoteLibraryProvider::GoogleDrive {
@@ -490,9 +469,7 @@ pub(crate) fn reauthorize_remote_library(
                 .as_ref()
                 .map(|session| session.client_id.clone())
                 .ok_or_else(|| {
-                    library_error(
-                        "missing Google Drive session details during reauthorization".to_owned(),
-                    )
+                    CommandError::from(LibraryError::Internal("missing Google Drive session details during reauthorization".to_owned(),))
                 })?,
         }),
         RemoteLibraryProvider::Dropbox => Some(RemoteLibraryConnectionConfig::Dropbox {
@@ -500,9 +477,7 @@ pub(crate) fn reauthorize_remote_library(
                 .as_ref()
                 .map(|session| session.app_key.clone())
                 .ok_or_else(|| {
-                    library_error(
-                        "missing Dropbox session details during reauthorization".to_owned(),
-                    )
+                    CommandError::from(LibraryError::Internal("missing Dropbox session details during reauthorization".to_owned(),))
                 })?,
         }),
         RemoteLibraryProvider::WebDav => Some(RemoteLibraryConnectionConfig::WebDav {
@@ -510,9 +485,7 @@ pub(crate) fn reauthorize_remote_library(
                 .as_ref()
                 .map(|session| session.server_url.clone())
                 .ok_or_else(|| {
-                    library_error(
-                        "missing WebDAV session details during reauthorization".to_owned(),
-                    )
+                    CommandError::from(LibraryError::Internal("missing WebDAV session details during reauthorization".to_owned(),))
                 })?,
         }),
     };
@@ -532,21 +505,15 @@ pub(crate) fn reauthorize_remote_library(
     let remote_revision = match provider {
         RemoteLibraryProvider::GoogleDrive => {
             let google = google_drive.clone().ok_or_else(|| {
-                library_error(
-                    "missing Google Drive session details during reauthorization".to_owned(),
-                )
+                CommandError::from(LibraryError::Internal("missing Google Drive session details during reauthorization".to_owned(),))
             })?;
             let access_token = google.access_token.clone().ok_or_else(|| {
-                library_error(
-                    "Google Drive sign-in has not completed yet. Finish the browser flow first."
-                        .to_owned(),
-                )
+                CommandError::from(LibraryError::Internal("Google Drive sign-in has not completed yet. Finish the browser flow first."
+                        .to_owned(),))
             })?;
             let refresh_token = google.refresh_token.clone().ok_or_else(|| {
-                library_error(
-                    "Google Drive did not return a refresh token. Reauthorize and ensure consent was granted."
-                        .to_owned(),
-                )
+                CommandError::from(LibraryError::Internal("Google Drive did not return a refresh token. Reauthorize and ensure consent was granted."
+                        .to_owned(),))
             })?;
             let secret = GoogleDriveSecret {
                 library_id: library_id.clone(),
@@ -560,19 +527,15 @@ pub(crate) fn reauthorize_remote_library(
         }
         RemoteLibraryProvider::Dropbox => {
             let dropbox = dropbox.clone().ok_or_else(|| {
-                library_error("missing Dropbox session details during reauthorization".to_owned())
+                CommandError::from(LibraryError::Internal("missing Dropbox session details during reauthorization".to_owned()))
             })?;
             let access_token = dropbox.access_token.clone().ok_or_else(|| {
-                library_error(
-                    "Dropbox sign-in has not completed yet. Finish the browser flow first."
-                        .to_owned(),
-                )
+                CommandError::from(LibraryError::Internal("Dropbox sign-in has not completed yet. Finish the browser flow first."
+                        .to_owned(),))
             })?;
             let refresh_token = dropbox.refresh_token.clone().ok_or_else(|| {
-                library_error(
-                    "Dropbox did not return a refresh token. Reauthorize and ensure consent was granted."
-                        .to_owned(),
-                )
+                CommandError::from(LibraryError::Internal("Dropbox did not return a refresh token. Reauthorize and ensure consent was granted."
+                        .to_owned(),))
             })?;
             let secret = DropboxSecret {
                 library_id: library_id.clone(),
@@ -586,7 +549,7 @@ pub(crate) fn reauthorize_remote_library(
         }
         RemoteLibraryProvider::WebDav => {
             let webdav = webdav.clone().ok_or_else(|| {
-                library_error("missing WebDAV session details during reauthorization".to_owned())
+                CommandError::from(LibraryError::Internal("missing WebDAV session details during reauthorization".to_owned()))
             })?;
             let secret = WebDavSecret {
                 root_url: remote_root_locator.clone(),
@@ -600,21 +563,15 @@ pub(crate) fn reauthorize_remote_library(
     match provider {
         RemoteLibraryProvider::GoogleDrive => {
             let secret = google_drive.ok_or_else(|| {
-                library_error(
-                    "missing Google Drive session details during reauthorization".to_owned(),
-                )
+                CommandError::from(LibraryError::Internal("missing Google Drive session details during reauthorization".to_owned(),))
             })?;
             let access_token = secret.access_token.ok_or_else(|| {
-                library_error(
-                    "Google Drive sign-in has not completed yet. Finish the browser flow first."
-                        .to_owned(),
-                )
+                CommandError::from(LibraryError::Internal("Google Drive sign-in has not completed yet. Finish the browser flow first."
+                        .to_owned(),))
             })?;
             let refresh_token = secret.refresh_token.ok_or_else(|| {
-                library_error(
-                    "Google Drive did not return a refresh token. Reauthorize and ensure consent was granted."
-                        .to_owned(),
-                )
+                CommandError::from(LibraryError::Internal("Google Drive did not return a refresh token. Reauthorize and ensure consent was granted."
+                        .to_owned(),))
             })?;
             store_google_drive_secret(
                 app_data_dir,
@@ -630,19 +587,15 @@ pub(crate) fn reauthorize_remote_library(
         }
         RemoteLibraryProvider::Dropbox => {
             let secret = dropbox.ok_or_else(|| {
-                library_error("missing Dropbox session details during reauthorization".to_owned())
+                CommandError::from(LibraryError::Internal("missing Dropbox session details during reauthorization".to_owned()))
             })?;
             let access_token = secret.access_token.ok_or_else(|| {
-                library_error(
-                    "Dropbox sign-in has not completed yet. Finish the browser flow first."
-                        .to_owned(),
-                )
+                CommandError::from(LibraryError::Internal("Dropbox sign-in has not completed yet. Finish the browser flow first."
+                        .to_owned(),))
             })?;
             let refresh_token = secret.refresh_token.ok_or_else(|| {
-                library_error(
-                    "Dropbox did not return a refresh token. Reauthorize and ensure consent was granted."
-                        .to_owned(),
-                )
+                CommandError::from(LibraryError::Internal("Dropbox did not return a refresh token. Reauthorize and ensure consent was granted."
+                        .to_owned(),))
             })?;
             store_dropbox_secret(
                 app_data_dir,
@@ -658,7 +611,7 @@ pub(crate) fn reauthorize_remote_library(
         }
         RemoteLibraryProvider::WebDav => {
             let secret = webdav.ok_or_else(|| {
-                library_error("missing WebDAV session details during reauthorization".to_owned())
+                CommandError::from(LibraryError::Internal("missing WebDAV session details during reauthorization".to_owned()))
             })?;
             store_webdav_secret(app_data_dir, &library_id, secret.username, secret.password)?;
         }
@@ -690,7 +643,7 @@ pub(crate) fn reauthorize_remote_library(
         .shell.library
         .lock()
         .map_err(|_| state_lock_error("library lock was poisoned"))?;
-    *guard = Some(LibraryRoot::open(&root_path).map_err(library_error)?);
+    *guard = Some(LibraryRoot::open(&root_path).map_err(|e| CommandError::from(LibraryError::Internal(e.to_string())))?);
 
     Ok(LibraryRegistrySnapshot {
         active_library_id: config.active_library_id.clone(),

--- a/src-tauri/src/commands/remote_library/sync.rs
+++ b/src-tauri/src/commands/remote_library/sync.rs
@@ -1,10 +1,10 @@
 use crate::{
     cache,
     commands::error::{
-        database_error, library_error, state_lock_error, CommandError, CommandResult,
+        database_error, state_lock_error, CommandError, CommandResult,
     },
     config::{AppConfig, RegisteredLibrary, RemoteLibraryProvider},
-    library::Song,
+    library::{error::LibraryError, Song},
     library_root::LibraryRoot,
     AppState,
 };
@@ -107,50 +107,50 @@ fn copy_file_if_present(source: Option<&Path>, destination: &Path) -> CommandRes
 
     if let Some(parent) = destination.parent() {
         fs::create_dir_all(parent).map_err(|error| {
-            library_error(format!("failed to create {}: {error}", parent.display()))
+            CommandError::from(LibraryError::Internal(format!("failed to create {}: {error}", parent.display())))
         })?;
     }
 
     fs::copy(source, destination).map_err(|error| {
-        library_error(format!(
+        CommandError::from(LibraryError::Internal(format!(
             "failed to copy {} to {}: {error}",
             source.display(),
             destination.display()
-        ))
+        )))
     })?;
     Ok(())
 }
 
 fn copy_directory_recursive(source: &Path, destination: &Path) -> CommandResult<()> {
     if !source.exists() {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "source directory {} does not exist",
             source.display()
-        )));
+        ))));
     }
 
     if destination.exists() {
         fs::remove_dir_all(destination).map_err(|error| {
-            library_error(format!(
+            CommandError::from(LibraryError::Internal(format!(
                 "failed to clear destination directory {}: {error}",
                 destination.display()
-            ))
+            )))
         })?;
     }
     fs::create_dir_all(destination).map_err(|error| {
-        library_error(format!(
+        CommandError::from(LibraryError::Internal(format!(
             "failed to create destination directory {}: {error}",
             destination.display()
-        ))
+        )))
     })?;
 
     for entry in fs::read_dir(source).map_err(|error| {
-        library_error(format!(
+        CommandError::from(LibraryError::Internal(format!(
             "failed to read directory {}: {error}",
             source.display()
-        ))
+        )))
     })? {
-        let entry = entry.map_err(|error| library_error(error.to_string()))?;
+        let entry = entry.map_err(|error| CommandError::from(LibraryError::Internal(error.to_string())))?;
         let source_path = entry.path();
         let destination_path = destination.join(entry.file_name());
 
@@ -159,18 +159,18 @@ fn copy_directory_recursive(source: &Path, destination: &Path) -> CommandResult<
         } else {
             if let Some(parent) = destination_path.parent() {
                 fs::create_dir_all(parent).map_err(|error| {
-                    library_error(format!(
+                    CommandError::from(LibraryError::Internal(format!(
                         "failed to create destination directory {}: {error}",
                         parent.display()
-                    ))
+                    )))
                 })?;
             }
             fs::copy(&source_path, &destination_path).map_err(|error| {
-                library_error(format!(
+                CommandError::from(LibraryError::Internal(format!(
                     "failed to copy {} to {}: {error}",
                     source_path.display(),
                     destination_path.display()
-                ))
+                )))
             })?;
         }
     }
@@ -206,11 +206,11 @@ fn load_registered_remote_library(
         .libraries
         .iter()
         .find(|entry| entry.id() == library_id)
-        .ok_or_else(|| library_error(format!("remote repository {library_id} was not found")))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal(format!("remote repository {library_id} was not found"))))?;
     if !matches!(library, RegisteredLibrary::Remote { .. }) {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "library {library_id} is not a remote repository"
-        )));
+        ))));
     }
     Ok(library.clone())
 }
@@ -232,7 +232,7 @@ fn remote_database_revision(
         Some(RemoteLibraryProvider::GoogleDrive) => {
             let mut secret = load_google_drive_secret(app_data_dir, library)?;
             let root_folder_id = library.remote_root_locator().ok_or_else(|| {
-                library_error("remote repository is missing a remote locator".to_owned())
+                CommandError::from(LibraryError::Internal("remote repository is missing a remote locator".to_owned()))
             })?;
             Ok(google_drive_find_relative_entry(
                 app_data_dir,
@@ -245,7 +245,7 @@ fn remote_database_revision(
         Some(RemoteLibraryProvider::Dropbox) => {
             let mut secret = load_dropbox_secret(app_data_dir, library)?;
             let root_path = library.remote_root_locator().ok_or_else(|| {
-                library_error("remote repository is missing a remote locator".to_owned())
+                CommandError::from(LibraryError::Internal("remote repository is missing a remote locator".to_owned()))
             })?;
             Ok(dropbox_get_metadata(
                 app_data_dir,
@@ -254,9 +254,7 @@ fn remote_database_revision(
             )?
             .and_then(|metadata| dropbox_metadata_revision(&metadata)))
         }
-        _ => Err(library_error(
-            "the active remote provider is not supported for database revision checks".to_owned(),
-        )),
+        _ => Err(CommandError::from(LibraryError::Internal("the active remote provider is not supported for database revision checks".to_owned(),))),
     }
 }
 
@@ -271,12 +269,12 @@ fn remote_database_conflict_error(provider_revision: Option<&str>) -> CommandErr
     let revision_detail = provider_revision
         .map(|revision| format!(" Remote revision: {revision}."))
         .unwrap_or_default();
-    library_error(format!(
+    CommandError::from(LibraryError::Internal(format!(
         "Remote repository database changed on another device before this publish. \
          OpenKara stopped before overwriting it. Use Settings > Karaoke Library > \
          Refresh remote repository, then retry this edit. If refresh fails because authentication \
          or the server changed, use Reauthorize remote repository first.{revision_detail}"
-    ))
+    )))
 }
 
 fn sync_remote_database_from_provider(
@@ -297,9 +295,7 @@ fn sync_remote_database_from_provider(
             initialize_or_sync_dropbox_library(app_data_dir, library, &secret)?
         }
         None => {
-            return Err(library_error(
-                "the active remote provider is not supported for sync".to_owned(),
-            ));
+            return Err(CommandError::from(LibraryError::Internal("the active remote provider is not supported for sync".to_owned(),)));
         }
     };
     update_remote_revision_in_config(app_data_dir, library.id(), revision)?;
@@ -349,7 +345,7 @@ fn upload_remote_database(app_data_dir: &Path, library: &RegisteredLibrary) -> C
         Some(RemoteLibraryProvider::GoogleDrive) => {
             let secret = load_google_drive_secret(app_data_dir, library)?;
             let root_folder_id = library.remote_root_locator().ok_or_else(|| {
-                library_error("remote repository is missing a remote locator".to_owned())
+                CommandError::from(LibraryError::Internal("remote repository is missing a remote locator".to_owned()))
             })?;
             google_drive_upload_relative_file_to_remote(
                 app_data_dir,
@@ -366,7 +362,7 @@ fn upload_remote_database(app_data_dir: &Path, library: &RegisteredLibrary) -> C
                 "openkara.db",
             )?
             .ok_or_else(|| {
-                library_error("Google Drive database file is missing after upload".to_owned())
+                CommandError::from(LibraryError::Internal("Google Drive database file is missing after upload".to_owned()))
             })?;
             update_remote_revision_in_config(
                 app_data_dir,
@@ -377,7 +373,7 @@ fn upload_remote_database(app_data_dir: &Path, library: &RegisteredLibrary) -> C
         Some(RemoteLibraryProvider::Dropbox) => {
             let secret = load_dropbox_secret(app_data_dir, library)?;
             let root_path = library.remote_root_locator().ok_or_else(|| {
-                library_error("remote repository is missing a remote locator".to_owned())
+                CommandError::from(LibraryError::Internal("remote repository is missing a remote locator".to_owned()))
             })?;
             dropbox_upload_relative_file_to_remote(
                 app_data_dir,
@@ -393,7 +389,7 @@ fn upload_remote_database(app_data_dir: &Path, library: &RegisteredLibrary) -> C
                 &dropbox_join_path(root_path, "openkara.db"),
             )?
             .ok_or_else(|| {
-                library_error("Dropbox database file is missing after upload".to_owned())
+                CommandError::from(LibraryError::Internal("Dropbox database file is missing after upload".to_owned()))
             })?;
             update_remote_revision_in_config(
                 app_data_dir,
@@ -401,9 +397,7 @@ fn upload_remote_database(app_data_dir: &Path, library: &RegisteredLibrary) -> C
                 dropbox_metadata_revision(&metadata),
             )
         }
-        _ => Err(library_error(
-            "the active remote provider is not supported for database upload".to_owned(),
-        )),
+        _ => Err(CommandError::from(LibraryError::Internal("the active remote provider is not supported for database upload".to_owned(),))),
     }
 }
 
@@ -455,13 +449,13 @@ pub fn ensure_remote_file_cached(app_data_dir: &Path, relative_path: &str) -> Co
                 &secret.username,
                 &secret.password,
             )?
-            .ok_or_else(|| library_error(format!("remote file {relative_path} was not found")))?;
+            .ok_or_else(|| CommandError::from(LibraryError::Internal(format!("remote file {relative_path} was not found"))))?;
             Ok(())
         }
         Some(RemoteLibraryProvider::GoogleDrive) => {
             let mut secret = load_google_drive_secret(app_data_dir, &library)?;
             let root_folder_id = library.remote_root_locator().ok_or_else(|| {
-                library_error("remote repository is missing a remote locator".to_owned())
+                CommandError::from(LibraryError::Internal("remote repository is missing a remote locator".to_owned()))
             })?;
             let entry = google_drive_find_relative_entry(
                 app_data_dir,
@@ -469,25 +463,23 @@ pub fn ensure_remote_file_cached(app_data_dir: &Path, relative_path: &str) -> Co
                 root_folder_id,
                 relative_path,
             )?
-            .ok_or_else(|| library_error(format!("remote file {relative_path} was not found")))?;
+            .ok_or_else(|| CommandError::from(LibraryError::Internal(format!("remote file {relative_path} was not found"))))?;
             google_drive_download_file(app_data_dir, &mut secret, &entry.id, &destination)
         }
         Some(RemoteLibraryProvider::Dropbox) => {
             let mut secret = load_dropbox_secret(app_data_dir, &library)?;
             let root_path = library.remote_root_locator().ok_or_else(|| {
-                library_error("remote repository is missing a remote locator".to_owned())
+                CommandError::from(LibraryError::Internal("remote repository is missing a remote locator".to_owned()))
             })?;
             let remote_path = dropbox_join_path(root_path, relative_path);
             if dropbox_get_metadata(app_data_dir, &mut secret, &remote_path)?.is_none() {
-                return Err(library_error(format!(
+                return Err(CommandError::from(LibraryError::Internal(format!(
                     "remote file {relative_path} was not found"
-                )));
+                ))));
             }
             dropbox_download_file(app_data_dir, &mut secret, &remote_path, &destination)
         }
-        _ => Err(library_error(
-            "the active remote provider is not supported for file caching".to_owned(),
-        )),
+        _ => Err(CommandError::from(LibraryError::Internal("the active remote provider is not supported for file caching".to_owned(),))),
     }
 }
 
@@ -514,9 +506,7 @@ fn remote_delete_relative_path(
         Some(RemoteLibraryProvider::Dropbox) => {
             dropbox_delete_relative_path_from_remote(app_data_dir, library, relative_path)
         }
-        None => Err(library_error(
-            "the bound remote provider is not supported for deletion".to_owned(),
-        )),
+        None => Err(CommandError::from(LibraryError::Internal("the bound remote provider is not supported for deletion".to_owned(),))),
     }
 }
 
@@ -616,7 +606,7 @@ fn delete_remote_song_from_mirror(
         remote_root,
         &song.hash,
     )
-    .map_err(|error| library_error(error.to_string()))?;
+    .map_err(|error| CommandError::from(LibraryError::Internal(error.to_string())))?;
     Ok(())
 }
 
@@ -748,14 +738,12 @@ pub(crate) fn mirror_local_library_to_remote<R: tauri::Runtime>(
         .iter()
         .find(|entry| entry.id() == local_library_id)
     else {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "local library {local_library_id} was not found"
-        )));
+        ))));
     };
     if !matches!(local_library, RegisteredLibrary::Local { .. }) {
-        return Err(library_error(
-            "the source library must be a local library".to_owned(),
-        ));
+        return Err(CommandError::from(LibraryError::Internal("the source library must be a local library".to_owned(),)));
     }
 
     let Some(remote_library) = config
@@ -763,14 +751,12 @@ pub(crate) fn mirror_local_library_to_remote<R: tauri::Runtime>(
         .iter()
         .find(|entry| entry.id() == remote_library_id)
     else {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "remote repository {remote_library_id} was not found"
-        )));
+        ))));
     };
     if !matches!(remote_library, RegisteredLibrary::Remote { .. }) {
-        return Err(library_error(
-            "the target library must be a remote repository".to_owned(),
-        ));
+        return Err(CommandError::from(LibraryError::Internal("the target library must be a remote repository".to_owned(),)));
     }
 
     let original_active_library_id = config.active_library_id.clone();
@@ -793,7 +779,7 @@ fn publish_song_internal<R: tauri::Runtime>(
 ) -> CommandResult<UploadStatusSnapshot> {
     let config = load_app_config(&state.shell.app_data_dir)?;
     let remote_library = resolve_active_remote(&config)
-        .ok_or_else(|| library_error("no bound remote repository is available for publishing"))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal("no bound remote repository is available for publishing".to_string())))?;
     let remote_library =
         prepare_remote_database_for_mutation(&state.shell.app_data_dir, &remote_library)?;
 
@@ -817,7 +803,7 @@ fn publish_song_internal<R: tauri::Runtime>(
 
     let song = cache::get_song_by_hash(&local_connection, song_id)
         .map_err(|error| database_error(error.to_string()))?
-        .ok_or_else(|| library_error(format!("song {song_id} was not found")))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal(format!("song {song_id} was not found"))))?;
 
     let running = mark_upload_status(
         state,
@@ -834,9 +820,9 @@ fn publish_song_internal<R: tauri::Runtime>(
         let stem_entry = cache::stems::get_cached_stem_entry(&local_connection, song_id)
             .map_err(|error| database_error(error.to_string()))?
             .ok_or_else(|| {
-                library_error(format!(
+                CommandError::from(LibraryError::Internal(format!(
                     "song {song_id} must have cached stems before publishing to a remote repository"
-                ))
+                )))
             })?;
         if !same_root {
             let source_stems_dir = local_root.resolve(&format!("stems/{song_id}"));
@@ -858,7 +844,7 @@ fn publish_song_internal<R: tauri::Runtime>(
             Some(RemoteLibraryProvider::GoogleDrive) => {
                 let remote_secret = load_google_drive_secret(&state.shell.app_data_dir, &remote_library)?;
                 let root_folder_id = remote_library.remote_root_locator().ok_or_else(|| {
-                    library_error("remote repository is missing a remote locator".to_owned())
+                    CommandError::from(LibraryError::Internal("remote repository is missing a remote locator".to_owned()))
                 })?;
                 google_drive_upload_directory_to_remote(
                     &state.shell.app_data_dir,
@@ -871,7 +857,7 @@ fn publish_song_internal<R: tauri::Runtime>(
             Some(RemoteLibraryProvider::Dropbox) => {
                 let remote_secret = load_dropbox_secret(&state.shell.app_data_dir, &remote_library)?;
                 let root_path = remote_library.remote_root_locator().ok_or_else(|| {
-                    library_error("remote repository is missing a remote locator".to_owned())
+                    CommandError::from(LibraryError::Internal("remote repository is missing a remote locator".to_owned()))
                 })?;
                 dropbox_upload_directory_to_remote(
                     &state.shell.app_data_dir,
@@ -882,9 +868,7 @@ fn publish_song_internal<R: tauri::Runtime>(
                 )?;
             }
             _ => {
-                return Err(library_error(
-                    "the bound remote provider is not supported for publishing".to_owned(),
-                ));
+                return Err(CommandError::from(LibraryError::Internal("the bound remote provider is not supported for publishing".to_owned(),)));
             }
         }
         sync_song_lyrics_to_remote(&local_connection, &remote_connection, song_id)?;
@@ -903,7 +887,7 @@ fn publish_song_internal<R: tauri::Runtime>(
                     let remote_secret =
                         load_google_drive_secret(&state.shell.app_data_dir, &remote_library)?;
                     let root_folder_id = remote_library.remote_root_locator().ok_or_else(|| {
-                        library_error("remote repository is missing a remote locator".to_owned())
+                        CommandError::from(LibraryError::Internal("remote repository is missing a remote locator".to_owned()))
                     })?;
                     google_drive_upload_relative_file_to_remote(
                         &state.shell.app_data_dir,
@@ -916,7 +900,7 @@ fn publish_song_internal<R: tauri::Runtime>(
                 Some(RemoteLibraryProvider::Dropbox) => {
                     let remote_secret = load_dropbox_secret(&state.shell.app_data_dir, &remote_library)?;
                     let root_path = remote_library.remote_root_locator().ok_or_else(|| {
-                        library_error("remote repository is missing a remote locator".to_owned())
+                        CommandError::from(LibraryError::Internal("remote repository is missing a remote locator".to_owned()))
                     })?;
                     dropbox_upload_relative_file_to_remote(
                         &state.shell.app_data_dir,
@@ -927,9 +911,7 @@ fn publish_song_internal<R: tauri::Runtime>(
                     )?;
                 }
                 _ => {
-                    return Err(library_error(
-                        "the bound remote provider is not supported for publishing".to_owned(),
-                    ));
+                    return Err(CommandError::from(LibraryError::Internal("the bound remote provider is not supported for publishing".to_owned(),)));
                 }
             }
         }
@@ -946,7 +928,7 @@ fn publish_song_internal<R: tauri::Runtime>(
                     let remote_secret =
                         load_google_drive_secret(&state.shell.app_data_dir, &remote_library)?;
                     let root_folder_id = remote_library.remote_root_locator().ok_or_else(|| {
-                        library_error("remote repository is missing a remote locator".to_owned())
+                        CommandError::from(LibraryError::Internal("remote repository is missing a remote locator".to_owned()))
                     })?;
                     google_drive_upload_relative_file_to_remote(
                         &state.shell.app_data_dir,
@@ -959,7 +941,7 @@ fn publish_song_internal<R: tauri::Runtime>(
                 Some(RemoteLibraryProvider::Dropbox) => {
                     let remote_secret = load_dropbox_secret(&state.shell.app_data_dir, &remote_library)?;
                     let root_path = remote_library.remote_root_locator().ok_or_else(|| {
-                        library_error("remote repository is missing a remote locator".to_owned())
+                        CommandError::from(LibraryError::Internal("remote repository is missing a remote locator".to_owned()))
                     })?;
                     dropbox_upload_relative_file_to_remote(
                         &state.shell.app_data_dir,
@@ -970,9 +952,7 @@ fn publish_song_internal<R: tauri::Runtime>(
                     )?;
                 }
                 _ => {
-                    return Err(library_error(
-                        "the bound remote provider is not supported for publishing".to_owned(),
-                    ));
+                    return Err(CommandError::from(LibraryError::Internal("the bound remote provider is not supported for publishing".to_owned(),)));
                 }
             }
         }
@@ -1017,7 +997,7 @@ fn publish_song_internal<R: tauri::Runtime>(
 pub(crate) fn sync_active_remote_library(state: &AppState) -> CommandResult<()> {
     let config = load_app_config(&state.shell.app_data_dir)?;
     let Some(active_library) = config.active_library() else {
-        return Err(library_error("no library is currently active"));
+        return Err(CommandError::from(LibraryError::Internal("no library is currently active".to_string())));
     };
 
     if matches!(active_library, RegisteredLibrary::Remote { .. }) {

--- a/src-tauri/src/commands/remote_library/types.rs
+++ b/src-tauri/src/commands/remote_library/types.rs
@@ -1,6 +1,7 @@
 use crate::{
     cache,
-    commands::error::{database_error, library_error, CommandError, CommandResult},
+    commands::error::{database_error, CommandError, CommandResult},
+    library::error::LibraryError,
     config::{self, AppConfig, RegisteredLibrary, RemoteLibraryProvider},
     library_root::LibraryRoot,
     system_credentials,
@@ -327,9 +328,9 @@ pub(crate) fn store_remote_credential<T: Serialize>(
     secret: &T,
 ) -> CommandResult<()> {
     system_credentials::store_json(app_data_dir, library_id, secret).map_err(|error| {
-        library_error(format!(
+        CommandError::from(LibraryError::Internal(format!(
             "failed to store remote credentials in the system credential store: {error}"
-        ))
+        )))
     })
 }
 
@@ -338,17 +339,17 @@ pub(crate) fn load_remote_credential<T: serde::de::DeserializeOwned>(
     library_id: &str,
 ) -> CommandResult<Option<T>> {
     system_credentials::load_json(app_data_dir, library_id).map_err(|error| {
-        library_error(format!(
+        CommandError::from(LibraryError::Internal(format!(
             "failed to load remote credentials from the system credential store: {error}"
-        ))
+        )))
     })
 }
 
 pub(crate) fn delete_remote_credential(app_data_dir: &Path, library_id: &str) -> CommandResult<()> {
     system_credentials::delete(app_data_dir, library_id).map_err(|error| {
-        library_error(format!(
+        CommandError::from(LibraryError::Internal(format!(
             "failed to remove remote credentials from the system credential store: {error}"
-        ))
+        )))
     })
 }
 
@@ -357,15 +358,13 @@ pub(crate) fn stored_google_drive_client_id(library: &RegisteredLibrary) -> Comm
         .google_drive_client_id()
         .map(str::to_owned)
         .ok_or_else(|| {
-            library_error(
-                "remote repository is missing the Google Drive OAuth client ID metadata".to_owned(),
-            )
+            CommandError::from(LibraryError::Internal("remote repository is missing the Google Drive OAuth client ID metadata".to_owned(),))
         })
 }
 
 pub(crate) fn stored_dropbox_app_key(library: &RegisteredLibrary) -> CommandResult<String> {
     library.dropbox_app_key().map(str::to_owned).ok_or_else(|| {
-        library_error("remote repository is missing the Dropbox app key metadata".to_owned())
+        CommandError::from(LibraryError::Internal("remote repository is missing the Dropbox app key metadata".to_owned()))
     })
 }
 
@@ -374,18 +373,18 @@ pub(crate) fn stored_webdav_server_url(library: &RegisteredLibrary) -> CommandRe
         .webdav_server_url()
         .map(str::to_owned)
         .ok_or_else(|| {
-            library_error("remote repository is missing the WebDAV server URL metadata".to_owned())
+            CommandError::from(LibraryError::Internal("remote repository is missing the WebDAV server URL metadata".to_owned()))
         })
 }
 
 pub(crate) fn load_app_config(app_data_dir: &Path) -> CommandResult<AppConfig> {
     Ok(config::load_config(app_data_dir)
-        .map_err(library_error)?
+        .map_err(|e| CommandError::from(LibraryError::Internal(e.to_string())))?
         .unwrap_or_default())
 }
 
 pub(crate) fn persist_app_config(app_data_dir: &Path, config: &AppConfig) -> CommandResult<()> {
-    config::save_config(app_data_dir, config).map_err(library_error)
+    config::save_config(app_data_dir, config).map_err(|e| CommandError::from(LibraryError::Internal(e.to_string())))
 }
 
 pub(crate) fn load_remote_root(
@@ -394,13 +393,13 @@ pub(crate) fn load_remote_root(
 ) -> CommandResult<LibraryRoot> {
     let root_path = library
         .working_copy_root()
-        .ok_or_else(|| library_error("remote repository is missing a cached working copy"))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal("remote repository is missing a cached working copy".to_string())))?;
     let root = if root_path.join(".openkara-library").exists() {
-        LibraryRoot::open(&root_path).map_err(library_error)?
+        LibraryRoot::open(&root_path).map_err(|e| CommandError::from(LibraryError::Internal(e.to_string())))?
     } else {
-        LibraryRoot::create(&root_path).map_err(library_error)?
+        LibraryRoot::create(&root_path).map_err(|e| CommandError::from(LibraryError::Internal(e.to_string())))?
     };
-    cache::initialize_library_database(&root.database_path()).map_err(library_error)?;
+    cache::initialize_library_database(&root.database_path()).map_err(|e| CommandError::from(LibraryError::DatabaseUnavailable(e.to_string())))?;
 
     // Ensure the directory structure exists even if the cached copy was created
     // before the remote repository folder layout stabilized.

--- a/src-tauri/src/commands/remote_library/webdav.rs
+++ b/src-tauri/src/commands/remote_library/webdav.rs
@@ -1,6 +1,7 @@
 use crate::{
     cache,
-    commands::error::{library_error, CommandResult},
+    commands::error::{CommandError, CommandResult},
+    library::error::LibraryError,
     config::RegisteredLibrary,
     library_root::LibraryRoot,
 };
@@ -19,7 +20,7 @@ use super::types::{
 
 pub(crate) fn normalize_server_url(raw: &str) -> CommandResult<String> {
     let mut url = Url::parse(raw)
-        .map_err(|error| library_error(format!("invalid WebDAV server URL: {error}")))?;
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("invalid WebDAV server URL: {error}"))))?;
     if !raw.ends_with('/') {
         let next_path = format!("{}/", url.path().trim_end_matches('/'));
         url.set_path(&next_path);
@@ -40,7 +41,7 @@ pub(crate) fn join_url(base: &str, relative: &str) -> CommandResult<String> {
     Url::parse(base)
         .and_then(|url| url.join(relative))
         .map(|url| url.to_string())
-        .map_err(|error| library_error(format!("failed to join URL {base} + {relative}: {error}")))
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to join URL {base} + {relative}: {error}"))))
 }
 
 pub(crate) fn remote_path_display_from_url(url: &str) -> String {
@@ -58,7 +59,7 @@ pub(crate) fn webdav_client() -> CommandResult<Client> {
     Client::builder()
         .redirect(reqwest::redirect::Policy::limited(10))
         .build()
-        .map_err(|error| library_error(format!("failed to create WebDAV client: {error}")))
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to create WebDAV client: {error}"))))
 }
 
 pub(crate) fn webdav_send(
@@ -81,7 +82,7 @@ pub(crate) fn webdav_send(
     }
     request.send().map_err(|_error| {
         tracing::trace!("WebDAV request to {url} failed");
-        library_error("WebDAV request failed. Check the server URL and try again.".to_owned())
+        CommandError::from(LibraryError::Internal("WebDAV request failed. Check the server URL and try again.".to_owned()))
     })
 }
 
@@ -108,10 +109,10 @@ pub(crate) fn webdav_get_etag(
         return Ok(None);
     }
     if !response.status().is_success() {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "WebDAV HEAD {url} failed with status {}",
             response.status()
-        )));
+        ))));
     }
     Ok(response
         .headers()
@@ -128,16 +129,16 @@ pub(crate) fn ensure_webdav_collection_chain(
     password: &str,
 ) -> CommandResult<()> {
     let server = Url::parse(server_url)
-        .map_err(|error| library_error(format!("invalid WebDAV server URL: {error}")))?;
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("invalid WebDAV server URL: {error}"))))?;
     let target = Url::parse(target_url)
-        .map_err(|error| library_error(format!("invalid WebDAV target URL: {error}")))?;
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("invalid WebDAV target URL: {error}"))))?;
 
     let server_segments = non_empty_path_segments(&server);
     let target_segments = non_empty_path_segments(&target);
     if !target_segments.starts_with(&server_segments) {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "WebDAV target URL {target_url} is not inside server URL {server_url}"
-        )));
+        ))));
     }
 
     let mut current_segments = server_segments;
@@ -163,9 +164,9 @@ pub(crate) fn ensure_webdav_collection_chain(
         match response.status() {
             StatusCode::CREATED | StatusCode::METHOD_NOT_ALLOWED | StatusCode::CONFLICT => {}
             status => {
-                return Err(library_error(format!(
+                return Err(CommandError::from(LibraryError::Internal(format!(
                     "failed to create WebDAV collection {current_url}: {status}"
-                )))
+                ))))
             }
         }
     }
@@ -195,14 +196,14 @@ pub(crate) fn download_webdav_file(
         return Ok(None);
     }
     if !response.status().is_success() {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "failed to download {url}: {}",
             response.status()
-        )));
+        ))));
     }
     if let Some(parent) = destination.parent() {
         fs::create_dir_all(parent).map_err(|error| {
-            library_error(format!("failed to create {}: {error}", parent.display()))
+            CommandError::from(LibraryError::Internal(format!("failed to create {}: {error}", parent.display())))
         })?;
     }
     let etag = response
@@ -212,18 +213,18 @@ pub(crate) fn download_webdav_file(
         .map(str::to_owned);
     let bytes = response
         .bytes()
-        .map_err(|error| library_error(format!("failed to read WebDAV response: {error}")))?;
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to read WebDAV response: {error}"))))?;
     let mut file = fs::File::create(destination).map_err(|error| {
-        library_error(format!(
+        CommandError::from(LibraryError::Internal(format!(
             "failed to create {}: {error}",
             destination.display()
-        ))
+        )))
     })?;
     file.write_all(bytes.as_ref()).map_err(|error| {
-        library_error(format!(
+        CommandError::from(LibraryError::Internal(format!(
             "failed to write {}: {error}",
             destination.display()
-        ))
+        )))
     })?;
     Ok(etag)
 }
@@ -236,7 +237,7 @@ pub(crate) fn upload_webdav_file(
     password: &str,
 ) -> CommandResult<Option<String>> {
     let bytes = fs::read(source)
-        .map_err(|error| library_error(format!("failed to read {}: {error}", source.display())))?;
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to read {}: {error}", source.display()))))?;
     upload_webdav_bytes(client, url, bytes, username, password)
 }
 
@@ -257,10 +258,10 @@ pub(crate) fn upload_webdav_bytes(
         Some(bytes),
     )?;
     if !response.status().is_success() {
-        return Err(library_error(format!(
+        return Err(CommandError::from(LibraryError::Internal(format!(
             "failed to upload {url}: {}",
             response.status()
-        )));
+        ))));
     }
     Ok(response
         .headers()
@@ -273,11 +274,11 @@ pub(crate) fn parse_webdav_payload(
     payload: Option<serde_json::Value>,
 ) -> CommandResult<WebDavSessionData> {
     let payload = payload.ok_or_else(|| {
-        library_error("WebDAV connection details are required for this provider".to_owned())
+        CommandError::from(LibraryError::Internal("WebDAV connection details are required for this provider".to_owned()))
     })?;
 
     match serde_json::from_value::<RemoteAuthPayloadInput>(payload)
-        .map_err(|error| library_error(format!("invalid remote auth payload: {error}")))?
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("invalid remote auth payload: {error}"))))?
     {
         RemoteAuthPayloadInput::WebDav {
             server_url,
@@ -286,15 +287,13 @@ pub(crate) fn parse_webdav_payload(
             root_path,
         } => {
             if server_url.trim().is_empty() {
-                return Err(library_error(
-                    "WebDAV server URL cannot be empty".to_owned(),
-                ));
+                return Err(CommandError::from(LibraryError::Internal("WebDAV server URL cannot be empty".to_owned(),)));
             }
             if username.trim().is_empty() {
-                return Err(library_error("WebDAV username cannot be empty".to_owned()));
+                return Err(CommandError::from(LibraryError::Internal("WebDAV username cannot be empty".to_owned())));
             }
             if password.trim().is_empty() {
-                return Err(library_error("WebDAV password cannot be empty".to_owned()));
+                return Err(CommandError::from(LibraryError::Internal("WebDAV password cannot be empty".to_owned())));
             }
 
             Ok(WebDavSessionData {
@@ -326,7 +325,7 @@ pub(crate) fn load_webdav_secret(
 ) -> CommandResult<WebDavSecret> {
     let remote_root_url = library
         .remote_root_locator()
-        .ok_or_else(|| library_error("remote repository is missing a remote locator"))?
+        .ok_or_else(|| CommandError::from(LibraryError::Internal("remote repository is missing a remote locator".to_string())))?
         .to_owned();
     if let Some(secret) = load_remote_credential::<StoredWebDavSecret>(app_data_dir, library.id())?
     {
@@ -336,9 +335,7 @@ pub(crate) fn load_webdav_secret(
             password: secret.password,
         });
     }
-    Err(library_error(
-        "missing stored credentials for the remote repository".to_owned(),
-    ))
+    Err(CommandError::from(LibraryError::Internal("missing stored credentials for the remote repository".to_owned(),)))
 }
 
 pub(crate) fn webdav_marker_url(root_url: &str) -> CommandResult<String> {
@@ -356,13 +353,13 @@ pub(crate) fn initialize_or_sync_webdav_library(
 ) -> CommandResult<Option<String>> {
     let root_path = library
         .working_copy_root()
-        .ok_or_else(|| library_error("remote repository is missing a cached working copy"))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal("remote repository is missing a cached working copy".to_string())))?;
     let root = if root_path.join(".openkara-library").exists() {
-        LibraryRoot::open(&root_path).map_err(library_error)?
+        LibraryRoot::open(&root_path).map_err(|e| CommandError::from(LibraryError::Internal(e.to_string())))?
     } else {
-        LibraryRoot::create(&root_path).map_err(library_error)?
+        LibraryRoot::create(&root_path).map_err(|e| CommandError::from(LibraryError::Internal(e.to_string())))?
     };
-    cache::initialize_library_database(&root.database_path()).map_err(library_error)?;
+    cache::initialize_library_database(&root.database_path()).map_err(|e| CommandError::from(LibraryError::DatabaseUnavailable(e.to_string())))?;
 
     let client = webdav_client()?;
     let server_url = stored_webdav_server_url(library)?;
@@ -426,20 +423,18 @@ pub(crate) fn refresh_existing_webdav_library(
 ) -> CommandResult<Option<String>> {
     let root_path = library
         .working_copy_root()
-        .ok_or_else(|| library_error("remote repository is missing a cached working copy"))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal("remote repository is missing a cached working copy".to_string())))?;
     let root = if root_path.join(".openkara-library").exists() {
-        LibraryRoot::open(&root_path).map_err(library_error)?
+        LibraryRoot::open(&root_path).map_err(|e| CommandError::from(LibraryError::Internal(e.to_string())))?
     } else {
-        LibraryRoot::create(&root_path).map_err(library_error)?
+        LibraryRoot::create(&root_path).map_err(|e| CommandError::from(LibraryError::Internal(e.to_string())))?
     };
-    cache::initialize_library_database(&root.database_path()).map_err(library_error)?;
+    cache::initialize_library_database(&root.database_path()).map_err(|e| CommandError::from(LibraryError::DatabaseUnavailable(e.to_string())))?;
 
     let client = webdav_client()?;
     let marker_url = webdav_marker_url(&secret.root_url)?;
     if !webdav_exists(&client, &marker_url, &secret.username, &secret.password)? {
-        return Err(library_error(
-            "The selected WebDAV path is not an OpenKara remote repository.".to_owned(),
-        ));
+        return Err(CommandError::from(LibraryError::Internal("The selected WebDAV path is not an OpenKara remote repository.".to_owned(),)));
     }
 
     let database_url = webdav_database_url(&secret.root_url)?;
@@ -450,7 +445,7 @@ pub(crate) fn refresh_existing_webdav_library(
         &secret.username,
         &secret.password,
     )?
-    .ok_or_else(|| library_error("The selected WebDAV path is missing openkara.db.".to_owned()))
+    .ok_or_else(|| CommandError::from(LibraryError::Internal("The selected WebDAV path is missing openkara.db.".to_owned())))
     .map(Some)
 }
 
@@ -461,7 +456,7 @@ pub(crate) fn upload_relative_file_to_remote(
 ) -> CommandResult<()> {
     let local_root = library
         .working_copy_root()
-        .ok_or_else(|| library_error("remote repository is missing a cached working copy"))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal("remote repository is missing a cached working copy".to_string())))?;
     let source = local_root.join(relative_path);
     let client = webdav_client()?;
     let server_url = stored_webdav_server_url(library)?;
@@ -500,20 +495,20 @@ pub(crate) fn upload_directory_to_remote(
 ) -> CommandResult<()> {
     let local_root = library
         .working_copy_root()
-        .ok_or_else(|| library_error("remote repository is missing a cached working copy"))?;
+        .ok_or_else(|| CommandError::from(LibraryError::Internal("remote repository is missing a cached working copy".to_string())))?;
     let base = local_root.join(relative_directory);
     if !base.exists() {
         return Ok(());
     }
 
     for entry in fs::read_dir(&base)
-        .map_err(|error| library_error(format!("failed to read {}: {error}", base.display())))?
+        .map_err(|error| CommandError::from(LibraryError::Internal(format!("failed to read {}: {error}", base.display()))))?
     {
-        let entry = entry.map_err(|error| library_error(error.to_string()))?;
+        let entry = entry.map_err(|error| CommandError::from(LibraryError::Internal(error.to_string())))?;
         let path = entry.path();
         let relative = path
             .strip_prefix(&local_root)
-            .map_err(|error| library_error(error.to_string()))?
+            .map_err(|error| CommandError::from(LibraryError::Internal(error.to_string())))?
             .to_string_lossy()
             .replace('\\', "/");
 
@@ -548,9 +543,7 @@ pub(crate) fn delete_relative_path_from_remote(
         }
         status => {
             tracing::trace!("WebDAV delete at {url} returned {status}");
-            Err(library_error(
-                "WebDAV delete failed. Check permissions and try again.".to_owned(),
-            ))
+            Err(CommandError::from(LibraryError::Internal("WebDAV delete failed. Check permissions and try again.".to_owned(),)))
         }
     }
 }

--- a/src-tauri/src/commands/separation.rs
+++ b/src-tauri/src/commands/separation.rs
@@ -1,9 +1,9 @@
 use crate::{
     cache,
-    commands::error::{separation_error, state_lock_error, CommandError, CommandResult},
+    commands::error::{state_lock_error, CommandError, CommandResult},
     commands::remote_library,
     config::{self, ExecutionProviderPreference, StemMode},
-    separator::{self, model::LoadedModel, model_cache::ModelCache},
+    separator::{self, error::SeparationError, model::LoadedModel, model_cache::ModelCache},
     AppState,
 };
 use serde::Serialize;
@@ -104,7 +104,7 @@ pub fn upgrade_to_four_stem(
     {
         let library_root = state.library_root()?;
         let connection = cache::open_database(&library_root.database_path())
-            .map_err(|e| separation_error(e.to_string()))?;
+            .map_err(|e| SeparationError::Failed(e.to_string()))?;
         if let Ok(Some(entry)) = cache::stems::get_cached_stem_entry(&connection, &song_id) {
             if entry.has_individual_stems() {
                 return Ok(completed_status(
@@ -147,7 +147,7 @@ pub fn re_separate(
     {
         let library_root = state.library_root()?;
         let connection = cache::open_database(&library_root.database_path())
-            .map_err(|e| separation_error(e.to_string()))?;
+            .map_err(|e| SeparationError::Failed(e.to_string()))?;
         let _ = cache::stems::delete_stem_cache_entry(&connection, &library_root, &song_id);
     }
 
@@ -222,10 +222,10 @@ fn spawn_separation_job(
         let final_status = match result {
             Ok(Ok(artifacts)) => status_from_job_result(&song_id, Ok(artifacts)),
             Ok(Err(error)) => {
-                status_from_job_result(&song_id, Err(separation_error(error.to_string())))
+                status_from_job_result(&song_id, Err(SeparationError::Failed(error.to_string()).into()))
             }
             Err(error) => {
-                status_from_job_result(&song_id, Err(separation_error(error.to_string())))
+                status_from_job_result(&song_id, Err(SeparationError::Failed(error.to_string()).into()))
             }
         };
 
@@ -350,11 +350,11 @@ pub fn downgrade_single_to_two_stem(
 ) -> CommandResult<SeparationStatusSnapshot> {
     let library_root = state.library_root()?;
     let connection = cache::open_database(&library_root.database_path())
-        .map_err(|e| separation_error(e.to_string()))?;
+        .map_err(|e| SeparationError::Failed(e.to_string()))?;
 
     let (updated_entry, _freed_bytes) =
         cache::stems::downgrade_to_two_stem(&connection, &library_root, &song_id)
-            .map_err(|e| separation_error(e.to_string()))?;
+            .map_err(|e| SeparationError::Failed(e.to_string()))?;
 
     let completed = completed_status(
         &song_id,
@@ -456,14 +456,10 @@ pub fn get_separation_status_from_map(
 fn ensure_song_can_be_separated(state: &State<'_, AppState>, song_id: &str) -> CommandResult<()> {
     let library_root = state.library_root()?;
     let connection = cache::open_database(&library_root.database_path())
-        .map_err(|e| separation_error(e.to_string()))?;
+        .map_err(|e| SeparationError::Failed(e.to_string()))?;
     let song = cache::get_song_by_hash(&connection, song_id)
-        .map_err(|e| separation_error(e.to_string()))?
-        .ok_or_else(|| {
-            separation_error(format!(
-                "song with hash {song_id} was not found in the library"
-            ))
-        })?;
+        .map_err(|e| SeparationError::Failed(e.to_string()))?
+        .ok_or_else(|| SeparationError::SongNotFound(song_id.to_owned()))?;
 
     validate_song_can_be_separated(&song, song_id)
 }
@@ -472,15 +468,15 @@ fn validate_song_can_be_separated(song: &crate::library::Song, song_id: &str) ->
     if song.is_media_g() {
         // Media+G songs already carry karaoke graphics and intentionally skip
         // the stem pipeline, which is designed for plain audio assets only.
-        return Err(separation_error(format!(
+        return Err(SeparationError::Failed(format!(
             "song {song_id} is a Media+G track and cannot be separated"
-        )));
+        )).into());
     }
 
     if song.is_instrumental() {
-        return Err(separation_error(format!(
+        return Err(SeparationError::Failed(format!(
             "song {song_id} is marked instrumental and cannot be separated"
-        )));
+        )).into());
     }
 
     Ok(())
@@ -649,7 +645,7 @@ mod tests {
 
     #[test]
     fn status_from_job_result_maps_errors_to_failed_status() {
-        let error = separation_error("boom".to_owned());
+        let error: CommandError = SeparationError::Failed("boom".to_owned()).into();
 
         let status = status_from_job_result("song-1", Err(error.clone()));
 

--- a/src-tauri/src/library/error.rs
+++ b/src-tauri/src/library/error.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum LibraryError {
+    #[error("media read failed: {0}")]
+    MediaReadFailed(String),
+
+    #[error("database unavailable: {0}")]
+    DatabaseUnavailable(String),
+
+    #[error("library error: {0}")]
+    Internal(String),
+}

--- a/src-tauri/src/library/mod.rs
+++ b/src-tauri/src/library/mod.rs
@@ -1,3 +1,5 @@
+pub mod error;
+
 use crate::commands::error::CommandError;
 use serde::Serialize;
 

--- a/src-tauri/src/lyrics/error.rs
+++ b/src-tauri/src/lyrics/error.rs
@@ -1,0 +1,19 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum LyricsError {
+    #[error("song {0} was not found in the library")]
+    SongNotFound(String),
+
+    #[error("lyrics not ready: {0}")]
+    LyricsNotReady(String),
+
+    #[error("network unavailable: {0}")]
+    NetworkUnavailable(String),
+
+    #[error("database unavailable: {0}")]
+    DatabaseUnavailable(String),
+
+    #[error("lyrics error: {0}")]
+    Internal(String),
+}

--- a/src-tauri/src/lyrics/fetch.rs
+++ b/src-tauri/src/lyrics/fetch.rs
@@ -44,23 +44,29 @@ impl TimedLyricsProvider<'_> {
 
     fn fetch_timed_lrc(self, query: &LyricsLookupQuery) -> Result<Option<String>> {
         match self {
-            Self::LrcLib(client) => client.fetch_by_track(query).map(|result| {
-                result.and_then(|lyrics| {
-                    lyrics
-                        .synced_lyrics
-                        .filter(|lyrics| !lyrics.trim().is_empty())
+            Self::LrcLib(client) => client
+                .fetch_by_track(query)
+                .map(|result| {
+                    result.and_then(|lyrics| {
+                        lyrics
+                            .synced_lyrics
+                            .filter(|lyrics| !lyrics.trim().is_empty())
+                    })
                 })
-            }),
-            Self::LrcApi(client) => client.fetch_by_track(query).map(|result| {
-                result.and_then(|lyrics| {
-                    let lrc = lyrics.lrc.trim();
-                    if lrc.is_empty() {
-                        None
-                    } else {
-                        Some(lyrics.lrc)
-                    }
+                .map_err(Into::into),
+            Self::LrcApi(client) => client
+                .fetch_by_track(query)
+                .map(|result| {
+                    result.and_then(|lyrics| {
+                        let lrc = lyrics.lrc.trim();
+                        if lrc.is_empty() {
+                            None
+                        } else {
+                            Some(lyrics.lrc)
+                        }
+                    })
                 })
-            }),
+                .map_err(Into::into),
         }
     }
 }

--- a/src-tauri/src/lyrics/lrcapi.rs
+++ b/src-tauri/src/lyrics/lrcapi.rs
@@ -1,5 +1,5 @@
+use crate::lyrics::error::LyricsError;
 use crate::lyrics::lrclib::LyricsLookupQuery;
-use anyhow::{Context, Result};
 use serde::Deserialize;
 
 const DEFAULT_BASE_URL: &str = "https://api.lrc.cx";
@@ -50,7 +50,10 @@ impl LrcApiClient {
         Self::new(DEFAULT_BASE_URL)
     }
 
-    pub fn fetch_by_track(&self, query: &LyricsLookupQuery) -> Result<Option<LrcApiLyrics>> {
+    pub fn fetch_by_track(
+        &self,
+        query: &LyricsLookupQuery,
+    ) -> Result<Option<LrcApiLyrics>, LyricsError> {
         let url = format!("{}/jsonapi", self.base_url);
         let mut request = self.http.get(url).query(&[
             ("title", query.track_name.as_str()),
@@ -61,13 +64,15 @@ impl LrcApiClient {
             request = request.query(&[("album", album_name)]);
         }
 
-        let response = request.send().context("failed to request timed lyrics")?;
+        let response = request
+            .send()
+            .map_err(|e| LyricsError::NetworkUnavailable(format!("failed to request lyrics from LrcAPI: {e}")))?;
         let response = response
             .error_for_status()
-            .context("timed lyrics provider returned a non-success response")?;
+            .map_err(|e| LyricsError::NetworkUnavailable(format!("LrcAPI returned a non-success response: {e}")))?;
         let response = response
             .json::<LrcApiResponse>()
-            .context("failed to deserialize timed lyrics response")?;
+            .map_err(|e| LyricsError::NetworkUnavailable(format!("failed to deserialize LrcAPI lyrics response: {e}")))?;
 
         Ok(match response {
             LrcApiResponse::Hits(entries) => entries
@@ -78,8 +83,8 @@ impl LrcApiClient {
                 if miss.message.trim() == "未找到歌词" {
                     None
                 } else {
-                    return Err(anyhow::anyhow!(format!(
-                        "timed lyrics provider returned an unexpected response: {}",
+                    return Err(LyricsError::NetworkUnavailable(format!(
+                        "LrcAPI returned an unexpected response: {}",
                         miss.message
                     )));
                 }

--- a/src-tauri/src/lyrics/lrclib.rs
+++ b/src-tauri/src/lyrics/lrclib.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use crate::lyrics::error::LyricsError;
 use serde::Deserialize;
 
 const DEFAULT_BASE_URL: &str = "https://lrclib.net";
@@ -47,7 +47,10 @@ impl LrcLibClient {
         Self::new(DEFAULT_BASE_URL)
     }
 
-    pub fn fetch_by_track(&self, query: &LyricsLookupQuery) -> Result<Option<LrcLibLyrics>> {
+    pub fn fetch_by_track(
+        &self,
+        query: &LyricsLookupQuery,
+    ) -> Result<Option<LrcLibLyrics>, LyricsError> {
         let url = format!("{}/api/get", self.base_url);
         let mut request = self.http.get(url).query(&[
             ("track_name", query.track_name.as_str()),
@@ -62,17 +65,19 @@ impl LrcLibClient {
             request = request.query(&[("duration", duration_seconds)]);
         }
 
-        let response = request.send().context("failed to request timed lyrics")?;
+        let response = request
+            .send()
+            .map_err(|e| LyricsError::NetworkUnavailable(format!("failed to request lyrics from LRCLIB: {e}")))?;
         if response.status() == reqwest::StatusCode::NOT_FOUND {
             return Ok(None);
         }
 
         let response = response
             .error_for_status()
-            .context("timed lyrics provider returned a non-success response")?;
+            .map_err(|e| LyricsError::NetworkUnavailable(format!("LRCLIB returned a non-success response: {e}")))?;
         let lyrics = response
             .json::<LrcLibLyrics>()
-            .context("failed to deserialize timed lyrics response")?;
+            .map_err(|e| LyricsError::NetworkUnavailable(format!("failed to deserialize LRCLIB lyrics response: {e}")))?;
 
         Ok(Some(lyrics))
     }

--- a/src-tauri/src/lyrics/mod.rs
+++ b/src-tauri/src/lyrics/mod.rs
@@ -1,3 +1,4 @@
+pub mod error;
 pub mod fetch;
 pub mod lrcapi;
 pub mod lrclib;

--- a/src-tauri/src/separator/error.rs
+++ b/src-tauri/src/separator/error.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum SeparationError {
+    #[error("song {0} was not found in the library")]
+    SongNotFound(String),
+
+    #[error("failed to decode audio: {0}")]
+    AudioDecodeFailed(String),
+
+    #[error("separation failed: {0}")]
+    Failed(String),
+}

--- a/src-tauri/src/separator/job.rs
+++ b/src-tauri/src/separator/job.rs
@@ -69,7 +69,7 @@ pub fn separate_song_into_cache(
     };
     let absolute_path = library_root.resolve(song_path);
     let decoded_audio = decode::decode_file(&absolute_path)
-        .with_context(|| format!("failed to decode audio for {}", song_path))?;
+        .map_err(|e| anyhow::anyhow!("failed to decode audio for {}: {}", song_path, e))?;
 
     report_progress(MODEL_LOAD_PROGRESS);
     let mut model_cache = model_cache

--- a/src-tauri/src/separator/mod.rs
+++ b/src-tauri/src/separator/mod.rs
@@ -1,5 +1,6 @@
 pub mod bootstrap;
 pub mod checkpoint;
+pub mod error;
 pub mod inference;
 pub mod job;
 pub mod mix;

--- a/src-tauri/src/services/playback.rs
+++ b/src-tauri/src/services/playback.rs
@@ -32,42 +32,6 @@ fn bump_airplay_stream_generation(airplay: &AirPlayState) {
         .fetch_add(1, Ordering::SeqCst);
 }
 
-/// Classify an `anyhow::Error` from the audio/cache/playback_source layer into
-/// a typed `PlaybackError`.  This is the service-boundary conversion point —
-/// downstream modules still use `anyhow::Result`, and we map once here so that
-/// the command layer can use `From<PlaybackError> for CommandError` directly.
-fn classify_playback_error(err: anyhow::Error) -> PlaybackError {
-    let msg = err.to_string();
-    if msg.contains("no track is loaded") {
-        return PlaybackError::InvalidPlaybackState(msg);
-    }
-    if msg.contains("does not have cached stems")
-        || msg.contains("karaoke audio is not loaded")
-        || msg.contains("no cached stems for song")
-    {
-        return PlaybackError::KaraokeNotReady(msg);
-    }
-    if msg.contains("failed to decode audio")
-        || msg.contains("failed to open audio file")
-        || msg.contains("failed to probe audio format")
-        || msg.contains("failed to probe audio")
-        || msg.contains("audio container does not expose a default track")
-        || msg.contains("failed to create audio decoder")
-        || msg.contains("failed while reading audio packets")
-        || msg.contains("failed to decode stem")
-    {
-        return PlaybackError::AudioDecodeFailed(msg);
-    }
-    if msg.contains("no default output audio device is available")
-        || msg.contains("failed to read default audio output config")
-        || msg.contains("failed to start audio output stream")
-        || msg.contains("audio output start lock was poisoned")
-    {
-        return PlaybackError::AudioOutputUnavailable(msg);
-    }
-    PlaybackError::Internal(msg)
-}
-
 pub(crate) fn spawn_airplay_control_refresh_worker(
     airplay_audience_active: Arc<AtomicBool>,
     airplay_control_refresh_token: Arc<AtomicU64>,
@@ -186,21 +150,18 @@ pub fn play<R: Runtime>(
     let PlaybackSourceLoad {
         decoded_audio,
         stems,
-    } = load_playback_source(Some(&state.shell.app_data_dir), &connection, &library_root, &song)
-        .map_err(classify_playback_error)?;
+    } = load_playback_source(Some(&state.shell.app_data_dir), &connection, &library_root, &song)?;
     let snapshot = decode_then_start_track_if_latest(
         &state.playback.playback,
         &state.playback.playback_request_id,
         request_id,
         active_song_id.clone(),
         move || Ok(decoded_audio),
-    )
-    .map_err(classify_playback_error)?;
+    )?;
     let snapshot = if let Some(stems) = stems {
         decode_then_attach_stems_if_current_song(&state.playback.playback, &active_song_id, move || {
             Ok(stems)
-        })
-        .map_err(classify_playback_error)?
+        })?
     } else {
         snapshot
     };
@@ -234,8 +195,7 @@ pub fn resume<R: Runtime>(
         .playback
         .lock()
         .map_err(|_| PlaybackError::Internal("playback controller lock was poisoned".to_owned()))?;
-    let snapshot = playback.play(monotonic_now_ms())
-        .map_err(classify_playback_error)?;
+    let snapshot = playback.play(monotonic_now_ms())?;
     drop(playback);
 
     ensure_output_thread(state)?;
@@ -257,8 +217,7 @@ pub fn pause<R: Runtime>(
         .playback
         .lock()
         .map_err(|_| PlaybackError::Internal("playback controller lock was poisoned".to_owned()))?;
-    let snapshot = playback.pause(monotonic_now_ms())
-        .map_err(classify_playback_error)?;
+    let snapshot = playback.pause(monotonic_now_ms())?;
     emit_playback_position(app_handle, &snapshot)
         .map_err(|e| PlaybackError::Internal(e.to_string()))?;
     Ok(snapshot)
@@ -278,8 +237,7 @@ pub fn seek<R: Runtime>(
         .lock()
         .map_err(|_| PlaybackError::Internal("playback controller lock was poisoned".to_owned()))?;
     let previous_position_ms = playback.snapshot(monotonic_now_ms()).position_ms;
-    let snapshot = playback.seek(ms, monotonic_now_ms())
-        .map_err(classify_playback_error)?;
+    let snapshot = playback.seek(ms, monotonic_now_ms())?;
     drop(playback);
 
     let mut cdg_state = state
@@ -301,8 +259,7 @@ pub fn set_volume(state: &AppState, level: f32) -> Result<PlaybackStateSnapshot,
         .playback
         .lock()
         .map_err(|_| PlaybackError::Internal("playback controller lock was poisoned".to_owned()))?;
-    let snapshot = playback.set_volume(level)
-        .map_err(classify_playback_error)?;
+    let snapshot = playback.set_volume(level)?;
     drop(playback);
     if state.airplay.airplay_audience_active.load(Ordering::SeqCst) {
         state
@@ -323,8 +280,7 @@ pub fn set_stem_volume(
         .playback
         .lock()
         .map_err(|_| PlaybackError::Internal("playback controller lock was poisoned".to_owned()))?;
-    let snapshot = playback.set_stem_volume(stem, level)
-        .map_err(classify_playback_error)?;
+    let snapshot = playback.set_stem_volume(stem, level)?;
     drop(playback);
     if state.airplay.airplay_audience_active.load(Ordering::SeqCst) {
         state
@@ -365,7 +321,6 @@ pub fn load_stems(state: &AppState) -> Result<PlaybackStateSnapshot, PlaybackErr
     decode_then_attach_stems_if_current_song(&state.playback.playback, &song_id, || {
         load_cached_stems_for_song(Some(&state.shell.app_data_dir), &connection, &library_root, &song)
     })
-    .map_err(classify_playback_error)
 }
 
 pub fn get_state(state: &AppState) -> Result<PlaybackStateSnapshot, PlaybackError> {
@@ -444,12 +399,11 @@ pub fn play_song_from_library(
     let PlaybackSourceLoad {
         decoded_audio,
         stems,
-    } = load_playback_source(None, connection, library_root, &song)
-        .map_err(classify_playback_error)?;
+    } = load_playback_source(None, connection, library_root, &song)?;
     let snapshot = controller.start_track(song.hash.clone(), decoded_audio, now_ms);
     if let Some(stems) = stems {
         controller.attach_stems(&song.hash, stems)
-            .map_err(classify_playback_error)?;
+            .map_err(|e| PlaybackError::Internal(e.to_string()))?;
         return Ok(controller.snapshot(now_ms));
     }
     Ok(snapshot)
@@ -464,7 +418,6 @@ pub(crate) fn ensure_output_thread(state: &AppState) -> Result<(), PlaybackError
         state.airplay.airplay_local_output_suppressed.clone(),
         state.shell.shutdown.clone(),
     )
-    .map_err(classify_playback_error)
 }
 
 pub(crate) fn ensure_output_thread_inner(
@@ -474,7 +427,7 @@ pub(crate) fn ensure_output_thread_inner(
     airplay_audio_tap: Arc<crate::airplay_stream::AirPlayAudioTap>,
     airplay_local_output_suppressed: Arc<AtomicBool>,
     shutdown: Arc<AtomicBool>,
-) -> anyhow::Result<()> {
+) -> Result<(), PlaybackError> {
     output::ensure_output_thread(
         audio_output_started,
         audio_output_start_lock,
@@ -492,16 +445,16 @@ fn decode_then_start_track_if_latest<F>(
     request_id: u64,
     song_id: String,
     decode_audio: F,
-) -> anyhow::Result<PlaybackStateSnapshot>
+) -> Result<PlaybackStateSnapshot, PlaybackError>
 where
-    F: FnOnce() -> anyhow::Result<decode::DecodedAudio>,
+    F: FnOnce() -> Result<decode::DecodedAudio, PlaybackError>,
 {
     // Decode before taking the playback lock so expensive file IO does not stall
     // output/control paths, then apply a latest-request-wins guard before swap-in.
     let decoded_audio = decode_audio()?;
     let mut playback = playback
         .lock()
-        .map_err(|_| anyhow::anyhow!("playback controller lock was poisoned"))?;
+        .map_err(|_| PlaybackError::Internal("playback controller lock was poisoned".to_owned()))?;
 
     if latest_request_id.load(Ordering::SeqCst) != request_id {
         return Ok(playback.snapshot(monotonic_now_ms()));
@@ -514,20 +467,21 @@ fn decode_then_attach_stems_if_current_song<F>(
     playback: &Arc<Mutex<PlaybackController>>,
     song_id: &str,
     decode_stems: F,
-) -> anyhow::Result<PlaybackStateSnapshot>
+) -> Result<PlaybackStateSnapshot, PlaybackError>
 where
-    F: FnOnce() -> anyhow::Result<LoadedStems>,
+    F: FnOnce() -> Result<LoadedStems, PlaybackError>,
 {
     let loaded_stems = decode_stems()?;
     let mut playback = playback
         .lock()
-        .map_err(|_| anyhow::anyhow!("playback controller lock was poisoned"))?;
+        .map_err(|_| PlaybackError::Internal("playback controller lock was poisoned".to_owned()))?;
 
     if playback.current_song_id() != Some(song_id) {
         return Ok(playback.snapshot(monotonic_now_ms()));
     }
 
-    playback.attach_stems(song_id, loaded_stems)?;
+    playback.attach_stems(song_id, loaded_stems)
+        .map_err(|e| PlaybackError::Internal(e.to_string()))?;
     Ok(playback.snapshot(monotonic_now_ms()))
 }
 

--- a/src-tauri/src/services/playback.rs
+++ b/src-tauri/src/services/playback.rs
@@ -1,6 +1,6 @@
 use crate::{
     audio::{
-        decode, output,
+        decode, error::PlaybackError, output,
         playback::{
             monotonic_now_ms, playback_position_event, LoadedStems, PlaybackController,
             PlaybackStateSnapshot, StemName, PLAYBACK_POSITION_EVENT,
@@ -14,7 +14,6 @@ use crate::{
     },
     state::{AppState, AirPlayState},
 };
-use anyhow::{Context, Result};
 use rusqlite::Connection;
 use std::path::Path;
 use std::sync::{
@@ -31,6 +30,42 @@ fn bump_airplay_stream_generation(airplay: &AirPlayState) {
     airplay
         .airplay_stream_generation
         .fetch_add(1, Ordering::SeqCst);
+}
+
+/// Classify an `anyhow::Error` from the audio/cache/playback_source layer into
+/// a typed `PlaybackError`.  This is the service-boundary conversion point —
+/// downstream modules still use `anyhow::Result`, and we map once here so that
+/// the command layer can use `From<PlaybackError> for CommandError` directly.
+fn classify_playback_error(err: anyhow::Error) -> PlaybackError {
+    let msg = err.to_string();
+    if msg.contains("no track is loaded") {
+        return PlaybackError::InvalidPlaybackState(msg);
+    }
+    if msg.contains("does not have cached stems")
+        || msg.contains("karaoke audio is not loaded")
+        || msg.contains("no cached stems for song")
+    {
+        return PlaybackError::KaraokeNotReady(msg);
+    }
+    if msg.contains("failed to decode audio")
+        || msg.contains("failed to open audio file")
+        || msg.contains("failed to probe audio format")
+        || msg.contains("failed to probe audio")
+        || msg.contains("audio container does not expose a default track")
+        || msg.contains("failed to create audio decoder")
+        || msg.contains("failed while reading audio packets")
+        || msg.contains("failed to decode stem")
+    {
+        return PlaybackError::AudioDecodeFailed(msg);
+    }
+    if msg.contains("no default output audio device is available")
+        || msg.contains("failed to read default audio output config")
+        || msg.contains("failed to start audio output stream")
+        || msg.contains("audio output start lock was poisoned")
+    {
+        return PlaybackError::AudioOutputUnavailable(msg);
+    }
+    PlaybackError::Internal(msg)
 }
 
 pub(crate) fn spawn_airplay_control_refresh_worker(
@@ -96,18 +131,20 @@ pub fn play<R: Runtime>(
     state: &AppState,
     app_handle: &AppHandle<R>,
     song_id: &str,
-) -> Result<PlaybackStateSnapshot> {
+) -> Result<PlaybackStateSnapshot, PlaybackError> {
     state.airplay.airplay_audio_tap.bump_epoch();
     crate::airplay_stream::notify_audio_epoch(state.airplay.airplay_audio_tap.current_epoch());
     bump_airplay_stream_generation(&state.airplay);
     let library_root = state
         .shell
         .library_root()
-        .map_err(|error| anyhow::anyhow!(error.message.clone()))?;
-    let connection = cache::open_database(&library_root.database_path())?;
+        .map_err(|error| PlaybackError::Internal(error.message))?;
+    let connection = cache::open_database(&library_root.database_path())
+        .map_err(|e| PlaybackError::Internal(e.to_string()))?;
     let request_id = state.playback.playback_request_id.fetch_add(1, Ordering::SeqCst) + 1;
-    let song = cache::get_song_by_hash(&connection, song_id)?
-        .with_context(|| format!("song with hash {song_id} was not found in the library"))?;
+    let song = cache::get_song_by_hash(&connection, song_id)
+        .map_err(|e| PlaybackError::Internal(e.to_string()))?
+        .ok_or_else(|| PlaybackError::SongNotFound(song_id.to_owned()))?;
     let active_song_id = song.hash.clone();
     let needs_remote_download = song.is_remote() || song.is_remote_stems();
 
@@ -117,10 +154,11 @@ pub fn play<R: Runtime>(
                 .playback
                 .playback
                 .lock()
-                .map_err(|_| anyhow::anyhow!("playback controller lock was poisoned"))?;
+                .map_err(|_| PlaybackError::Internal("playback controller lock was poisoned".to_owned()))?;
             playback.start_track_loading(&active_song_id)
         };
-        emit_playback_position(app_handle, &snapshot)?;
+        emit_playback_position(app_handle, &snapshot)
+            .map_err(|e| PlaybackError::Internal(e.to_string()))?;
 
         let background_state = state.clone();
         let background_handle = app_handle.clone();
@@ -148,18 +186,21 @@ pub fn play<R: Runtime>(
     let PlaybackSourceLoad {
         decoded_audio,
         stems,
-    } = load_playback_source(Some(&state.shell.app_data_dir), &connection, &library_root, &song)?;
+    } = load_playback_source(Some(&state.shell.app_data_dir), &connection, &library_root, &song)
+        .map_err(classify_playback_error)?;
     let snapshot = decode_then_start_track_if_latest(
         &state.playback.playback,
         &state.playback.playback_request_id,
         request_id,
         active_song_id.clone(),
         move || Ok(decoded_audio),
-    )?;
+    )
+    .map_err(classify_playback_error)?;
     let snapshot = if let Some(stems) = stems {
         decode_then_attach_stems_if_current_song(&state.playback.playback, &active_song_id, move || {
             Ok(stems)
-        })?
+        })
+        .map_err(classify_playback_error)?
     } else {
         snapshot
     };
@@ -170,12 +211,13 @@ pub fn play<R: Runtime>(
             .playback
             .cdg_state
             .lock()
-            .map_err(|_| anyhow::anyhow!("CDG state lock was poisoned"))?;
+            .map_err(|_| PlaybackError::Internal("CDG state lock was poisoned".to_owned()))?;
         *cdg_state = next_cdg_state;
     }
 
     ensure_output_thread(state)?;
-    emit_playback_position(app_handle, &snapshot)?;
+    emit_playback_position(app_handle, &snapshot)
+        .map_err(|e| PlaybackError::Internal(e.to_string()))?;
 
     Ok(snapshot)
 }
@@ -183,7 +225,7 @@ pub fn play<R: Runtime>(
 pub fn resume<R: Runtime>(
     state: &AppState,
     app_handle: &AppHandle<R>,
-) -> Result<PlaybackStateSnapshot> {
+) -> Result<PlaybackStateSnapshot, PlaybackError> {
     state.airplay.airplay_audio_tap.bump_epoch();
     crate::airplay_stream::notify_audio_epoch(state.airplay.airplay_audio_tap.current_epoch());
     bump_airplay_stream_generation(&state.airplay);
@@ -191,12 +233,14 @@ pub fn resume<R: Runtime>(
         .playback
         .playback
         .lock()
-        .map_err(|_| anyhow::anyhow!("playback controller lock was poisoned"))?;
-    let snapshot = playback.play(monotonic_now_ms())?;
+        .map_err(|_| PlaybackError::Internal("playback controller lock was poisoned".to_owned()))?;
+    let snapshot = playback.play(monotonic_now_ms())
+        .map_err(classify_playback_error)?;
     drop(playback);
 
     ensure_output_thread(state)?;
-    emit_playback_position(app_handle, &snapshot)?;
+    emit_playback_position(app_handle, &snapshot)
+        .map_err(|e| PlaybackError::Internal(e.to_string()))?;
 
     Ok(snapshot)
 }
@@ -204,7 +248,7 @@ pub fn resume<R: Runtime>(
 pub fn pause<R: Runtime>(
     state: &AppState,
     app_handle: &AppHandle<R>,
-) -> Result<PlaybackStateSnapshot> {
+) -> Result<PlaybackStateSnapshot, PlaybackError> {
     state.airplay.airplay_audio_tap.bump_epoch();
     crate::airplay_stream::notify_audio_epoch(state.airplay.airplay_audio_tap.current_epoch());
     bump_airplay_stream_generation(&state.airplay);
@@ -212,9 +256,11 @@ pub fn pause<R: Runtime>(
         .playback
         .playback
         .lock()
-        .map_err(|_| anyhow::anyhow!("playback controller lock was poisoned"))?;
-    let snapshot = playback.pause(monotonic_now_ms())?;
-    emit_playback_position(app_handle, &snapshot)?;
+        .map_err(|_| PlaybackError::Internal("playback controller lock was poisoned".to_owned()))?;
+    let snapshot = playback.pause(monotonic_now_ms())
+        .map_err(classify_playback_error)?;
+    emit_playback_position(app_handle, &snapshot)
+        .map_err(|e| PlaybackError::Internal(e.to_string()))?;
     Ok(snapshot)
 }
 
@@ -222,7 +268,7 @@ pub fn seek<R: Runtime>(
     state: &AppState,
     app_handle: &AppHandle<R>,
     ms: u64,
-) -> Result<PlaybackStateSnapshot> {
+) -> Result<PlaybackStateSnapshot, PlaybackError> {
     state.airplay.airplay_audio_tap.bump_epoch();
     crate::airplay_stream::notify_audio_epoch(state.airplay.airplay_audio_tap.current_epoch());
     bump_airplay_stream_generation(&state.airplay);
@@ -230,30 +276,33 @@ pub fn seek<R: Runtime>(
         .playback
         .playback
         .lock()
-        .map_err(|_| anyhow::anyhow!("playback controller lock was poisoned"))?;
+        .map_err(|_| PlaybackError::Internal("playback controller lock was poisoned".to_owned()))?;
     let previous_position_ms = playback.snapshot(monotonic_now_ms()).position_ms;
-    let snapshot = playback.seek(ms, monotonic_now_ms())?;
+    let snapshot = playback.seek(ms, monotonic_now_ms())
+        .map_err(classify_playback_error)?;
     drop(playback);
 
     let mut cdg_state = state
         .playback
         .cdg_state
         .lock()
-        .map_err(|_| anyhow::anyhow!("CDG state lock was poisoned"))?;
+        .map_err(|_| PlaybackError::Internal("CDG state lock was poisoned".to_owned()))?;
     mark_cdg_reset_for_seek(&mut cdg_state, previous_position_ms, snapshot.position_ms);
     drop(cdg_state);
 
-    emit_playback_position(app_handle, &snapshot)?;
+    emit_playback_position(app_handle, &snapshot)
+        .map_err(|e| PlaybackError::Internal(e.to_string()))?;
     Ok(snapshot)
 }
 
-pub fn set_volume(state: &AppState, level: f32) -> Result<PlaybackStateSnapshot> {
+pub fn set_volume(state: &AppState, level: f32) -> Result<PlaybackStateSnapshot, PlaybackError> {
     let mut playback = state
         .playback
         .playback
         .lock()
-        .map_err(|_| anyhow::anyhow!("playback controller lock was poisoned"))?;
-    let snapshot = playback.set_volume(level)?;
+        .map_err(|_| PlaybackError::Internal("playback controller lock was poisoned".to_owned()))?;
+    let snapshot = playback.set_volume(level)
+        .map_err(classify_playback_error)?;
     drop(playback);
     if state.airplay.airplay_audience_active.load(Ordering::SeqCst) {
         state
@@ -268,13 +317,14 @@ pub fn set_stem_volume(
     state: &AppState,
     stem: StemName,
     level: f32,
-) -> Result<PlaybackStateSnapshot> {
+) -> Result<PlaybackStateSnapshot, PlaybackError> {
     let mut playback = state
         .playback
         .playback
         .lock()
-        .map_err(|_| anyhow::anyhow!("playback controller lock was poisoned"))?;
-    let snapshot = playback.set_stem_volume(stem, level)?;
+        .map_err(|_| PlaybackError::Internal("playback controller lock was poisoned".to_owned()))?;
+    let snapshot = playback.set_stem_volume(stem, level)
+        .map_err(classify_playback_error)?;
     drop(playback);
     if state.airplay.airplay_audience_active.load(Ordering::SeqCst) {
         state
@@ -285,21 +335,22 @@ pub fn set_stem_volume(
     Ok(snapshot)
 }
 
-pub fn load_stems(state: &AppState) -> Result<PlaybackStateSnapshot> {
+pub fn load_stems(state: &AppState) -> Result<PlaybackStateSnapshot, PlaybackError> {
     let library_root = state
         .shell
         .library_root()
-        .map_err(|error| anyhow::anyhow!(error.message.clone()))?;
-    let connection = cache::open_database(&library_root.database_path())?;
+        .map_err(|error| PlaybackError::Internal(error.message))?;
+    let connection = cache::open_database(&library_root.database_path())
+        .map_err(|e| PlaybackError::Internal(e.to_string()))?;
     let mut playback = state
         .playback
         .playback
         .lock()
-        .map_err(|_| anyhow::anyhow!("playback controller lock was poisoned"))?;
+        .map_err(|_| PlaybackError::Internal("playback controller lock was poisoned".to_owned()))?;
 
     let song_id = playback
         .current_song_id()
-        .context("no track is loaded")?
+        .ok_or_else(|| PlaybackError::InvalidPlaybackState("no track is loaded".to_owned()))?
         .to_owned();
 
     if playback.has_stems() {
@@ -307,21 +358,22 @@ pub fn load_stems(state: &AppState) -> Result<PlaybackStateSnapshot> {
     }
 
     let song = cache::get_song_by_hash(&connection, &song_id)
-        .context("failed to load song before stem attachment")?
-        .with_context(|| format!("song with hash {song_id} was not found in the library"))?;
+        .map_err(|e| PlaybackError::Internal(e.to_string()))?
+        .ok_or_else(|| PlaybackError::SongNotFound(song_id.clone()))?;
     drop(playback);
 
     decode_then_attach_stems_if_current_song(&state.playback.playback, &song_id, || {
         load_cached_stems_for_song(Some(&state.shell.app_data_dir), &connection, &library_root, &song)
     })
+    .map_err(classify_playback_error)
 }
 
-pub fn get_state(state: &AppState) -> Result<PlaybackStateSnapshot> {
+pub fn get_state(state: &AppState) -> Result<PlaybackStateSnapshot, PlaybackError> {
     let mut playback = state
         .playback
         .playback
         .lock()
-        .map_err(|_| anyhow::anyhow!("playback controller lock was poisoned"))?;
+        .map_err(|_| PlaybackError::Internal("playback controller lock was poisoned".to_owned()))?;
     Ok(playback.snapshot(monotonic_now_ms()))
 }
 
@@ -336,7 +388,7 @@ fn play_remote_background<R: Runtime>(
     playback_arc: &Arc<Mutex<PlaybackController>>,
     request_id: u64,
     request_id_arc: &AtomicU64,
-) -> Result<()> {
+) -> anyhow::Result<()> {
     let connection = cache::open_database(&library_root.database_path())?;
     let PlaybackSourceLoad {
         decoded_audio,
@@ -385,23 +437,25 @@ pub fn play_song_from_library(
     controller: &mut PlaybackController,
     song_id: &str,
     now_ms: u64,
-) -> Result<PlaybackStateSnapshot> {
+) -> Result<PlaybackStateSnapshot, PlaybackError> {
     let song = cache::get_song_by_hash(connection, song_id)
-        .context("failed to load song from library")?
-        .with_context(|| format!("song with hash {song_id} was not found in the library"))?;
+        .map_err(|e| PlaybackError::Internal(e.to_string()))?
+        .ok_or_else(|| PlaybackError::SongNotFound(song_id.to_owned()))?;
     let PlaybackSourceLoad {
         decoded_audio,
         stems,
-    } = load_playback_source(None, connection, library_root, &song)?;
+    } = load_playback_source(None, connection, library_root, &song)
+        .map_err(classify_playback_error)?;
     let snapshot = controller.start_track(song.hash.clone(), decoded_audio, now_ms);
     if let Some(stems) = stems {
-        controller.attach_stems(&song.hash, stems)?;
+        controller.attach_stems(&song.hash, stems)
+            .map_err(classify_playback_error)?;
         return Ok(controller.snapshot(now_ms));
     }
     Ok(snapshot)
 }
 
-pub(crate) fn ensure_output_thread(state: &AppState) -> Result<()> {
+pub(crate) fn ensure_output_thread(state: &AppState) -> Result<(), PlaybackError> {
     ensure_output_thread_inner(
         &state.playback.audio_output_started,
         &state.playback.audio_output_start_lock,
@@ -410,6 +464,7 @@ pub(crate) fn ensure_output_thread(state: &AppState) -> Result<()> {
         state.airplay.airplay_local_output_suppressed.clone(),
         state.shell.shutdown.clone(),
     )
+    .map_err(classify_playback_error)
 }
 
 pub(crate) fn ensure_output_thread_inner(
@@ -419,7 +474,7 @@ pub(crate) fn ensure_output_thread_inner(
     airplay_audio_tap: Arc<crate::airplay_stream::AirPlayAudioTap>,
     airplay_local_output_suppressed: Arc<AtomicBool>,
     shutdown: Arc<AtomicBool>,
-) -> Result<()> {
+) -> anyhow::Result<()> {
     output::ensure_output_thread(
         audio_output_started,
         audio_output_start_lock,
@@ -437,9 +492,9 @@ fn decode_then_start_track_if_latest<F>(
     request_id: u64,
     song_id: String,
     decode_audio: F,
-) -> Result<PlaybackStateSnapshot>
+) -> anyhow::Result<PlaybackStateSnapshot>
 where
-    F: FnOnce() -> Result<decode::DecodedAudio>,
+    F: FnOnce() -> anyhow::Result<decode::DecodedAudio>,
 {
     // Decode before taking the playback lock so expensive file IO does not stall
     // output/control paths, then apply a latest-request-wins guard before swap-in.
@@ -459,9 +514,9 @@ fn decode_then_attach_stems_if_current_song<F>(
     playback: &Arc<Mutex<PlaybackController>>,
     song_id: &str,
     decode_stems: F,
-) -> Result<PlaybackStateSnapshot>
+) -> anyhow::Result<PlaybackStateSnapshot>
 where
-    F: FnOnce() -> Result<LoadedStems>,
+    F: FnOnce() -> anyhow::Result<LoadedStems>,
 {
     let loaded_stems = decode_stems()?;
     let mut playback = playback

--- a/src-tauri/src/services/playback_source.rs
+++ b/src-tauri/src/services/playback_source.rs
@@ -1,6 +1,7 @@
 use crate::{
     audio::{
         decode,
+        error::PlaybackError,
         playback::{LoadedStems, StemSet},
     },
     cache,
@@ -24,11 +25,11 @@ pub(crate) fn probe_song_audio(library_root: &LibraryRoot, song: &Song) -> Resul
     if song.media_g_container.as_deref() == Some(MEDIA_G_ZIP) {
         let asset = media_g::inspect_zip_for_media_g(&absolute_path)?;
         return decode::probe_bytes(asset.audio_bytes, &asset.audio_extension)
-            .with_context(|| format!("failed to probe audio for {}", song_path));
+            .map_err(|e| anyhow::anyhow!("failed to probe audio for {}: {}", song_path, e));
     }
 
     decode::probe_file(&absolute_path)
-        .with_context(|| format!("failed to probe audio for {}", song_path))
+        .map_err(|e| anyhow::anyhow!("failed to probe audio for {}: {}", song_path, e))
 }
 
 pub(crate) fn load_song_audio(
@@ -40,11 +41,11 @@ pub(crate) fn load_song_audio(
     if song.media_g_container.as_deref() == Some(MEDIA_G_ZIP) {
         let asset = media_g::inspect_zip_for_media_g(&absolute_path)?;
         return decode::decode_bytes(asset.audio_bytes, &asset.audio_extension)
-            .with_context(|| format!("failed to decode audio for {}", song_path));
+            .map_err(|e| anyhow::anyhow!("failed to decode audio for {}: {}", song_path, e));
     }
 
     decode::decode_file(&absolute_path)
-        .with_context(|| format!("failed to decode audio for {}", song_path))
+        .map_err(|e| anyhow::anyhow!("failed to decode audio for {}: {}", song_path, e))
 }
 
 pub(crate) fn load_playback_source(
@@ -52,17 +53,20 @@ pub(crate) fn load_playback_source(
     connection: &Connection,
     library_root: &LibraryRoot,
     song: &Song,
-) -> Result<PlaybackSourceLoad> {
+) -> Result<PlaybackSourceLoad, PlaybackError> {
     if song.is_remote_stems() {
-        return load_remote_stems_playback_source(connection, library_root, song);
+        return load_remote_stems_playback_source(connection, library_root, song)
+            .map_err(|e| PlaybackError::Internal(e.to_string()));
     }
 
     if song.is_remote() {
-        ensure_remote_song_files_cached(app_data_dir, song)?;
+        ensure_remote_song_files_cached(app_data_dir, song)
+            .map_err(|e| PlaybackError::Internal(e.to_string()))?;
     }
 
     Ok(PlaybackSourceLoad {
-        decoded_audio: load_song_audio(library_root, song)?,
+        decoded_audio: load_song_audio(library_root, song)
+            .map_err(|e| PlaybackError::AudioDecodeFailed(e.to_string()))?,
         stems: None,
     })
 }
@@ -72,19 +76,22 @@ pub(crate) fn load_cached_stems_for_song(
     connection: &Connection,
     library_root: &LibraryRoot,
     song: &Song,
-) -> Result<LoadedStems> {
+) -> Result<LoadedStems, PlaybackError> {
     if song.is_remote_stems() {
-        ensure_remote_stem_files_cached(app_data_dir, connection, song)?;
-        return load_remote_stems_playback_source(connection, library_root, song)?
+        ensure_remote_stem_files_cached(app_data_dir, connection, song)
+            .map_err(|e| PlaybackError::Internal(e.to_string()))?;
+        return load_remote_stems_playback_source(connection, library_root, song)
+            .map_err(|e| PlaybackError::Internal(e.to_string()))?
             .stems
-            .context("remote stems song did not yield attached stems");
+            .ok_or_else(|| PlaybackError::KaraokeNotReady("remote stems song did not yield attached stems".to_owned()));
     }
 
     let cached = cache::stems::get_cached_stem_entry(connection, &song.hash)
-        .context("failed to load cached stems")?
-        .with_context(|| format!("no cached stems for song {}", song.hash))?;
+        .map_err(|e| PlaybackError::Internal(format!("failed to load cached stems: {e}")))?
+        .ok_or_else(|| PlaybackError::KaraokeNotReady(format!("no cached stems for song {}", song.hash)))?;
 
     decode_stem_entry(library_root, &cached)
+        .map_err(|e| PlaybackError::AudioDecodeFailed(e.to_string()))
 }
 
 pub(crate) fn resolve_song_file_path(song: &Song) -> Result<&str> {
@@ -196,7 +203,7 @@ fn decode_stem_entry(
 ) -> Result<LoadedStems> {
     let load_stem = |path: &str| -> Result<decode::DecodedAudio> {
         let abs = library_root.resolve(path);
-        decode::decode_file(&abs).with_context(|| format!("failed to decode stem {}", path))
+        decode::decode_file(&abs).map_err(|e| anyhow::anyhow!("failed to decode stem {}: {}", path, e))
     };
 
     if cached.has_individual_stems() {

--- a/src-tauri/src/state/shell.rs
+++ b/src-tauri/src/state/shell.rs
@@ -1,5 +1,6 @@
 use crate::commands::bootstrap::{self, ModelBootstrapStatusSnapshot};
-use crate::commands::error::{library_error, state_lock_error, CommandError};
+use crate::commands::error::{state_lock_error, CommandError};
+use crate::library::error::LibraryError;
 use crate::library_root::LibraryRoot;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
@@ -41,7 +42,7 @@ impl AppShell {
             .map_err(|_| state_lock_error("library lock was poisoned"))?;
         guard
             .clone()
-            .ok_or_else(|| library_error("no library configured".to_owned()))
+            .ok_or_else(|| CommandError::from(LibraryError::Internal("no library configured".to_owned())))
     }
 
     /// Resolve the path to the active AI model based on the current config.

--- a/src-tauri/tests/phase3_status.rs
+++ b/src-tauri/tests/phase3_status.rs
@@ -1,4 +1,5 @@
-use openkara_lib::commands::error::{separation_error, ErrorCode, FallbackAction};
+use openkara_lib::commands::error::{CommandError, ErrorCode, FallbackAction};
+use openkara_lib::separator::error::SeparationError;
 use openkara_lib::commands::separation::{
     completed_status, failed_status, idle_status, running_status, SeparationState,
 };
@@ -33,7 +34,7 @@ fn separation_status_helpers_cover_idle_running_completed_and_failed_states() {
         Some("/tmp/accompaniment.ogg")
     );
 
-    let failed = failed_status("song-a", separation_error("boom"));
+    let failed = failed_status("song-a", CommandError::from(SeparationError::Failed("boom".to_owned())));
     assert_eq!(failed.state, SeparationState::Failed);
     let failed_error = failed
         .error

--- a/src-tauri/tests/phase5_errors.rs
+++ b/src-tauri/tests/phase5_errors.rs
@@ -1,10 +1,14 @@
-use openkara_lib::commands::error::{
-    library_error, lyrics_error, playback_error, separation_error, ErrorCode, FallbackAction,
-};
+use openkara_lib::audio::error::PlaybackError;
+use openkara_lib::commands::error::{CommandError, ErrorCode, FallbackAction};
+use openkara_lib::library::error::LibraryError;
+use openkara_lib::lyrics::error::LyricsError;
+use openkara_lib::separator::error::SeparationError;
 
 #[test]
 fn playback_errors_map_decode_failures_to_reimport_song_fallback() {
-    let error = playback_error("failed to decode audio for /tmp/corrupt.mp3");
+    let error = CommandError::from(PlaybackError::AudioDecodeFailed(
+        "failed to decode audio for /tmp/corrupt.mp3".to_owned(),
+    ));
 
     assert_eq!(error.code, ErrorCode::AudioDecodeFailed);
     assert_eq!(error.fallback, FallbackAction::ReimportSong);
@@ -13,7 +17,9 @@ fn playback_errors_map_decode_failures_to_reimport_song_fallback() {
 
 #[test]
 fn playback_errors_map_missing_stems_to_original_mode_fallback() {
-    let error = playback_error("song with hash song-a does not have cached stems");
+    let error = CommandError::from(PlaybackError::KaraokeNotReady(
+        "song with hash song-a does not have cached stems".to_owned(),
+    ));
 
     assert_eq!(error.code, ErrorCode::KaraokeNotReady);
     assert_eq!(error.fallback, FallbackAction::StayInOriginalMode);
@@ -22,7 +28,9 @@ fn playback_errors_map_missing_stems_to_original_mode_fallback() {
 
 #[test]
 fn lyrics_errors_map_missing_cache_to_empty_state_fallback() {
-    let error = lyrics_error("song with hash song-a does not have cached lyrics");
+    let error = CommandError::from(LyricsError::LyricsNotReady(
+        "song with hash song-a does not have cached lyrics".to_owned(),
+    ));
 
     assert_eq!(error.code, ErrorCode::LyricsNotReady);
     assert_eq!(error.fallback, FallbackAction::ShowEmptyState);
@@ -31,7 +39,9 @@ fn lyrics_errors_map_missing_cache_to_empty_state_fallback() {
 
 #[test]
 fn lyrics_errors_map_network_failures_to_retry_fallback() {
-    let error = lyrics_error("failed to request timed lyrics");
+    let error = CommandError::from(LyricsError::NetworkUnavailable(
+        "failed to request timed lyrics".to_owned(),
+    ));
 
     assert_eq!(error.code, ErrorCode::NetworkUnavailable);
     assert_eq!(error.fallback, FallbackAction::Retry);
@@ -40,7 +50,7 @@ fn lyrics_errors_map_network_failures_to_retry_fallback() {
 
 #[test]
 fn separation_errors_map_worker_failures_to_retry_fallback() {
-    let error = separation_error("failed to separate stems for song song-a");
+    let error = CommandError::from(SeparationError::Failed("failed to separate stems for song song-a".to_owned()));
 
     assert_eq!(error.code, ErrorCode::SeparationFailed);
     assert_eq!(error.fallback, FallbackAction::Retry);
@@ -49,7 +59,9 @@ fn separation_errors_map_worker_failures_to_retry_fallback() {
 
 #[test]
 fn library_errors_map_missing_media_to_reimport_fallback() {
-    let error = library_error("failed to open audio file at /tmp/missing.mp3");
+    let error = CommandError::from(LibraryError::MediaReadFailed(
+        "failed to open audio file at /tmp/missing.mp3".to_owned(),
+    ));
 
     assert_eq!(error.code, ErrorCode::MediaReadFailed);
     assert_eq!(error.fallback, FallbackAction::ReimportSong);


### PR DESCRIPTION
## Summary
- Replace fragile `.contains()` string-matching in error classification with typed `From` impls
- Add `thiserror` derive macros for domain error enums (PlaybackError, SeparationError, LibraryError, LyricsError)
- Each domain error converts to `CommandError` via `From` trait — compile-time guaranteed routing

## Test plan
- [ ] `cargo test` passes
- [x] Error variants correctly map to expected `ErrorCode` and `FallbackAction`