### PR TITLE
fix(ui): style desktop scrollbars for dark shell on Windows/Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Security
 
-- Bump direct `quick-xml` to 0.41 and document a scoped `cargo-deny` ignore for the residual Tauri/plist 0.39.x chain (RUSTSEC-2026-0195).
+- Bump direct `quick-xml` to 0.41 and document scoped `cargo-deny` ignores for the residual Tauri/plist 0.39.x chain (RUSTSEC-2026-0194/0195).
+- Bump `anyhow` to 1.0.103 (RUSTSEC-2026-0190).
 
 ## [0.9.0] - 2026-06-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Style Windows and Linux scrollbars to match the dark desktop shell instead of showing light WebView2/WebKitGTK tracks ([#51](https://github.com/thedavidweng/OpenKara/issues/51)).
+
 ## [0.9.0] - 2026-06-14
 
 ### 📝 Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Style Windows and Linux scrollbars to match the dark desktop shell instead of showing light WebView2/WebKitGTK tracks ([#51](https://github.com/thedavidweng/OpenKara/issues/51)).
 
+### Security
+
+- Bump direct `quick-xml` to 0.41 and document a scoped `cargo-deny` ignore for the residual Tauri/plist 0.39.x chain (RUSTSEC-2026-0195).
+
 ## [0.9.0] - 2026-06-14
 
 ### 📝 Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- Style Windows and Linux scrollbars to match the dark desktop shell instead of showing light WebView2/WebKitGTK tracks ([#51](https://github.com/thedavidweng/OpenKara/issues/51)).
+- Style Windows and Linux scrollbars to match the dark desktop shell instead of showing light WebView2/WebKitGTK tracks ([#51](https://github.com/thedavidweng/OpenKara/issues/51)): Windows uses Tauri `scrollBarStyle: fluentOverlay` (WebView2 overlay scrollbars) plus scoped dark `scrollbar-*` / `::-webkit-scrollbar` CSS; Linux keeps CSS-only styling.
 
 ### Security
 

--- a/packaging/flatpak/generated/cargo-sources.json
+++ b/packaging/flatpak/generated/cargo-sources.json
@@ -1445,6 +1445,19 @@
   {
     "type": "archive",
     "archive-type": "tar-gzip",
+    "url": "https://static.crates.io/crates/filetime/filetime-0.2.29.crate",
+    "sha256": "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759",
+    "dest": "cargo/vendor/filetime-0.2.29"
+  },
+  {
+    "type": "inline",
+    "contents": "{\"package\": \"5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759\", \"files\": {}}",
+    "dest": "cargo/vendor/filetime-0.2.29",
+    "dest-filename": ".cargo-checksum.json"
+  },
+  {
+    "type": "archive",
+    "archive-type": "tar-gzip",
     "url": "https://static.crates.io/crates/find-msvc-tools/find-msvc-tools-0.1.9.crate",
     "sha256": "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582",
     "dest": "cargo/vendor/find-msvc-tools-0.1.9"
@@ -3954,14 +3967,27 @@
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/quick-xml/quick-xml-0.39.2.crate",
-    "sha256": "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d",
-    "dest": "cargo/vendor/quick-xml-0.39.2"
+    "url": "https://static.crates.io/crates/quick-xml/quick-xml-0.39.4.crate",
+    "sha256": "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e",
+    "dest": "cargo/vendor/quick-xml-0.39.4"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d\", \"files\": {}}",
-    "dest": "cargo/vendor/quick-xml-0.39.2",
+    "contents": "{\"package\": \"cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e\", \"files\": {}}",
+    "dest": "cargo/vendor/quick-xml-0.39.4",
+    "dest-filename": ".cargo-checksum.json"
+  },
+  {
+    "type": "archive",
+    "archive-type": "tar-gzip",
+    "url": "https://static.crates.io/crates/quick-xml/quick-xml-0.41.0.crate",
+    "sha256": "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1",
+    "dest": "cargo/vendor/quick-xml-0.41.0"
+  },
+  {
+    "type": "inline",
+    "contents": "{\"package\": \"e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1\", \"files\": {}}",
+    "dest": "cargo/vendor/quick-xml-0.41.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
@@ -4227,6 +4253,19 @@
   {
     "type": "archive",
     "archive-type": "tar-gzip",
+    "url": "https://static.crates.io/crates/regex-lite/regex-lite-0.1.9.crate",
+    "sha256": "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973",
+    "dest": "cargo/vendor/regex-lite-0.1.9"
+  },
+  {
+    "type": "inline",
+    "contents": "{\"package\": \"cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973\", \"files\": {}}",
+    "dest": "cargo/vendor/regex-lite-0.1.9",
+    "dest-filename": ".cargo-checksum.json"
+  },
+  {
+    "type": "archive",
+    "archive-type": "tar-gzip",
     "url": "https://static.crates.io/crates/regex-syntax/regex-syntax-0.8.10.crate",
     "sha256": "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a",
     "dest": "cargo/vendor/regex-syntax-0.8.10"
@@ -4274,6 +4313,19 @@
     "type": "inline",
     "contents": "{\"package\": \"a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7\", \"files\": {}}",
     "dest": "cargo/vendor/ring-0.17.14",
+    "dest-filename": ".cargo-checksum.json"
+  },
+  {
+    "type": "archive",
+    "archive-type": "tar-gzip",
+    "url": "https://static.crates.io/crates/ringbuf/ringbuf-0.4.8.crate",
+    "sha256": "fe47b720588c8702e34b5979cb3271a8b1842c7cb6f57408efa70c779363488c",
+    "dest": "cargo/vendor/ringbuf-0.4.8"
+  },
+  {
+    "type": "inline",
+    "contents": "{\"package\": \"fe47b720588c8702e34b5979cb3271a8b1842c7cb6f57408efa70c779363488c\", \"files\": {}}",
+    "dest": "cargo/vendor/ringbuf-0.4.8",
     "dest-filename": ".cargo-checksum.json"
   },
   {
@@ -5353,6 +5405,19 @@
     "type": "inline",
     "contents": "{\"package\": \"f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd\", \"files\": {}}",
     "dest": "cargo/vendor/tao-macros-0.1.3",
+    "dest-filename": ".cargo-checksum.json"
+  },
+  {
+    "type": "archive",
+    "archive-type": "tar-gzip",
+    "url": "https://static.crates.io/crates/tar/tar-0.4.46.crate",
+    "sha256": "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840",
+    "dest": "cargo/vendor/tar-0.4.46"
+  },
+  {
+    "type": "inline",
+    "contents": "{\"package\": \"3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840\", \"files\": {}}",
+    "dest": "cargo/vendor/tar-0.4.46",
     "dest-filename": ".cargo-checksum.json"
   },
   {
@@ -7555,6 +7620,19 @@
   {
     "type": "archive",
     "archive-type": "tar-gzip",
+    "url": "https://static.crates.io/crates/xattr/xattr-1.6.1.crate",
+    "sha256": "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156",
+    "dest": "cargo/vendor/xattr-1.6.1"
+  },
+  {
+    "type": "inline",
+    "contents": "{\"package\": \"32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156\", \"files\": {}}",
+    "dest": "cargo/vendor/xattr-1.6.1",
+    "dest-filename": ".cargo-checksum.json"
+  },
+  {
+    "type": "archive",
+    "archive-type": "tar-gzip",
     "url": "https://static.crates.io/crates/yoke/yoke-0.8.2.crate",
     "sha256": "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca",
     "dest": "cargo/vendor/yoke-0.8.2"
@@ -7739,96 +7817,5 @@
     "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n",
     "dest": "cargo",
     "dest-filename": "config"
-  },
-  {
-    "type": "archive",
-    "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/ringbuf/ringbuf-0.4.8.crate",
-    "sha256": "fe47b720588c8702e34b5979cb3271a8b1842c7cb6f57408efa70c779363488c",
-    "dest": "cargo/vendor/ringbuf-0.4.8"
-  },
-  {
-    "type": "inline",
-    "contents": "{\"package\":\"fe47b720588c8702e34b5979cb3271a8b1842c7cb6f57408efa70c779363488c\",\"files\":{}}",
-    "dest": "cargo/vendor/ringbuf-0.4.8",
-    "dest-filename": ".cargo-checksum.json"
-  },
-  {
-    "type": "archive",
-    "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/filetime/filetime-0.2.29.crate",
-    "sha256": "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759",
-    "dest": "cargo/vendor/filetime-0.2.29"
-  },
-  {
-    "type": "inline",
-    "contents": "{\"package\": \"5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759\", \"files\": {}}",
-    "dest": "cargo/vendor/filetime-0.2.29",
-    "dest-filename": ".cargo-checksum.json"
-  },
-  {
-    "type": "archive",
-    "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/tar/tar-0.4.46.crate",
-    "sha256": "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840",
-    "dest": "cargo/vendor/tar-0.4.46"
-  },
-  {
-    "type": "inline",
-    "contents": "{\"package\": \"3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840\", \"files\": {}}",
-    "dest": "cargo/vendor/tar-0.4.46",
-    "dest-filename": ".cargo-checksum.json"
-  },
-  {
-    "type": "archive",
-    "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/miniz_oxide/miniz_oxide-0.8.9.crate",
-    "sha256": "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316",
-    "dest": "cargo/vendor/miniz_oxide-0.8.9"
-  },
-  {
-    "type": "inline",
-    "contents": "{\"package\": \"1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316\", \"files\": {}}",
-    "dest": "cargo/vendor/miniz_oxide-0.8.9",
-    "dest-filename": ".cargo-checksum.json"
-  },
-  {
-    "type": "archive",
-    "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/crc32fast/crc32fast-1.5.0.crate",
-    "sha256": "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511",
-    "dest": "cargo/vendor/crc32fast-1.5.0"
-  },
-  {
-    "type": "inline",
-    "contents": "{\"package\": \"9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511\", \"files\": {}}",
-    "dest": "cargo/vendor/crc32fast-1.5.0",
-    "dest-filename": ".cargo-checksum.json"
-  },
-  {
-    "type": "archive",
-    "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/regex-lite/regex-lite-0.1.9.crate",
-    "sha256": "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973",
-    "dest": "cargo/vendor/regex-lite-0.1.9"
-  },
-  {
-    "type": "inline",
-    "contents": "{\"package\": \"cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973\", \"files\": {}}",
-    "dest": "cargo/vendor/regex-lite-0.1.9",
-    "dest-filename": ".cargo-checksum.json"
-  },
-  {
-    "type": "archive",
-    "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/xattr/xattr-1.6.1.crate",
-    "sha256": "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156",
-    "dest": "cargo/vendor/xattr-1.6.1"
-  },
-  {
-    "type": "inline",
-    "contents": "{\"package\": \"32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156\", \"files\": {}}",
-    "dest": "cargo/vendor/xattr-1.6.1",
-    "dest-filename": ".cargo-checksum.json"
   }
 ]

--- a/packaging/flatpak/generated/cargo-sources.json
+++ b/packaging/flatpak/generated/cargo-sources.json
@@ -93,14 +93,14 @@
   {
     "type": "archive",
     "archive-type": "tar-gzip",
-    "url": "https://static.crates.io/crates/anyhow/anyhow-1.0.102.crate",
-    "sha256": "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c",
-    "dest": "cargo/vendor/anyhow-1.0.102"
+    "url": "https://static.crates.io/crates/anyhow/anyhow-1.0.103.crate",
+    "sha256": "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3",
+    "dest": "cargo/vendor/anyhow-1.0.103"
   },
   {
     "type": "inline",
-    "contents": "{\"package\": \"7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c\", \"files\": {}}",
-    "dest": "cargo/vendor/anyhow-1.0.102",
+    "contents": "{\"package\": \"2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3\", \"files\": {}}",
+    "dest": "cargo/vendor/anyhow-1.0.103",
     "dest-filename": ".cargo-checksum.json"
   },
   {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2747,7 +2747,7 @@ dependencies = [
  "mockito",
  "open",
  "ort",
- "quick-xml",
+ "quick-xml 0.41.0",
  "rand 0.10.1",
  "regex-lite",
  "reqwest",
@@ -2941,7 +2941,7 @@ checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.39.4",
  "serde",
  "time",
 ]
@@ -3100,9 +3100,18 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -65,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "aotuv_lancer_vorbis_sys"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,7 +23,7 @@ cc = "1.2.61"
 tauri-build = { version = "2.6.0", features = [] }
 
 [dependencies]
-anyhow = "1.0.102"
+anyhow = "1.0.103"
 thiserror = "2"
 audioadapter-buffers = "3.0.0"
 base64 = "0.22.1"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,7 +48,7 @@ tiny_http = "0.12.0"
 tracing = "0.1"
 vorbis_rs = "0.5.5"
 zip = { version = "8.6.0", default-features = false, features = ["deflate"] }
-quick-xml = "0.39"
+quick-xml = "0.41"
 regex-lite = "0.1"
 flate2 = "1"
 tar = "0.4"

--- a/src-tauri/deny.toml
+++ b/src-tauri/deny.toml
@@ -1,6 +1,11 @@
 [advisories]
 unmaintained = "workspace"
 yanked = "warn"
+ignore = [
+    # Transitive via tauri/plist (^0.39). OpenKara's TTML parser uses quick-xml 0.41;
+    # plist parsing uses Reader on trusted Apple plist XML, not NsReader on untrusted input.
+    { id = "RUSTSEC-2026-0195", reason = "Residual quick-xml 0.39.x from tauri/plist until upstream bumps; direct openkara dep is 0.41." },
+]
 
 [licenses]
 version = 2

--- a/src-tauri/deny.toml
+++ b/src-tauri/deny.toml
@@ -4,6 +4,7 @@ yanked = "warn"
 ignore = [
     # Transitive via tauri/plist (^0.39). OpenKara's TTML parser uses quick-xml 0.41;
     # plist parsing uses Reader on trusted Apple plist XML, not NsReader on untrusted input.
+    { id = "RUSTSEC-2026-0194", reason = "Residual quick-xml 0.39.x from tauri/plist until upstream bumps; direct openkara dep is 0.41." },
     { id = "RUSTSEC-2026-0195", reason = "Residual quick-xml 0.39.x from tauri/plist until upstream bumps; direct openkara dep is 0.41." },
 ]
 

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -10,7 +10,8 @@
         "height": 800,
         "resizable": true,
         "decorations": false,
-        "shadow": true
+        "shadow": true,
+        "scrollBarStyle": "fluentOverlay"
       }
     ]
   }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -94,7 +94,7 @@
     --panel-blur: 12px;
     /* WebView2 / WebKitGTK default to light classic scrollbars; align with dark chrome. */
     --scrollbar-thumb: var(--color-border-light);
-    --scrollbar-thumb-hover: var(--color-active);
+    --scrollbar-thumb-hover: var(--color-text-dimmer);
     --scrollbar-track: transparent;
     color-scheme: dark;
   }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -92,6 +92,41 @@
     --color-control-primary-foreground: #17191d;
     --color-ghost-hover: rgba(255, 255, 255, 0.06);
     --panel-blur: 12px;
+    /* WebView2 / WebKitGTK default to light classic scrollbars; align with dark chrome. */
+    color-scheme: dark;
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-border-light) transparent;
+  }
+
+  [data-window-chrome-platform="desktop"] ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+
+  [data-window-chrome-platform="desktop"] ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  [data-window-chrome-platform="desktop"] ::-webkit-scrollbar-thumb {
+    background-color: var(--color-border-light);
+    border: 2px solid transparent;
+    border-radius: 9999px;
+    background-clip: padding-box;
+  }
+
+  [data-window-chrome-platform="desktop"] ::-webkit-scrollbar-thumb:hover {
+    background-color: var(--color-active);
+  }
+
+  [data-window-chrome-platform="desktop"] ::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+
+  /* Windows classic scrollbar arrows clash with the dark shell — hide them. */
+  [data-window-chrome-platform="desktop"] ::-webkit-scrollbar-button {
+    display: none;
+    height: 0;
+    width: 0;
   }
 
   [data-window-shell-tier="mac"] {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -99,9 +99,12 @@
     color-scheme: dark;
   }
 
-  /* Standard scrollbar props (WebView2 121+, Firefox). CSS layers on native appearance. */
+  /* Standard scrollbar props (WebView2 121+, Firefox). CSS layers on native appearance.
+     scrollbar-width/color do not inherit, and AppLayout is overflow-hidden — lists and
+     panels scroll on nested overflow-y-auto nodes, so descendants must set these too. */
   @supports (scrollbar-width: thin) {
-    [data-window-chrome-platform="desktop"] {
+    [data-window-chrome-platform="desktop"],
+    [data-window-chrome-platform="desktop"] * {
       scrollbar-width: thin;
       scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
     }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -93,40 +93,52 @@
     --color-ghost-hover: rgba(255, 255, 255, 0.06);
     --panel-blur: 12px;
     /* WebView2 / WebKitGTK default to light classic scrollbars; align with dark chrome. */
+    --scrollbar-thumb: var(--color-border-light);
+    --scrollbar-thumb-hover: var(--color-active);
+    --scrollbar-track: transparent;
     color-scheme: dark;
-    scrollbar-width: thin;
-    scrollbar-color: var(--color-border-light) transparent;
   }
 
-  [data-window-chrome-platform="desktop"] ::-webkit-scrollbar {
-    width: 10px;
-    height: 10px;
+  /* Standard scrollbar props (WebView2 121+, Firefox). CSS layers on native appearance. */
+  @supports (scrollbar-width: thin) {
+    [data-window-chrome-platform="desktop"] {
+      scrollbar-width: thin;
+      scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+    }
   }
 
-  [data-window-chrome-platform="desktop"] ::-webkit-scrollbar-track {
-    background: transparent;
-  }
+  /* WebKit fallback for engines without scrollbar-color (older WebView2, WebKitGTK). */
+  @supports not (scrollbar-color: auto) {
+    [data-window-chrome-platform="desktop"] ::-webkit-scrollbar {
+      width: 10px;
+      height: 10px;
+    }
 
-  [data-window-chrome-platform="desktop"] ::-webkit-scrollbar-thumb {
-    background-color: var(--color-border-light);
-    border: 2px solid transparent;
-    border-radius: 9999px;
-    background-clip: padding-box;
-  }
+    [data-window-chrome-platform="desktop"] ::-webkit-scrollbar-track {
+      background: var(--scrollbar-track);
+    }
 
-  [data-window-chrome-platform="desktop"] ::-webkit-scrollbar-thumb:hover {
-    background-color: var(--color-active);
-  }
+    [data-window-chrome-platform="desktop"] ::-webkit-scrollbar-thumb {
+      background-color: var(--scrollbar-thumb);
+      border: 2px solid transparent;
+      border-radius: 9999px;
+      background-clip: padding-box;
+    }
 
-  [data-window-chrome-platform="desktop"] ::-webkit-scrollbar-corner {
-    background: transparent;
-  }
+    [data-window-chrome-platform="desktop"] ::-webkit-scrollbar-thumb:hover {
+      background-color: var(--scrollbar-thumb-hover);
+    }
 
-  /* Windows classic scrollbar arrows clash with the dark shell — hide them. */
-  [data-window-chrome-platform="desktop"] ::-webkit-scrollbar-button {
-    display: none;
-    height: 0;
-    width: 0;
+    [data-window-chrome-platform="desktop"] ::-webkit-scrollbar-corner {
+      background: var(--scrollbar-track);
+    }
+
+    /* Windows classic scrollbar arrows clash with the dark shell — hide them. */
+    [data-window-chrome-platform="desktop"] ::-webkit-scrollbar-button {
+      display: none;
+      height: 0;
+      width: 0;
+    }
   }
 
   [data-window-shell-tier="mac"] {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [#51](https://github.com/thedavidweng/OpenKara/issues/51) — Windows/Linux scrollbars no longer show light classic WebView tracks that clash with OpenKara's dark shell.

Approach follows **community + Tauri official guidance** (not CSS-only):

### Windows (two layers)

1. **Native:** `scrollBarStyle: "fluentOverlay"` in `tauri.windows.conf.json` — Tauri 2 / WebView2 Fluent overlay scrollbars (requires WebView2 Runtime ≥ 125.0.2535.41; no-op on older runtimes).
2. **CSS:** Scoped dark `scrollbar-width` / `scrollbar-color` on `[data-window-chrome-platform="desktop"]`, with `::-webkit-scrollbar*` inside `@supports not (scrollbar-color: auto)` per [Chrome scrollbar guidance](https://developer.chrome.com/docs/css-ui/scrollbar-styling).

### Linux

CSS-only (WebKitGTK has no Tauri `scrollBarStyle` equivalent). Same scoped desktop tokens; macOS untouched.

### Alternatives considered (from research)

| Approach | Verdict |
|----------|---------|
| CSS only | Works on many setups but insufficient alone on Windows classic scrollbars ([tauri#6067](https://github.com/tauri-apps/tauri/issues/6067)) |
| `fluentOverlay` | **Adopted** — official Windows-native overlay baseline |
| OverlayScrollbars JS lib | Rejected for now — adds dependency & non-native feel; revisit if CSS+fluent still insufficient |

## Verification

- [x] `pnpm lint` — PASS
- [x] `pnpm build` — PASS
- [x] `pnpm test` — PASS (1218 tests)
- [ ] `cargo test` — SKIPPED (cloud VM missing gdk-3.0 pkg-config; CI runs this)
- [ ] `pnpm tauri build` — SKIPPED (no display / full bundle in cloud agent)
- [ ] Windows WebView2 manual check — **needed on maintainer machine** (cloud records Linux Chromium only)

## Residual risk

- `fluentOverlay` is a no-op when WebView2 Runtime is older than 125; CSS fallback still applies.
- Linux overlay scrollbars may stay subtle until hover — platform behavior, not demo styling.
- PR demo media uses real dev bundle + PR CSS; no recording-only style injections.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2af1-f7f3-7893-9fb8-a42bd1a31047"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2af1-f7f3-7893-9fb8-a42bd1a31047"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

