### PR TITLE
refactor: add RemoteProvider trait seam for cloud storage dispatch

### DIFF
--- a/src-tauri/src/commands/remote_library/dropbox.rs
+++ b/src-tauri/src/commands/remote_library/dropbox.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use reqwest::{Method, StatusCode, Url};
 use std::{
+    cell::RefCell,
     collections::HashMap,
     fs,
     io::Write,
@@ -856,7 +857,7 @@ pub(crate) fn refresh_existing_dropbox_library(
     Ok(dropbox_metadata_revision(&metadata))
 }
 
-fn dropbox_delete_path(
+pub(crate) fn dropbox_delete_path(
     app_data_dir: &Path,
     secret: &mut DropboxSecret,
     path: &str,
@@ -873,28 +874,106 @@ fn dropbox_delete_path(
     }
 }
 
-pub(crate) fn delete_relative_path_from_remote(
-    app_data_dir: &Path,
-    library: &RegisteredLibrary,
-    relative_path: &str,
-) -> CommandResult<()> {
-    let mut secret = load_dropbox_secret(app_data_dir, library)?;
-    let root_path = library
-        .remote_root_locator()
-        .ok_or_else(|| library_error("remote repository is missing a remote locator".to_owned()))?;
-    dropbox_delete_path(
-        app_data_dir,
-        &mut secret,
-        &dropbox_join_path(root_path, relative_path),
-    )
+// --- RemoteProvider implementation ---
+
+pub(crate) struct DropboxProvider<'a> {
+    app_data_dir: &'a Path,
+    secret: RefCell<DropboxSecret>,
+    library: &'a RegisteredLibrary,
 }
 
-pub(crate) fn delete_remote_root(
-    app_data_dir: &Path,
-    library: &RegisteredLibrary,
-) -> CommandResult<()> {
-    delete_relative_path_from_remote(app_data_dir, library, "")
+impl<'a> DropboxProvider<'a> {
+    pub(crate) fn new(
+        app_data_dir: &'a Path,
+        secret: DropboxSecret,
+        library: &'a RegisteredLibrary,
+    ) -> Self {
+        Self {
+            app_data_dir,
+            secret: RefCell::new(secret),
+            library,
+        }
+    }
 }
+
+impl RemoteProvider for DropboxProvider<'_> {
+    fn get_revision(&self, relative_path: &str) -> CommandResult<Option<String>> {
+        let mut secret = self.secret.borrow_mut();
+        let root_path = self
+            .library
+            .remote_root_locator()
+            .ok_or_else(|| library_error("remote repository is missing a remote locator".to_owned()))?;
+        let remote_path = dropbox_join_path(root_path, relative_path);
+        Ok(dropbox_get_metadata(self.app_data_dir, &mut secret, &remote_path)?
+            .as_ref()
+            .and_then(dropbox_metadata_revision))
+    }
+
+    fn download_file(&self, relative_path: &str, destination: &Path) -> CommandResult<()> {
+        let mut secret = self.secret.borrow_mut();
+        let root_path = self
+            .library
+            .remote_root_locator()
+            .ok_or_else(|| library_error("remote repository is missing a remote locator".to_owned()))?;
+        let remote_path = dropbox_join_path(root_path, relative_path);
+        if dropbox_get_metadata(self.app_data_dir, &mut secret, &remote_path)?.is_none() {
+            return Err(library_error(format!(
+                "remote file {relative_path} was not found"
+            )));
+        }
+        dropbox_download_file(self.app_data_dir, &mut secret, &remote_path, destination)
+    }
+
+    fn upload_file(&self, relative_path: &str) -> CommandResult<()> {
+        let secret = self.secret.borrow();
+        let root_path = self
+            .library
+            .remote_root_locator()
+            .ok_or_else(|| library_error("remote repository is missing a remote locator".to_owned()))?;
+        dropbox_upload_relative_file_to_remote(
+            self.app_data_dir,
+            self.library,
+            &secret,
+            relative_path,
+            root_path,
+        )
+    }
+
+    fn upload_directory(&self, relative_path: &str) -> CommandResult<()> {
+        let secret = self.secret.borrow();
+        let root_path = self
+            .library
+            .remote_root_locator()
+            .ok_or_else(|| library_error("remote repository is missing a remote locator".to_owned()))?;
+        dropbox_upload_directory_to_remote(
+            self.app_data_dir,
+            self.library,
+            &secret,
+            relative_path,
+            root_path,
+        )
+    }
+
+    fn delete_path(&self, relative_path: &str) -> CommandResult<()> {
+        let mut secret = self.secret.borrow_mut();
+        let root_path = self
+            .library
+            .remote_root_locator()
+            .ok_or_else(|| library_error("remote repository is missing a remote locator".to_owned()))?;
+        dropbox_delete_path(
+            self.app_data_dir,
+            &mut secret,
+            &dropbox_join_path(root_path, relative_path),
+        )
+    }
+
+    fn initialize_or_sync(&self) -> CommandResult<Option<String>> {
+        let secret = self.secret.borrow();
+        initialize_or_sync_dropbox_library(self.app_data_dir, self.library, &secret)
+    }
+}
+
+use super::provider::RemoteProvider;
 
 #[cfg(test)]
 mod tests {

--- a/src-tauri/src/commands/remote_library/google_drive.rs
+++ b/src-tauri/src/commands/remote_library/google_drive.rs
@@ -1085,6 +1085,9 @@ impl RemoteProvider for GoogleDriveProvider<'_> {
             .library
             .remote_root_locator()
             .ok_or_else(|| library_error("remote repository is missing a remote locator".to_owned()))?;
+        if relative_path.is_empty() {
+            return google_drive_delete_entry(self.app_data_dir, &mut secret, root_folder_id);
+        }
         let Some(entry) =
             google_drive_find_relative_entry(self.app_data_dir, &mut secret, root_folder_id, relative_path)?
         else {

--- a/src-tauri/src/commands/remote_library/google_drive.rs
+++ b/src-tauri/src/commands/remote_library/google_drive.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use reqwest::{blocking::Client, Method, Url};
 use std::{
+    cell::RefCell,
     collections::HashMap,
     fs,
     io::Write,
@@ -981,7 +982,7 @@ pub(crate) fn refresh_existing_google_drive_library(
         .or(database_entry.modified_time))
 }
 
-fn google_drive_delete_entry(
+pub(crate) fn google_drive_delete_entry(
     app_data_dir: &Path,
     secret: &mut GoogleDriveSecret,
     file_id: &str,
@@ -997,33 +998,108 @@ fn google_drive_delete_entry(
     }
 }
 
-pub(crate) fn delete_relative_path_from_remote(
-    app_data_dir: &Path,
-    library: &RegisteredLibrary,
-    relative_path: &str,
-) -> CommandResult<()> {
-    let mut secret = load_google_drive_secret(app_data_dir, library)?;
-    let root_folder_id = library
-        .remote_root_locator()
-        .ok_or_else(|| library_error("remote repository is missing a remote locator".to_owned()))?;
-    let Some(entry) =
-        google_drive_find_relative_entry(app_data_dir, &mut secret, root_folder_id, relative_path)?
-    else {
-        return Ok(());
-    };
-    google_drive_delete_entry(app_data_dir, &mut secret, &entry.id)
+// --- RemoteProvider implementation ---
+
+pub(crate) struct GoogleDriveProvider<'a> {
+    app_data_dir: &'a Path,
+    secret: RefCell<GoogleDriveSecret>,
+    library: &'a RegisteredLibrary,
 }
 
-pub(crate) fn delete_remote_root(
-    app_data_dir: &Path,
-    library: &RegisteredLibrary,
-) -> CommandResult<()> {
-    let mut secret = load_google_drive_secret(app_data_dir, library)?;
-    let root_folder_id = library
-        .remote_root_locator()
-        .ok_or_else(|| library_error("remote repository is missing a remote locator".to_owned()))?;
-    google_drive_delete_entry(app_data_dir, &mut secret, root_folder_id)
+impl<'a> GoogleDriveProvider<'a> {
+    pub(crate) fn new(
+        app_data_dir: &'a Path,
+        secret: GoogleDriveSecret,
+        library: &'a RegisteredLibrary,
+    ) -> Self {
+        Self {
+            app_data_dir,
+            secret: RefCell::new(secret),
+            library,
+        }
+    }
 }
+
+impl RemoteProvider for GoogleDriveProvider<'_> {
+    fn get_revision(&self, relative_path: &str) -> CommandResult<Option<String>> {
+        let mut secret = self.secret.borrow_mut();
+        let root_folder_id = self
+            .library
+            .remote_root_locator()
+            .ok_or_else(|| library_error("remote repository is missing a remote locator".to_owned()))?;
+        Ok(
+            google_drive_find_relative_entry(self.app_data_dir, &mut secret, root_folder_id, relative_path)?
+                .and_then(|metadata| metadata.head_revision_id.or(metadata.modified_time)),
+        )
+    }
+
+    fn download_file(&self, relative_path: &str, destination: &Path) -> CommandResult<()> {
+        let mut secret = self.secret.borrow_mut();
+        let root_folder_id = self
+            .library
+            .remote_root_locator()
+            .ok_or_else(|| library_error("remote repository is missing a remote locator".to_owned()))?;
+        let entry = google_drive_find_relative_entry(
+            self.app_data_dir,
+            &mut secret,
+            root_folder_id,
+            relative_path,
+        )?
+        .ok_or_else(|| library_error(format!("remote file {relative_path} was not found")))?;
+        google_drive_download_file(self.app_data_dir, &mut secret, &entry.id, destination)
+    }
+
+    fn upload_file(&self, relative_path: &str) -> CommandResult<()> {
+        let secret = self.secret.borrow();
+        let root_folder_id = self
+            .library
+            .remote_root_locator()
+            .ok_or_else(|| library_error("remote repository is missing a remote locator".to_owned()))?;
+        google_drive_upload_relative_file_to_remote(
+            self.app_data_dir,
+            self.library,
+            &secret,
+            relative_path,
+            root_folder_id,
+        )
+    }
+
+    fn upload_directory(&self, relative_path: &str) -> CommandResult<()> {
+        let secret = self.secret.borrow();
+        let root_folder_id = self
+            .library
+            .remote_root_locator()
+            .ok_or_else(|| library_error("remote repository is missing a remote locator".to_owned()))?;
+        google_drive_upload_directory_to_remote(
+            self.app_data_dir,
+            self.library,
+            &secret,
+            relative_path,
+            root_folder_id,
+        )
+    }
+
+    fn delete_path(&self, relative_path: &str) -> CommandResult<()> {
+        let mut secret = self.secret.borrow_mut();
+        let root_folder_id = self
+            .library
+            .remote_root_locator()
+            .ok_or_else(|| library_error("remote repository is missing a remote locator".to_owned()))?;
+        let Some(entry) =
+            google_drive_find_relative_entry(self.app_data_dir, &mut secret, root_folder_id, relative_path)?
+        else {
+            return Ok(());
+        };
+        google_drive_delete_entry(self.app_data_dir, &mut secret, &entry.id)
+    }
+
+    fn initialize_or_sync(&self) -> CommandResult<Option<String>> {
+        let secret = self.secret.borrow();
+        initialize_or_sync_google_drive_library(self.app_data_dir, self.library, &secret)
+    }
+}
+
+use super::provider::RemoteProvider;
 
 #[cfg(test)]
 mod tests {

--- a/src-tauri/src/commands/remote_library/mod.rs
+++ b/src-tauri/src/commands/remote_library/mod.rs
@@ -2,6 +2,7 @@ mod auth;
 mod dropbox;
 mod google_drive;
 mod mutation;
+pub(crate) mod provider;
 mod registry;
 mod sync;
 mod types;
@@ -195,14 +196,6 @@ pub(crate) fn delete_remote_library_root(
     app_data_dir: &std::path::Path,
     library: &RegisteredLibrary,
 ) -> CommandResult<()> {
-    match library.provider() {
-        Some(RemoteLibraryProvider::GoogleDrive) => {
-            google_drive::delete_remote_root(app_data_dir, library)
-        }
-        Some(RemoteLibraryProvider::Dropbox) => dropbox::delete_remote_root(app_data_dir, library),
-        Some(RemoteLibraryProvider::WebDav) => webdav::delete_remote_root(app_data_dir, library),
-        None => Err(library_error(
-            "the target library must be remote".to_owned(),
-        )),
-    }
+    let provider = provider::create_provider(app_data_dir, library)?;
+    provider.delete_path("")
 }

--- a/src-tauri/src/commands/remote_library/provider.rs
+++ b/src-tauri/src/commands/remote_library/provider.rs
@@ -1,0 +1,67 @@
+use crate::commands::error::CommandResult;
+use crate::config::RegisteredLibrary;
+use std::path::Path;
+
+/// Unified interface for remote storage providers (Google Drive, Dropbox, WebDAV).
+///
+/// Each provider implementation holds its loaded secret internally and handles
+/// token refresh transparently (for OAuth-based providers).
+pub(crate) trait RemoteProvider {
+    /// Get the revision/etag for a relative path, or `None` if it doesn't exist.
+    fn get_revision(&self, relative_path: &str) -> CommandResult<Option<String>>;
+
+    /// Download a remote file to a local destination path.
+    fn download_file(&self, relative_path: &str, destination: &Path) -> CommandResult<()>;
+
+    /// Upload a local file (from the library's working copy) to the remote.
+    fn upload_file(&self, relative_path: &str) -> CommandResult<()>;
+
+    /// Upload a local directory (from the library's working copy) to the remote.
+    fn upload_directory(&self, relative_path: &str) -> CommandResult<()>;
+
+    /// Delete a remote path.
+    fn delete_path(&self, relative_path: &str) -> CommandResult<()>;
+
+    /// Initialize or sync the library (ensure folders exist, download DB if needed).
+    fn initialize_or_sync(&self) -> CommandResult<Option<String>>;
+}
+
+/// Create a `RemoteProvider` implementation for the given library.
+///
+/// Loads the provider's stored secret and constructs the appropriate provider struct.
+pub(crate) fn create_provider<'a>(
+    app_data_dir: &'a Path,
+    library: &'a RegisteredLibrary,
+) -> CommandResult<Box<dyn RemoteProvider + 'a>> {
+    use super::dropbox;
+    use super::google_drive;
+    use super::webdav;
+    use crate::commands::error::library_error;
+    use crate::config::RemoteLibraryProvider;
+
+    match library.provider() {
+        Some(RemoteLibraryProvider::WebDav) => {
+            let secret = webdav::load_webdav_secret(app_data_dir, library)?;
+            Ok(Box::new(webdav::WebDAVProvider::new(secret, library)))
+        }
+        Some(RemoteLibraryProvider::GoogleDrive) => {
+            let secret = google_drive::load_google_drive_secret(app_data_dir, library)?;
+            Ok(Box::new(google_drive::GoogleDriveProvider::new(
+                app_data_dir,
+                secret,
+                library,
+            )))
+        }
+        Some(RemoteLibraryProvider::Dropbox) => {
+            let secret = dropbox::load_dropbox_secret(app_data_dir, library)?;
+            Ok(Box::new(dropbox::DropboxProvider::new(
+                app_data_dir,
+                secret,
+                library,
+            )))
+        }
+        None => Err(library_error(
+            "the target library is not a remote library".to_owned(),
+        )),
+    }
+}

--- a/src-tauri/src/commands/remote_library/provider.rs
+++ b/src-tauri/src/commands/remote_library/provider.rs
@@ -42,7 +42,11 @@ pub(crate) fn create_provider<'a>(
     match library.provider() {
         Some(RemoteLibraryProvider::WebDav) => {
             let secret = webdav::load_webdav_secret(app_data_dir, library)?;
-            Ok(Box::new(webdav::WebDAVProvider::new(secret, library)))
+            Ok(Box::new(webdav::WebDAVProvider::new(
+                app_data_dir,
+                secret,
+                library,
+            )))
         }
         Some(RemoteLibraryProvider::GoogleDrive) => {
             let secret = google_drive::load_google_drive_secret(app_data_dir, library)?;

--- a/src-tauri/src/commands/remote_library/sync.rs
+++ b/src-tauri/src/commands/remote_library/sync.rs
@@ -3,7 +3,7 @@ use crate::{
     commands::error::{
         database_error, library_error, state_lock_error, CommandError, CommandResult,
     },
-    config::{AppConfig, RegisteredLibrary, RemoteLibraryProvider},
+    config::{AppConfig, RegisteredLibrary},
     library::Song,
     library_root::LibraryRoot,
     AppState,
@@ -12,28 +12,11 @@ use std::{collections::HashMap, fs, path::Path};
 use tauri::{AppHandle, Emitter};
 
 use super::{
-    dropbox::{
-        delete_relative_path_from_remote as dropbox_delete_relative_path_from_remote,
-        dropbox_download_file, dropbox_get_metadata, dropbox_join_path, dropbox_metadata_revision,
-        dropbox_upload_directory_to_remote, dropbox_upload_relative_file_to_remote,
-        initialize_or_sync_dropbox_library, load_dropbox_secret,
-    },
-    google_drive::{
-        delete_relative_path_from_remote as google_drive_delete_relative_path_from_remote,
-        google_drive_download_file, google_drive_find_relative_entry,
-        google_drive_upload_directory_to_remote, google_drive_upload_relative_file_to_remote,
-        initialize_or_sync_google_drive_library, load_google_drive_secret,
-    },
+    provider::create_provider,
     types::{
         current_unix_time_ms, load_app_config, load_remote_root, persist_app_config,
         upsert_stem_entry, UploadCompletePayload, UploadErrorPayload, UploadProgressPayload,
         UploadState, UploadStatusSnapshot,
-    },
-    webdav::{
-        delete_relative_path_from_remote as webdav_delete_relative_path_from_remote,
-        download_webdav_file, initialize_or_sync_webdav_library, join_url, load_webdav_secret,
-        upload_directory_to_remote, upload_relative_file_to_remote, webdav_client,
-        webdav_database_url, webdav_get_etag,
     },
 };
 
@@ -219,45 +202,8 @@ fn remote_database_revision(
     app_data_dir: &Path,
     library: &RegisteredLibrary,
 ) -> CommandResult<Option<String>> {
-    match library.provider() {
-        Some(RemoteLibraryProvider::WebDav) => {
-            let secret = load_webdav_secret(app_data_dir, library)?;
-            webdav_get_etag(
-                &webdav_client()?,
-                &webdav_database_url(&secret.root_url)?,
-                &secret.username,
-                &secret.password,
-            )
-        }
-        Some(RemoteLibraryProvider::GoogleDrive) => {
-            let mut secret = load_google_drive_secret(app_data_dir, library)?;
-            let root_folder_id = library.remote_root_locator().ok_or_else(|| {
-                library_error("remote repository is missing a remote locator".to_owned())
-            })?;
-            Ok(google_drive_find_relative_entry(
-                app_data_dir,
-                &mut secret,
-                root_folder_id,
-                "openkara.db",
-            )?
-            .and_then(|metadata| metadata.head_revision_id.or(metadata.modified_time)))
-        }
-        Some(RemoteLibraryProvider::Dropbox) => {
-            let mut secret = load_dropbox_secret(app_data_dir, library)?;
-            let root_path = library.remote_root_locator().ok_or_else(|| {
-                library_error("remote repository is missing a remote locator".to_owned())
-            })?;
-            Ok(dropbox_get_metadata(
-                app_data_dir,
-                &mut secret,
-                &dropbox_join_path(root_path, "openkara.db"),
-            )?
-            .and_then(|metadata| dropbox_metadata_revision(&metadata)))
-        }
-        _ => Err(library_error(
-            "the active remote provider is not supported for database revision checks".to_owned(),
-        )),
-    }
+    let provider = create_provider(app_data_dir, library)?;
+    provider.get_revision("openkara.db")
 }
 
 fn remote_database_revision_is_stale(
@@ -283,25 +229,8 @@ fn sync_remote_database_from_provider(
     app_data_dir: &Path,
     library: &RegisteredLibrary,
 ) -> CommandResult<RegisteredLibrary> {
-    let revision = match library.provider() {
-        Some(RemoteLibraryProvider::WebDav) => {
-            let secret = load_webdav_secret(app_data_dir, library)?;
-            initialize_or_sync_webdav_library(app_data_dir, library, &secret)?
-        }
-        Some(RemoteLibraryProvider::GoogleDrive) => {
-            let secret = load_google_drive_secret(app_data_dir, library)?;
-            initialize_or_sync_google_drive_library(app_data_dir, library, &secret)?
-        }
-        Some(RemoteLibraryProvider::Dropbox) => {
-            let secret = load_dropbox_secret(app_data_dir, library)?;
-            initialize_or_sync_dropbox_library(app_data_dir, library, &secret)?
-        }
-        None => {
-            return Err(library_error(
-                "the active remote provider is not supported for sync".to_owned(),
-            ));
-        }
-    };
+    let provider = create_provider(app_data_dir, library)?;
+    let revision = provider.initialize_or_sync()?;
     update_remote_revision_in_config(app_data_dir, library.id(), revision)?;
     load_registered_remote_library(app_data_dir, library.id())
 }
@@ -331,80 +260,10 @@ fn ensure_remote_database_upload_safe(
 fn upload_remote_database(app_data_dir: &Path, library: &RegisteredLibrary) -> CommandResult<()> {
     ensure_remote_database_upload_safe(app_data_dir, library)?;
 
-    match library.provider() {
-        Some(RemoteLibraryProvider::WebDav) => {
-            let secret = load_webdav_secret(app_data_dir, library)?;
-            upload_relative_file_to_remote(library, &secret, "openkara.db")?;
-            update_remote_revision_in_config(
-                app_data_dir,
-                library.id(),
-                webdav_get_etag(
-                    &webdav_client()?,
-                    &webdav_database_url(&secret.root_url)?,
-                    &secret.username,
-                    &secret.password,
-                )?,
-            )
-        }
-        Some(RemoteLibraryProvider::GoogleDrive) => {
-            let secret = load_google_drive_secret(app_data_dir, library)?;
-            let root_folder_id = library.remote_root_locator().ok_or_else(|| {
-                library_error("remote repository is missing a remote locator".to_owned())
-            })?;
-            google_drive_upload_relative_file_to_remote(
-                app_data_dir,
-                library,
-                &secret,
-                "openkara.db",
-                root_folder_id,
-            )?;
-            let mut refreshed_secret = load_google_drive_secret(app_data_dir, library)?;
-            let metadata = google_drive_find_relative_entry(
-                app_data_dir,
-                &mut refreshed_secret,
-                root_folder_id,
-                "openkara.db",
-            )?
-            .ok_or_else(|| {
-                library_error("Google Drive database file is missing after upload".to_owned())
-            })?;
-            update_remote_revision_in_config(
-                app_data_dir,
-                library.id(),
-                metadata.head_revision_id.or(metadata.modified_time),
-            )
-        }
-        Some(RemoteLibraryProvider::Dropbox) => {
-            let secret = load_dropbox_secret(app_data_dir, library)?;
-            let root_path = library.remote_root_locator().ok_or_else(|| {
-                library_error("remote repository is missing a remote locator".to_owned())
-            })?;
-            dropbox_upload_relative_file_to_remote(
-                app_data_dir,
-                library,
-                &secret,
-                "openkara.db",
-                root_path,
-            )?;
-            let mut refreshed_secret = load_dropbox_secret(app_data_dir, library)?;
-            let metadata = dropbox_get_metadata(
-                app_data_dir,
-                &mut refreshed_secret,
-                &dropbox_join_path(root_path, "openkara.db"),
-            )?
-            .ok_or_else(|| {
-                library_error("Dropbox database file is missing after upload".to_owned())
-            })?;
-            update_remote_revision_in_config(
-                app_data_dir,
-                library.id(),
-                dropbox_metadata_revision(&metadata),
-            )
-        }
-        _ => Err(library_error(
-            "the active remote provider is not supported for database upload".to_owned(),
-        )),
-    }
+    let provider = create_provider(app_data_dir, library)?;
+    provider.upload_file("openkara.db")?;
+    let new_revision = provider.get_revision("openkara.db")?;
+    update_remote_revision_in_config(app_data_dir, library.id(), new_revision)
 }
 
 fn active_remote_library(app_data_dir: &Path) -> CommandResult<Option<RegisteredLibrary>> {
@@ -443,52 +302,8 @@ pub fn ensure_remote_file_cached(app_data_dir: &Path, relative_path: &str) -> Co
         return Ok(());
     }
 
-    match library.provider() {
-        Some(RemoteLibraryProvider::WebDav) => {
-            let secret = load_webdav_secret(app_data_dir, &library)?;
-            let client = webdav_client()?;
-            let file_url = join_url(&secret.root_url, relative_path)?;
-            download_webdav_file(
-                &client,
-                &file_url,
-                &destination,
-                &secret.username,
-                &secret.password,
-            )?
-            .ok_or_else(|| library_error(format!("remote file {relative_path} was not found")))?;
-            Ok(())
-        }
-        Some(RemoteLibraryProvider::GoogleDrive) => {
-            let mut secret = load_google_drive_secret(app_data_dir, &library)?;
-            let root_folder_id = library.remote_root_locator().ok_or_else(|| {
-                library_error("remote repository is missing a remote locator".to_owned())
-            })?;
-            let entry = google_drive_find_relative_entry(
-                app_data_dir,
-                &mut secret,
-                root_folder_id,
-                relative_path,
-            )?
-            .ok_or_else(|| library_error(format!("remote file {relative_path} was not found")))?;
-            google_drive_download_file(app_data_dir, &mut secret, &entry.id, &destination)
-        }
-        Some(RemoteLibraryProvider::Dropbox) => {
-            let mut secret = load_dropbox_secret(app_data_dir, &library)?;
-            let root_path = library.remote_root_locator().ok_or_else(|| {
-                library_error("remote repository is missing a remote locator".to_owned())
-            })?;
-            let remote_path = dropbox_join_path(root_path, relative_path);
-            if dropbox_get_metadata(app_data_dir, &mut secret, &remote_path)?.is_none() {
-                return Err(library_error(format!(
-                    "remote file {relative_path} was not found"
-                )));
-            }
-            dropbox_download_file(app_data_dir, &mut secret, &remote_path, &destination)
-        }
-        _ => Err(library_error(
-            "the active remote provider is not supported for file caching".to_owned(),
-        )),
-    }
+    let provider = create_provider(app_data_dir, &library)?;
+    provider.download_file(relative_path, &destination)
 }
 
 fn resolve_active_remote(config: &AppConfig) -> Option<RegisteredLibrary> {
@@ -503,21 +318,8 @@ fn remote_delete_relative_path(
     library: &RegisteredLibrary,
     relative_path: &str,
 ) -> CommandResult<()> {
-    match library.provider() {
-        Some(RemoteLibraryProvider::WebDav) => {
-            let secret = load_webdav_secret(app_data_dir, library)?;
-            webdav_delete_relative_path_from_remote(&secret, relative_path)
-        }
-        Some(RemoteLibraryProvider::GoogleDrive) => {
-            google_drive_delete_relative_path_from_remote(app_data_dir, library, relative_path)
-        }
-        Some(RemoteLibraryProvider::Dropbox) => {
-            dropbox_delete_relative_path_from_remote(app_data_dir, library, relative_path)
-        }
-        None => Err(library_error(
-            "the bound remote provider is not supported for deletion".to_owned(),
-        )),
-    }
+    let provider = create_provider(app_data_dir, library)?;
+    provider.delete_path(relative_path)
 }
 
 fn song_ready_for_remote_publish(
@@ -830,6 +632,8 @@ fn publish_song_internal<R: tauri::Runtime>(
     )?;
     emit_upload_progress(app_handle, &running);
 
+    let provider = create_provider(&state.shell.app_data_dir, &remote_library)?;
+
     let publish_result = if song.is_separable() {
         let stem_entry = cache::stems::get_cached_stem_entry(&local_connection, song_id)
             .map_err(|error| database_error(error.to_string()))?
@@ -846,47 +650,7 @@ fn publish_song_internal<R: tauri::Runtime>(
         upsert_stem_entry(&remote_connection, &stem_entry)?;
 
         update_remote_song(&remote_connection, song.clone(), "stems_remote")?;
-        match remote_library.provider() {
-            Some(RemoteLibraryProvider::WebDav) => {
-                let remote_secret = load_webdav_secret(&state.shell.app_data_dir, &remote_library)?;
-                upload_directory_to_remote(
-                    &remote_library,
-                    &remote_secret,
-                    &format!("stems/{song_id}"),
-                )?;
-            }
-            Some(RemoteLibraryProvider::GoogleDrive) => {
-                let remote_secret = load_google_drive_secret(&state.shell.app_data_dir, &remote_library)?;
-                let root_folder_id = remote_library.remote_root_locator().ok_or_else(|| {
-                    library_error("remote repository is missing a remote locator".to_owned())
-                })?;
-                google_drive_upload_directory_to_remote(
-                    &state.shell.app_data_dir,
-                    &remote_library,
-                    &remote_secret,
-                    &format!("stems/{song_id}"),
-                    root_folder_id,
-                )?;
-            }
-            Some(RemoteLibraryProvider::Dropbox) => {
-                let remote_secret = load_dropbox_secret(&state.shell.app_data_dir, &remote_library)?;
-                let root_path = remote_library.remote_root_locator().ok_or_else(|| {
-                    library_error("remote repository is missing a remote locator".to_owned())
-                })?;
-                dropbox_upload_directory_to_remote(
-                    &state.shell.app_data_dir,
-                    &remote_library,
-                    &remote_secret,
-                    &format!("stems/{song_id}"),
-                    root_path,
-                )?;
-            }
-            _ => {
-                return Err(library_error(
-                    "the bound remote provider is not supported for publishing".to_owned(),
-                ));
-            }
-        }
+        provider.upload_directory(&format!("stems/{song_id}"))?;
         sync_song_lyrics_to_remote(&local_connection, &remote_connection, song_id)?;
         Ok::<_, CommandError>(())
     } else {
@@ -894,87 +658,13 @@ fn publish_song_internal<R: tauri::Runtime>(
             if !same_root {
                 copy_remote_song_assets(&local_root, &remote_root, file_path, file_path)?;
             }
-            match remote_library.provider() {
-                Some(RemoteLibraryProvider::WebDav) => {
-                    let remote_secret = load_webdav_secret(&state.shell.app_data_dir, &remote_library)?;
-                    upload_relative_file_to_remote(&remote_library, &remote_secret, file_path)?;
-                }
-                Some(RemoteLibraryProvider::GoogleDrive) => {
-                    let remote_secret =
-                        load_google_drive_secret(&state.shell.app_data_dir, &remote_library)?;
-                    let root_folder_id = remote_library.remote_root_locator().ok_or_else(|| {
-                        library_error("remote repository is missing a remote locator".to_owned())
-                    })?;
-                    google_drive_upload_relative_file_to_remote(
-                        &state.shell.app_data_dir,
-                        &remote_library,
-                        &remote_secret,
-                        file_path,
-                        root_folder_id,
-                    )?;
-                }
-                Some(RemoteLibraryProvider::Dropbox) => {
-                    let remote_secret = load_dropbox_secret(&state.shell.app_data_dir, &remote_library)?;
-                    let root_path = remote_library.remote_root_locator().ok_or_else(|| {
-                        library_error("remote repository is missing a remote locator".to_owned())
-                    })?;
-                    dropbox_upload_relative_file_to_remote(
-                        &state.shell.app_data_dir,
-                        &remote_library,
-                        &remote_secret,
-                        file_path,
-                        root_path,
-                    )?;
-                }
-                _ => {
-                    return Err(library_error(
-                        "the bound remote provider is not supported for publishing".to_owned(),
-                    ));
-                }
-            }
+            provider.upload_file(file_path)?;
         }
         if let Some(cdg_path) = song.cdg_path.as_deref() {
             if !same_root {
                 copy_remote_song_assets(&local_root, &remote_root, cdg_path, cdg_path)?;
             }
-            match remote_library.provider() {
-                Some(RemoteLibraryProvider::WebDav) => {
-                    let remote_secret = load_webdav_secret(&state.shell.app_data_dir, &remote_library)?;
-                    upload_relative_file_to_remote(&remote_library, &remote_secret, cdg_path)?;
-                }
-                Some(RemoteLibraryProvider::GoogleDrive) => {
-                    let remote_secret =
-                        load_google_drive_secret(&state.shell.app_data_dir, &remote_library)?;
-                    let root_folder_id = remote_library.remote_root_locator().ok_or_else(|| {
-                        library_error("remote repository is missing a remote locator".to_owned())
-                    })?;
-                    google_drive_upload_relative_file_to_remote(
-                        &state.shell.app_data_dir,
-                        &remote_library,
-                        &remote_secret,
-                        cdg_path,
-                        root_folder_id,
-                    )?;
-                }
-                Some(RemoteLibraryProvider::Dropbox) => {
-                    let remote_secret = load_dropbox_secret(&state.shell.app_data_dir, &remote_library)?;
-                    let root_path = remote_library.remote_root_locator().ok_or_else(|| {
-                        library_error("remote repository is missing a remote locator".to_owned())
-                    })?;
-                    dropbox_upload_relative_file_to_remote(
-                        &state.shell.app_data_dir,
-                        &remote_library,
-                        &remote_secret,
-                        cdg_path,
-                        root_path,
-                    )?;
-                }
-                _ => {
-                    return Err(library_error(
-                        "the bound remote provider is not supported for publishing".to_owned(),
-                    ));
-                }
-            }
+            provider.upload_file(cdg_path)?;
         }
 
         delete_remote_stem_cache_if_present(&remote_connection, &remote_root, song_id)?;

--- a/src-tauri/src/commands/remote_library/sync.rs
+++ b/src-tauri/src/commands/remote_library/sync.rs
@@ -262,8 +262,10 @@ fn upload_remote_database(app_data_dir: &Path, library: &RegisteredLibrary) -> C
 
     let provider = create_provider(app_data_dir, library)?;
     provider.upload_file("openkara.db")?;
-    let new_revision = provider.get_revision("openkara.db")?;
-    update_remote_revision_in_config(app_data_dir, library.id(), new_revision)
+    let new_revision = provider
+        .get_revision("openkara.db")?
+        .ok_or_else(|| library_error("database file is missing after upload"))?;
+    update_remote_revision_in_config(app_data_dir, library.id(), Some(new_revision))
 }
 
 fn active_remote_library(app_data_dir: &Path) -> CommandResult<Option<RegisteredLibrary>> {

--- a/src-tauri/src/commands/remote_library/sync.rs
+++ b/src-tauri/src/commands/remote_library/sync.rs
@@ -262,10 +262,20 @@ fn upload_remote_database(app_data_dir: &Path, library: &RegisteredLibrary) -> C
 
     let provider = create_provider(app_data_dir, library)?;
     provider.upload_file("openkara.db")?;
-    let new_revision = provider
-        .get_revision("openkara.db")?
-        .ok_or_else(|| library_error("database file is missing after upload"))?;
-    update_remote_revision_in_config(app_data_dir, library.id(), Some(new_revision))
+    let new_revision = provider.get_revision("openkara.db")?;
+    // WebDAV servers that don't return an ETag yield Ok(None) here; that is
+    // acceptable — we persist None as the revision rather than failing a
+    // successful upload.
+    if new_revision.is_none()
+        && matches!(
+            library.provider(),
+            Some(crate::config::RemoteLibraryProvider::GoogleDrive)
+                | Some(crate::config::RemoteLibraryProvider::Dropbox)
+        )
+    {
+        return Err(library_error("database file is missing after upload"));
+    }
+    update_remote_revision_in_config(app_data_dir, library.id(), new_revision)
 }
 
 fn active_remote_library(app_data_dir: &Path) -> CommandResult<Option<RegisteredLibrary>> {

--- a/src-tauri/src/commands/remote_library/sync.rs
+++ b/src-tauri/src/commands/remote_library/sync.rs
@@ -273,7 +273,14 @@ fn upload_remote_database(app_data_dir: &Path, library: &RegisteredLibrary) -> C
                 | Some(crate::config::RemoteLibraryProvider::Dropbox)
         )
     {
-        return Err(library_error("database file is missing after upload"));
+        return Err(library_error(format!(
+            "{} database file is missing after upload",
+            match library.provider() {
+                Some(crate::config::RemoteLibraryProvider::GoogleDrive) => "Google Drive",
+                Some(crate::config::RemoteLibraryProvider::Dropbox) => "Dropbox",
+                _ => "Remote",
+            }
+        )));
     }
     update_remote_revision_in_config(app_data_dir, library.id(), new_revision)
 }

--- a/src-tauri/src/commands/remote_library/webdav.rs
+++ b/src-tauri/src/commands/remote_library/webdav.rs
@@ -558,13 +558,22 @@ pub(crate) fn delete_relative_path_from_remote(
 // --- RemoteProvider implementation ---
 
 pub(crate) struct WebDAVProvider<'a> {
+    app_data_dir: &'a Path,
     secret: WebDavSecret,
     library: &'a RegisteredLibrary,
 }
 
 impl<'a> WebDAVProvider<'a> {
-    pub(crate) fn new(secret: WebDavSecret, library: &'a RegisteredLibrary) -> Self {
-        Self { secret, library }
+    pub(crate) fn new(
+        app_data_dir: &'a Path,
+        secret: WebDavSecret,
+        library: &'a RegisteredLibrary,
+    ) -> Self {
+        Self {
+            app_data_dir,
+            secret,
+            library,
+        }
     }
 }
 
@@ -596,7 +605,7 @@ impl RemoteProvider for WebDAVProvider<'_> {
     }
 
     fn initialize_or_sync(&self) -> CommandResult<Option<String>> {
-        initialize_or_sync_webdav_library(Path::new("/"), self.library, &self.secret)
+        initialize_or_sync_webdav_library(self.app_data_dir, self.library, &self.secret)
     }
 }
 

--- a/src-tauri/src/commands/remote_library/webdav.rs
+++ b/src-tauri/src/commands/remote_library/webdav.rs
@@ -578,9 +578,9 @@ impl RemoteProvider for WebDAVProvider<'_> {
     fn download_file(&self, relative_path: &str, destination: &Path) -> CommandResult<()> {
         let client = webdav_client()?;
         let url = join_url(&self.secret.root_url, relative_path)?;
-        download_webdav_file(&client, &url, destination, &self.secret.username, &self.secret.password)
-            .and_then(|opt| opt.ok_or_else(|| library_error(format!("remote file not found: {relative_path}"))))
-            .map(|_| ())
+        download_webdav_file(&client, &url, destination, &self.secret.username, &self.secret.password)?
+            .ok_or_else(|| library_error(format!("remote file {relative_path} was not found")))?;
+        Ok(())
     }
 
     fn upload_file(&self, relative_path: &str) -> CommandResult<()> {

--- a/src-tauri/src/commands/remote_library/webdav.rs
+++ b/src-tauri/src/commands/remote_library/webdav.rs
@@ -578,8 +578,9 @@ impl RemoteProvider for WebDAVProvider<'_> {
     fn download_file(&self, relative_path: &str, destination: &Path) -> CommandResult<()> {
         let client = webdav_client()?;
         let url = join_url(&self.secret.root_url, relative_path)?;
-        download_webdav_file(&client, &url, destination, &self.secret.username, &self.secret.password)?;
-        Ok(())
+        download_webdav_file(&client, &url, destination, &self.secret.username, &self.secret.password)
+            .and_then(|opt| opt.ok_or_else(|| library_error(format!("remote file not found: {relative_path}"))))
+            .map(|_| ())
     }
 
     fn upload_file(&self, relative_path: &str) -> CommandResult<()> {

--- a/src-tauri/src/commands/remote_library/webdav.rs
+++ b/src-tauri/src/commands/remote_library/webdav.rs
@@ -555,13 +555,51 @@ pub(crate) fn delete_relative_path_from_remote(
     }
 }
 
-pub(crate) fn delete_remote_root(
-    app_data_dir: &Path,
-    library: &RegisteredLibrary,
-) -> CommandResult<()> {
-    let secret = load_webdav_secret(app_data_dir, library)?;
-    delete_relative_path_from_remote(&secret, "")
+// --- RemoteProvider implementation ---
+
+pub(crate) struct WebDAVProvider<'a> {
+    secret: WebDavSecret,
+    library: &'a RegisteredLibrary,
 }
+
+impl<'a> WebDAVProvider<'a> {
+    pub(crate) fn new(secret: WebDavSecret, library: &'a RegisteredLibrary) -> Self {
+        Self { secret, library }
+    }
+}
+
+impl RemoteProvider for WebDAVProvider<'_> {
+    fn get_revision(&self, relative_path: &str) -> CommandResult<Option<String>> {
+        let client = webdav_client()?;
+        let url = join_url(&self.secret.root_url, relative_path)?;
+        webdav_get_etag(&client, &url, &self.secret.username, &self.secret.password)
+    }
+
+    fn download_file(&self, relative_path: &str, destination: &Path) -> CommandResult<()> {
+        let client = webdav_client()?;
+        let url = join_url(&self.secret.root_url, relative_path)?;
+        download_webdav_file(&client, &url, destination, &self.secret.username, &self.secret.password)?;
+        Ok(())
+    }
+
+    fn upload_file(&self, relative_path: &str) -> CommandResult<()> {
+        upload_relative_file_to_remote(self.library, &self.secret, relative_path)
+    }
+
+    fn upload_directory(&self, relative_path: &str) -> CommandResult<()> {
+        upload_directory_to_remote(self.library, &self.secret, relative_path)
+    }
+
+    fn delete_path(&self, relative_path: &str) -> CommandResult<()> {
+        delete_relative_path_from_remote(&self.secret, relative_path)
+    }
+
+    fn initialize_or_sync(&self) -> CommandResult<Option<String>> {
+        initialize_or_sync_webdav_library(Path::new("/"), self.library, &self.secret)
+    }
+}
+
+use super::provider::RemoteProvider;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary
- Define `RemoteProvider` trait with 6 file-operation methods (get_revision, download_file, upload_file, upload_directory, delete_path, initialize_or_sync)
- Add provider structs (WebDAVProvider, GoogleDriveProvider, DropboxProvider) that hold loaded secrets internally
- GoogleDrive/Dropbox use `RefCell` interior mutability for transparent token refresh
- Add `create_provider()` factory to construct providers from library config
- Replace 8 match blocks in sync.rs + mod.rs with polymorphic trait calls

## What stays as match blocks
- 10 match blocks in registry.rs remain — they interleave provider-specific secret construction from OAuth session data with lifecycle operations, which doesn't fit the file-operations trait

## Test plan
- [x] `cargo test` — 252 tests pass
- [x] `pnpm test` — 369 frontend tests pass
- [x] Upload/download/delete operations work for all 3 providers