### PR TITLE
refactor: extract useEventSubscriptions factory hook

### DIFF
--- a/src/hooks/use-event-subscription.ts
+++ b/src/hooks/use-event-subscription.ts
@@ -1,0 +1,57 @@
+import { useEffect } from "react";
+import { listen } from "@tauri-apps/api/event";
+
+interface EventSubscription {
+  event: string;
+  handler: (payload: unknown) => void;
+}
+
+/**
+ * Subscribe to multiple Tauri events with a single useEffect.
+ *
+ * Handles the common pattern of:
+ * - async listener setup with cancellation race protection
+ * - collecting unlisten callbacks
+ * - cleanup on unmount or dependency change
+ *
+ * Optional `onCleanup` runs before unlisteners are called (for clearing
+ * scheduled timers, etc.).
+ */
+export function useEventSubscriptions(
+  subscriptions: EventSubscription[],
+  enabled: boolean,
+  onCleanup?: () => void,
+  deps: unknown[] = [],
+): void {
+  useEffect(() => {
+    if (!enabled) return;
+
+    let cancelled = false;
+    const unlisteners: (() => void)[] = [];
+
+    const setup = async () => {
+      for (const sub of subscriptions) {
+        const unlisten = await listen(sub.event, (e) => {
+          if (!cancelled) sub.handler(e.payload);
+        });
+        if (cancelled) {
+          unlisten();
+        } else {
+          unlisteners.push(unlisten);
+        }
+      }
+    };
+
+    void setup();
+
+    return () => {
+      cancelled = true;
+      onCleanup?.();
+      unlisteners.forEach((fn) => fn());
+    };
+    // subscriptions and onCleanup are intentionally excluded — subscriptions is
+    // a new array each render and onCleanup should be stable. The deps parameter
+    // gives callers explicit control over when to re-subscribe.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, ...deps]);
+}

--- a/src/hooks/use-event-subscription.ts
+++ b/src/hooks/use-event-subscription.ts
@@ -21,7 +21,7 @@ export function useEventSubscriptions(
   subscriptions: EventSubscription[],
   enabled: boolean,
   onCleanup?: () => void,
-  deps: unknown[] = [],
+  deps: React.DependencyList = [],
 ): void {
   useEffect(() => {
     if (!enabled) return;
@@ -50,8 +50,9 @@ export function useEventSubscriptions(
       unlisteners.forEach((fn) => fn());
     };
     // subscriptions and onCleanup are intentionally excluded — subscriptions is
-    // a new array each render and onCleanup should be stable. The deps parameter
-    // gives callers explicit control over when to re-subscribe.
+    // a new array each render and onCleanup identity may change without requiring
+    // re-subscription (callers reach side-effects through stable refs). The deps
+    // parameter gives callers explicit control over when to re-subscribe.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled, ...deps]);
 }

--- a/src/hooks/use-playback-runtime.ts
+++ b/src/hooks/use-playback-runtime.ts
@@ -213,8 +213,10 @@ function useBatchSeparationEvents(enabled: boolean) {
     createBatchSeparationClearScheduler(clearBatchSeparation),
   );
 
-  // Recreate scheduler if the clear function changes
+  // Recreate scheduler if the clear function changes — drain the old one first
+  // so any pending timer invokes the stale closure.
   useEffect(() => {
+    clearSchedulerRef.current.clearAll();
     clearSchedulerRef.current =
       createBatchSeparationClearScheduler(clearBatchSeparation);
   }, [clearBatchSeparation]);
@@ -254,8 +256,10 @@ function useUploadEvents(enabled: boolean) {
     createStatusClearScheduler<string>(clearUploadStatus),
   );
 
-  // Recreate scheduler if the clear function changes
+  // Recreate scheduler if the clear function changes — drain the old one first
+  // so any pending timer invokes the stale closure.
   useEffect(() => {
+    clearSchedulerRef.current.clearAll();
     clearSchedulerRef.current =
       createStatusClearScheduler<string>(clearUploadStatus);
   }, [clearUploadStatus]);

--- a/src/hooks/use-playback-runtime.ts
+++ b/src/hooks/use-playback-runtime.ts
@@ -213,6 +213,12 @@ function useBatchSeparationEvents(enabled: boolean) {
     createBatchSeparationClearScheduler(clearBatchSeparation),
   );
 
+  // Recreate scheduler if the clear function changes
+  useEffect(() => {
+    clearSchedulerRef.current =
+      createBatchSeparationClearScheduler(clearBatchSeparation);
+  }, [clearBatchSeparation]);
+
   useEventSubscriptions(
     [
       {
@@ -247,6 +253,12 @@ function useUploadEvents(enabled: boolean) {
   const clearSchedulerRef = useRef(
     createStatusClearScheduler<string>(clearUploadStatus),
   );
+
+  // Recreate scheduler if the clear function changes
+  useEffect(() => {
+    clearSchedulerRef.current =
+      createStatusClearScheduler<string>(clearUploadStatus);
+  }, [clearUploadStatus]);
 
   useEventSubscriptions(
     [

--- a/src/hooks/use-playback-runtime.ts
+++ b/src/hooks/use-playback-runtime.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { listen } from "@tauri-apps/api/event";
+import { useEventSubscriptions } from "./use-event-subscription";
 import { usePlayerStore } from "@/stores/player-store";
 import { useLibraryStore } from "@/stores/library-store";
 import { useLyricsStore } from "@/stores/lyrics-store";
@@ -165,199 +166,120 @@ function useSeparationEvents(enabled: boolean) {
 function useBootstrapEvents(enabled: boolean) {
   const updateBootstrapStatus = useBootstrapStore((s) => s.updateStatus);
 
-  useEffect(() => {
-    if (!enabled) {
-      return;
-    }
-
-    const unlisteners: (() => void)[] = [];
-    let cancelled = false;
-
-    const setup = async () => {
-      const progressUnlisten = await listen<ModelBootstrapStatusSnapshot>(
-        "model-bootstrap-progress",
-        (e) => {
-          if (!cancelled) updateBootstrapStatus(e.payload);
-        },
-      );
-      const readyUnlisten = await listen<ModelBootstrapStatusSnapshot>(
-        "model-bootstrap-ready",
-        (e) => {
-          if (!cancelled) updateBootstrapStatus(e.payload);
-        },
-      );
-      const errorUnlisten = await listen<ModelBootstrapStatusSnapshot>(
-        "model-bootstrap-error",
-        (e) => {
-          if (!cancelled) updateBootstrapStatus(e.payload);
-        },
-      );
-
-      if (cancelled) {
-        progressUnlisten();
-        readyUnlisten();
-        errorUnlisten();
-      } else {
-        unlisteners.push(progressUnlisten, readyUnlisten, errorUnlisten);
-      }
-    };
-
-    void setup();
-
-    return () => {
-      cancelled = true;
-      unlisteners.forEach((fn) => fn());
-    };
-  }, [enabled, updateBootstrapStatus]);
+  useEventSubscriptions(
+    [
+      {
+        event: "model-bootstrap-progress",
+        handler: (payload) =>
+          updateBootstrapStatus(payload as ModelBootstrapStatusSnapshot),
+      },
+      {
+        event: "model-bootstrap-ready",
+        handler: (payload) =>
+          updateBootstrapStatus(payload as ModelBootstrapStatusSnapshot),
+      },
+      {
+        event: "model-bootstrap-error",
+        handler: (payload) =>
+          updateBootstrapStatus(payload as ModelBootstrapStatusSnapshot),
+      },
+    ],
+    enabled,
+    undefined,
+    [updateBootstrapStatus],
+  );
 }
 
 function usePlaybackEndedQueueAdvance(enabled: boolean) {
-  useEffect(() => {
-    if (!enabled) {
-      return;
-    }
-
-    let cancelled = false;
-    let unlisten: (() => void) | null = null;
-
-    const setup = async () => {
-      unlisten = await listen<PlaybackEndedEvent>("playback-ended", (e) => {
-        if (!cancelled) {
-          usePlayerStore.getState().playNextFromQueue(e.payload.song_id);
-        }
-      });
-    };
-
-    void setup();
-
-    return () => {
-      cancelled = true;
-      unlisten?.();
-    };
-  }, [enabled]);
+  useEventSubscriptions(
+    [
+      {
+        event: "playback-ended",
+        handler: (payload) => {
+          usePlayerStore
+            .getState()
+            .playNextFromQueue((payload as PlaybackEndedEvent).song_id);
+        },
+      },
+    ],
+    enabled,
+  );
 }
 
 function useBatchSeparationEvents(enabled: boolean) {
   const updateBatchProgress = useLibraryStore((s) => s.updateBatchProgress);
   const clearBatchSeparation = useLibraryStore((s) => s.clearBatchSeparation);
+  const clearSchedulerRef = useRef(
+    createBatchSeparationClearScheduler(clearBatchSeparation),
+  );
 
-  useEffect(() => {
-    if (!enabled) {
-      return;
-    }
-
-    const unlisteners: (() => void)[] = [];
-    let cancelled = false;
-    const clearScheduler =
-      createBatchSeparationClearScheduler(clearBatchSeparation);
-
-    const setup = async () => {
-      const progressUnlisten = await listen<BatchSeparationProgress>(
-        "batch-separation-progress",
-        (e) => {
-          if (!cancelled) updateBatchProgress(e.payload);
+  useEventSubscriptions(
+    [
+      {
+        event: "batch-separation-progress",
+        handler: (payload) =>
+          updateBatchProgress(payload as BatchSeparationProgress),
+      },
+      {
+        event: "batch-separation-complete",
+        handler: (payload) => {
+          updateBatchProgress(payload as BatchSeparationProgress);
+          clearSchedulerRef.current.scheduleAfterTerminalProgress();
         },
-      );
-      const completeUnlisten = await listen<BatchSeparationProgress>(
-        "batch-separation-complete",
-        (e) => {
-          if (!cancelled) {
-            updateBatchProgress(e.payload);
-            clearScheduler.scheduleAfterTerminalProgress();
-          }
+      },
+      {
+        event: "batch-separation-cancelled",
+        handler: (payload) => {
+          updateBatchProgress(payload as BatchSeparationProgress);
+          clearSchedulerRef.current.scheduleAfterTerminalProgress();
         },
-      );
-      const cancelledUnlisten = await listen<BatchSeparationProgress>(
-        "batch-separation-cancelled",
-        (e) => {
-          if (!cancelled) {
-            updateBatchProgress(e.payload);
-            clearScheduler.scheduleAfterTerminalProgress();
-          }
-        },
-      );
-
-      if (cancelled) {
-        progressUnlisten();
-        completeUnlisten();
-        cancelledUnlisten();
-      } else {
-        unlisteners.push(progressUnlisten, completeUnlisten, cancelledUnlisten);
-      }
-    };
-
-    void setup();
-
-    return () => {
-      cancelled = true;
-      clearScheduler.clearAll();
-      unlisteners.forEach((fn) => fn());
-    };
-  }, [enabled, clearBatchSeparation, updateBatchProgress]);
+      },
+    ],
+    enabled,
+    () => clearSchedulerRef.current.clearAll(),
+    [updateBatchProgress],
+  );
 }
 
 function useUploadEvents(enabled: boolean) {
   const updateUploadStatus = useLibraryStore((s) => s.updateUploadStatus);
   const clearUploadStatus = useLibraryStore((s) => s.clearUploadStatus);
+  const clearSchedulerRef = useRef(
+    createStatusClearScheduler<string>(clearUploadStatus),
+  );
 
-  useEffect(() => {
-    if (!enabled) {
-      return;
-    }
-
-    const unlisteners: (() => void)[] = [];
-    let cancelled = false;
-    const clearScheduler =
-      createStatusClearScheduler<string>(clearUploadStatus);
-
-    const setup = async () => {
-      const progressUnlisten = await listen<UploadProgressEvent>(
-        "upload-progress",
-        (e) => {
-          if (cancelled) return;
-          const songId = e.payload.song_id;
-          clearScheduler.cancel(songId);
-          updateUploadStatus(uploadProgressStatus(e.payload));
+  useEventSubscriptions(
+    [
+      {
+        event: "upload-progress",
+        handler: (payload) => {
+          const event = payload as UploadProgressEvent;
+          clearSchedulerRef.current.cancel(event.song_id);
+          updateUploadStatus(uploadProgressStatus(event));
         },
-      );
-
-      const completeUnlisten = await listen<UploadCompleteEvent>(
-        "upload-complete",
-        (e) => {
-          if (cancelled) return;
-          const songId = e.payload.song_id;
-          updateUploadStatus(uploadCompleteStatus(e.payload));
-          clearScheduler.schedule(songId);
+      },
+      {
+        event: "upload-complete",
+        handler: (payload) => {
+          const event = payload as UploadCompleteEvent;
+          updateUploadStatus(uploadCompleteStatus(event));
+          clearSchedulerRef.current.schedule(event.song_id);
         },
-      );
-
-      const errorUnlisten = await listen<UploadErrorEvent>(
-        "upload-error",
-        (e) => {
-          if (cancelled) return;
-          clearScheduler.cancel(e.payload.song_id);
-          updateUploadStatus(uploadErrorStatus(e.payload));
-          notifyError(e.payload.error);
+      },
+      {
+        event: "upload-error",
+        handler: (payload) => {
+          const event = payload as UploadErrorEvent;
+          clearSchedulerRef.current.cancel(event.song_id);
+          updateUploadStatus(uploadErrorStatus(event));
+          notifyError(event.error);
         },
-      );
-
-      if (cancelled) {
-        progressUnlisten();
-        completeUnlisten();
-        errorUnlisten();
-      } else {
-        unlisteners.push(progressUnlisten, completeUnlisten, errorUnlisten);
-      }
-    };
-
-    void setup();
-
-    return () => {
-      cancelled = true;
-      clearScheduler.clearAll();
-      unlisteners.forEach((fn) => fn());
-    };
-  }, [clearUploadStatus, enabled, updateUploadStatus]);
+      },
+    ],
+    enabled,
+    () => clearSchedulerRef.current.clearAll(),
+    [updateUploadStatus],
+  );
 }
 
 export function useEventListeners(enabled = true) {


### PR DESCRIPTION
## Summary
- Create `useEventSubscriptions` generic factory for Tauri event subscription boilerplate
- Handles: async listener setup, cancellation race protection, unlisten cleanup
- Supports optional `onCleanup` callback for scheduler cleanup
- Migrate 4 hooks: usePlaybackEndedQueueAdvance, useBootstrapEvents, useBatchSeparationEvents, useUploadEvents
- Leave 2 hooks unchanged: useSeparationEvents (has currentSongIdRef), usePlaybackPositionSubscription (typed generic)

## Net effect
- 152 lines added (factory + migration), 173 lines removed (replaced boilerplate)
- 4 hooks now share the same setup/cleanup pattern via the factory

## Test plan
- [x] `pnpm test` — 369 tests pass
- [x] `pnpm lint` — no issues