### PR TITLE
fix(lyrics): eliminate UI main-thread freeze on lyrics fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - Style Windows and Linux scrollbars to match the dark desktop shell instead of showing light WebView2/WebKitGTK tracks ([#51](https://github.com/thedavidweng/OpenKara/issues/51)): Windows uses Tauri `scrollBarStyle: fluentOverlay` (WebView2 overlay scrollbars) plus scoped dark `scrollbar-*` / `::-webkit-scrollbar` CSS; Linux keeps CSS-only styling.
+- Stop lyrics IPC commands from freezing the UI main thread. `fetch_lyrics`, `fetch_lyrics_online`, `set_lyrics_offset`, `save_manual_lyrics`, `import_lyrics_files`, and `extract_embedded_lyrics` were synchronous Tauri commands, which Tauri 2 runs on the webview main thread. They performed blocking file I/O (lofty embedded-lyrics reads) and `reqwest::blocking` network calls (LRCLIB/LrcApi fetches plus remote-library revision checks, database sync, and song publish), causing a ~1s rainbow-cursor freeze when web-lyrics lookup failed and fell back to embedded lyrics. All six commands are now `async`. `fetch_lyrics` and `fetch_lyrics_online` use async `reqwest` for network I/O (no `spawn_blocking` thread occupied during HTTP requests) and `spawn_blocking` only for short DB/file operations. The other four commands use `spawn_blocking` for their blocking work.
 
 ### Security
 

--- a/src-tauri/src/commands/lyrics.rs
+++ b/src-tauri/src/commands/lyrics.rs
@@ -1,7 +1,7 @@
 use crate::{
     cache,
     cache::lyrics::LyricsCacheEntry,
-    commands::error::{database_error, CommandResult},
+    commands::error::{database_error, internal_error, CommandResult},
     commands::remote_library,
     library::Song,
     library_root::LibraryRoot,
@@ -9,10 +9,11 @@ use crate::{
         self,
         error::LyricsError,
         fetch::{
-            fetch_online_timed_lyrics, lookup_query_from_song, LyricsSource, TimedLyricsProvider,
+            fetch_online_timed_lyrics_async, lookup_query_from_song, LyricsFetchResult,
+            LyricsSource, TimedLyricsProvider, TimedLyricsProviderAsync,
         },
         lrcapi::LrcApiClient,
-        lrclib::LrcLibClient,
+        lrclib::{LrcLibClient, LyricsLookupQuery},
         parser::LyricLine,
     },
     AppState,
@@ -32,40 +33,215 @@ pub struct LyricsPayload {
 }
 
 #[tauri::command]
-pub fn fetch_lyrics(
+pub async fn fetch_lyrics(
     state: State<'_, AppState>,
     app_handle: AppHandle,
     song_id: String,
 ) -> CommandResult<LyricsPayload> {
+    let background_state = state.inner().clone();
+
+    // Phase 1: cache check + local lyrics (spawn_blocking — fast DB + file I/O).
+    // Returns either a ready payload (cache hit / local lyrics) or a query for
+    // the online fetch phase.
+    let song_id_for_phase1 = song_id.clone();
+    let phase1 = tauri::async_runtime::spawn_blocking(move || {
+        fetch_lyrics_phase1(&background_state, &song_id_for_phase1)
+    })
+    .await
+    .map_err(|error| internal_error(format!("fetch_lyrics task failed: {error}")))??;
+
+    match phase1 {
+        FetchLyricsPhase1::Ready(payload) => Ok(payload),
+        FetchLyricsPhase1::NeedOnline { query, song_hash } => {
+            // Phase 2: online fetch (async — no spawn_blocking thread occupied).
+            let lrclib_client = LrcLibClient::new_default();
+            let lrcapi_client = LrcApiClient::new_default();
+            let providers = [
+                TimedLyricsProviderAsync::LrcLib(&lrclib_client),
+                TimedLyricsProviderAsync::LrcApi(&lrcapi_client),
+            ];
+            let online_result = fetch_online_timed_lyrics_async(&providers, &query)
+                .await
+                .map_err(|e| LyricsError::NetworkUnavailable(e.to_string()));
+
+            // Phase 3: parse + cache + remote sync (spawn_blocking — DB + remote I/O).
+            let state_for_phase3 = state.inner().clone();
+            let handle_for_phase3 = app_handle.clone();
+            let song_id_for_phase3 = song_id.clone();
+            tauri::async_runtime::spawn_blocking(move || {
+                fetch_lyrics_phase3(
+                    &state_for_phase3,
+                    &handle_for_phase3,
+                    &song_id_for_phase3,
+                    &song_hash,
+                    online_result,
+                )
+            })
+            .await
+            .map_err(|error| internal_error(format!("fetch_lyrics task failed: {error}")))?
+        }
+    }
+}
+
+/// Phase 1 result: either we have lyrics ready (cache hit or local source), or
+/// we need to fetch from the network.
+enum FetchLyricsPhase1 {
+    Ready(LyricsPayload),
+    NeedOnline {
+        query: LyricsLookupQuery,
+        song_hash: String,
+    },
+}
+
+// Phase 1: check SQLite cache, then read embedded/sidecar lyrics. All local
+// I/O — safe for a blocking worker thread. Does NOT call prepare/sync/publish
+// because those wrap the cache *write* in phase 3, and a stale cache miss just
+// means a redundant online fetch that gets corrected by the phase 3 cache write.
+fn fetch_lyrics_phase1(state: &AppState, song_id: &str) -> CommandResult<FetchLyricsPhase1> {
     let library_root = state.library_root()?;
     let connection = cache::open_database(&library_root.database_path()).map_err(database_error)?;
-    let lrclib_client = LrcLibClient::new_default();
-    let lrcapi_client = LrcApiClient::new_default();
 
-    remote_library::run_song_database_mutation(&state, &app_handle, &song_id, || {
-        fetch_lyrics_from_connection(
-            &connection,
-            &library_root,
-            &lrclib_client,
-            &lrcapi_client,
-            &song_id,
-        )
-        .map_err(Into::into)
+    let song = cache::get_song_by_hash(&connection, song_id)
+        .map_err(|e| database_error(e.to_string()))?
+        .ok_or(LyricsError::SongNotFound(song_id.to_string()))?;
+
+    // Cache hit — return immediately.
+    if let Some(cached) = cache::lyrics::get_lyrics_cache_entry(&connection, song_id)
+        .map_err(|e| database_error(e.to_string()))?
+    {
+        if cached.source == LyricsSource::Absent {
+            return Ok(FetchLyricsPhase1::Ready(empty_lyrics_payload(song.hash)));
+        }
+        let payload = payload_from_cached_entry(song.hash, cached)?;
+        return Ok(FetchLyricsPhase1::Ready(payload));
+    }
+
+    // No cache — try local sources (embedded + sidecar) first.
+    if let Some(song_path) = song.file_path.as_deref() {
+        let resolved_path = library_root.resolve(song_path);
+        if let Some(fetched) = lyrics::fetch::fetch_lyrics_for_song_local(&song, &resolved_path)
+            .map_err(|e| LyricsError::Internal(e.to_string()))?
+        {
+            // Parse and cache locally, then return.
+            let lines = lyrics::fetch::parse_lyrics_auto(&fetched.raw_lrc)
+                .map_err(|e| LyricsError::LyricsNotReady(e.to_string()))?;
+            let raw_lrc = fetched.raw_lrc.clone();
+            let source = fetched.source.clone();
+            cache::lyrics::upsert_lyrics_cache_entry(
+                &connection,
+                &LyricsCacheEntry {
+                    song_hash: song.hash.clone(),
+                    lrc: fetched.raw_lrc,
+                    source: source.clone(),
+                    offset_ms: 0,
+                    fetched_at: current_unix_timestamp()
+                        .map_err(|e| LyricsError::Internal(e.to_string()))?,
+                },
+            )
+            .map_err(|e| database_error(e.to_string()))?;
+
+            return Ok(FetchLyricsPhase1::Ready(LyricsPayload {
+                song_id: song.hash,
+                lines,
+                source: Some(source),
+                offset_ms: 0,
+                raw_lrc,
+            }));
+        }
+    }
+
+    // No local lyrics — defer to online fetch.
+    match lookup_query_from_song(&song) {
+        Some(query) => Ok(FetchLyricsPhase1::NeedOnline {
+            query,
+            song_hash: song.hash,
+        }),
+        None => Ok(FetchLyricsPhase1::Ready(empty_lyrics_payload(song.hash))),
+    }
+}
+
+// Phase 3: cache the online fetch result (or negative cache on miss), then
+// run remote-library sync/publish. Wrapped in run_song_database_mutation so
+// prepare/sync/publish happen around the DB write.
+fn fetch_lyrics_phase3(
+    state: &AppState,
+    app_handle: &AppHandle,
+    song_id: &str,
+    song_hash: &str,
+    online_result: Result<Option<LyricsFetchResult>, LyricsError>,
+) -> CommandResult<LyricsPayload> {
+    let library_root = state.library_root()?;
+    let connection = cache::open_database(&library_root.database_path()).map_err(database_error)?;
+
+    remote_library::run_song_database_mutation(state, app_handle, song_id, || {
+        let result: Result<LyricsPayload, LyricsError> = match online_result {
+            Ok(Some(fetched)) => {
+                let lines = lyrics::fetch::parse_lyrics_auto(&fetched.raw_lrc)
+                    .map_err(|e| LyricsError::LyricsNotReady(e.to_string()))?;
+                let raw_lrc = fetched.raw_lrc.clone();
+                let source = fetched.source.clone();
+                cache::lyrics::upsert_lyrics_cache_entry(
+                    &connection,
+                    &LyricsCacheEntry {
+                        song_hash: song_hash.to_owned(),
+                        lrc: fetched.raw_lrc,
+                        source: source.clone(),
+                        offset_ms: 0,
+                        fetched_at: current_unix_timestamp()
+                            .map_err(|e| LyricsError::Internal(e.to_string()))?,
+                    },
+                )
+                .map_err(|e| LyricsError::DatabaseUnavailable(e.to_string()))?;
+
+                Ok(LyricsPayload {
+                    song_id: song_hash.to_owned(),
+                    lines,
+                    source: Some(source),
+                    offset_ms: 0,
+                    raw_lrc,
+                })
+            }
+            Ok(None) => {
+                // All providers missed — cache negative lookup.
+                cache_negative_lyrics_lookup(&connection, song_hash)?;
+                Ok(empty_lyrics_payload(song_hash.to_owned()))
+            }
+            Err(_) => {
+                // Network error — don't cache, return empty.
+                Ok(empty_lyrics_payload(song_hash.to_owned()))
+            }
+        };
+        result.map_err(Into::into)
     })
 }
 
 #[tauri::command]
-pub fn set_lyrics_offset(
+pub async fn set_lyrics_offset(
     state: State<'_, AppState>,
     app_handle: AppHandle,
     song_id: String,
     ms: i64,
 ) -> CommandResult<()> {
+    let background_state = state.inner().clone();
+    let background_handle = app_handle.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        set_lyrics_offset_on_thread(&background_state, &background_handle, &song_id, ms)
+    })
+    .await
+    .map_err(|error| internal_error(format!("set_lyrics_offset task failed: {error}")))?
+}
+
+fn set_lyrics_offset_on_thread(
+    state: &AppState,
+    app_handle: &AppHandle,
+    song_id: &str,
+    ms: i64,
+) -> CommandResult<()> {
     let library = state.library_root()?;
     let connection = cache::open_database(&library.database_path()).map_err(database_error)?;
 
-    remote_library::run_song_database_mutation(&state, &app_handle, &song_id, || {
-        set_lyrics_offset_in_connection(&connection, &song_id, ms).map_err(Into::into)
+    remote_library::run_song_database_mutation(state, app_handle, song_id, || {
+        set_lyrics_offset_in_connection(&connection, song_id, ms).map_err(Into::into)
     })
 }
 
@@ -187,17 +363,32 @@ fn payload_from_cached_entry(
 }
 
 #[tauri::command]
-pub fn save_manual_lyrics(
+pub async fn save_manual_lyrics(
     state: State<'_, AppState>,
     app_handle: AppHandle,
     song_id: String,
     text: String,
 ) -> CommandResult<LyricsPayload> {
+    let background_state = state.inner().clone();
+    let background_handle = app_handle.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        save_manual_lyrics_on_thread(&background_state, &background_handle, &song_id, text)
+    })
+    .await
+    .map_err(|error| internal_error(format!("save_manual_lyrics task failed: {error}")))?
+}
+
+fn save_manual_lyrics_on_thread(
+    state: &AppState,
+    app_handle: &AppHandle,
+    song_id: &str,
+    text: String,
+) -> CommandResult<LyricsPayload> {
     let library = state.library_root()?;
     let connection = cache::open_database(&library.database_path()).map_err(database_error)?;
 
-    let publish_song_id = song_id.clone();
-    remote_library::run_song_database_mutation(&state, &app_handle, &song_id, || {
+    let publish_song_id = song_id.to_owned();
+    remote_library::run_song_database_mutation(state, app_handle, song_id, || {
         // Try parsing with auto-detection
         let lines = match lyrics::fetch::parse_lyrics_auto(&text) {
             Ok(parsed) if !parsed.is_empty() => parsed,
@@ -266,17 +457,31 @@ pub struct ImportLyricsResult {
 }
 
 #[tauri::command]
-pub fn import_lyrics_files(
+pub async fn import_lyrics_files(
     state: State<'_, AppState>,
     app_handle: AppHandle,
+    paths: Vec<String>,
+) -> CommandResult<ImportLyricsResult> {
+    let background_state = state.inner().clone();
+    let background_handle = app_handle.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        import_lyrics_files_on_thread(&background_state, &background_handle, paths)
+    })
+    .await
+    .map_err(|error| internal_error(format!("import_lyrics_files task failed: {error}")))?
+}
+
+fn import_lyrics_files_on_thread(
+    state: &AppState,
+    app_handle: &AppHandle,
     paths: Vec<String>,
 ) -> CommandResult<ImportLyricsResult> {
     let library = state.library_root()?;
     let connection = cache::open_database(&library.database_path()).map_err(database_error)?;
 
     remote_library::run_songs_database_mutation(
-        &state,
-        &app_handle,
+        state,
+        app_handle,
         || {
             let all_songs =
                 cache::list_songs(&connection).map_err(|e| database_error(e.to_string()))?;
@@ -372,16 +577,30 @@ pub fn import_lyrics_files(
 }
 
 #[tauri::command]
-pub fn extract_embedded_lyrics(
+pub async fn extract_embedded_lyrics(
     state: State<'_, AppState>,
     app_handle: AppHandle,
     song_id: String,
 ) -> CommandResult<LyricsPayload> {
+    let background_state = state.inner().clone();
+    let background_handle = app_handle.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        extract_embedded_lyrics_on_thread(&background_state, &background_handle, &song_id)
+    })
+    .await
+    .map_err(|error| internal_error(format!("extract_embedded_lyrics task failed: {error}")))?
+}
+
+fn extract_embedded_lyrics_on_thread(
+    state: &AppState,
+    app_handle: &AppHandle,
+    song_id: &str,
+) -> CommandResult<LyricsPayload> {
     let library_root = state.library_root()?;
     let connection = cache::open_database(&library_root.database_path()).map_err(database_error)?;
 
-    let publish_song_id = song_id.clone();
-    remote_library::run_song_database_mutation(&state, &app_handle, &song_id, || {
+    let publish_song_id = song_id.to_owned();
+    remote_library::run_song_database_mutation(state, app_handle, song_id, || {
         let song = cache::get_song_by_hash(&connection, &publish_song_id)
             .map_err(|e| LyricsError::DatabaseUnavailable(e.to_string()))?
             .ok_or(LyricsError::SongNotFound(publish_song_id.clone()))?;
@@ -434,78 +653,135 @@ pub fn extract_embedded_lyrics(
 }
 
 #[tauri::command]
-pub fn fetch_lyrics_online(
+pub async fn fetch_lyrics_online(
     state: State<'_, AppState>,
     app_handle: AppHandle,
     song_id: String,
+) -> CommandResult<LyricsPayload> {
+    // Phase 1: get song from DB (spawn_blocking — fast local read).
+    let background_state = state.inner().clone();
+    let song_id_for_phase1 = song_id.clone();
+    let phase1 = tauri::async_runtime::spawn_blocking(move || {
+        fetch_lyrics_online_phase1(&background_state, &song_id_for_phase1)
+    })
+    .await
+    .map_err(|error| internal_error(format!("fetch_lyrics_online task failed: {error}")))??;
+
+    match phase1 {
+        // No query possible (missing title/artist) — return empty without caching.
+        FetchOnlinePhase1::NoQuery(payload) => Ok(payload),
+        FetchOnlinePhase1::Fetch { query, song_hash } => {
+            // Phase 2: online fetch (async — no spawn_blocking thread occupied).
+            let lrclib_client = LrcLibClient::new_default();
+            let lrcapi_client = LrcApiClient::new_default();
+            let providers = [
+                TimedLyricsProviderAsync::LrcLib(&lrclib_client),
+                TimedLyricsProviderAsync::LrcApi(&lrcapi_client),
+            ];
+            let online_result = fetch_online_timed_lyrics_async(&providers, &query)
+                .await
+                .map_err(|e| LyricsError::NetworkUnavailable(e.to_string()));
+
+            // Phase 3: parse + cache + remote sync (spawn_blocking — DB + remote I/O).
+            let state_for_phase3 = state.inner().clone();
+            let handle_for_phase3 = app_handle.clone();
+            tauri::async_runtime::spawn_blocking(move || {
+                fetch_lyrics_online_phase3(
+                    &state_for_phase3,
+                    &handle_for_phase3,
+                    &song_hash,
+                    online_result,
+                )
+            })
+            .await
+            .map_err(|error| internal_error(format!("fetch_lyrics_online task failed: {error}")))?
+        }
+    }
+}
+
+enum FetchOnlinePhase1 {
+    NoQuery(LyricsPayload),
+    Fetch {
+        query: LyricsLookupQuery,
+        song_hash: String,
+    },
+}
+
+fn fetch_lyrics_online_phase1(state: &AppState, song_id: &str) -> CommandResult<FetchOnlinePhase1> {
+    let library_root = state.library_root()?;
+    let connection = cache::open_database(&library_root.database_path()).map_err(database_error)?;
+
+    let song = cache::get_song_by_hash(&connection, song_id)
+        .map_err(|e| database_error(e.to_string()))?
+        .ok_or(LyricsError::SongNotFound(song_id.to_owned()))?;
+
+    match lookup_query_from_song(&song) {
+        Some(query) => Ok(FetchOnlinePhase1::Fetch {
+            query,
+            song_hash: song.hash,
+        }),
+        None => Ok(FetchOnlinePhase1::NoQuery(LyricsPayload {
+            song_id: song.hash,
+            lines: Vec::new(),
+            source: None,
+            offset_ms: 0,
+            raw_lrc: String::new(),
+        })),
+    }
+}
+
+fn fetch_lyrics_online_phase3(
+    state: &AppState,
+    app_handle: &AppHandle,
+    song_hash: &str,
+    online_result: Result<Option<LyricsFetchResult>, LyricsError>,
 ) -> CommandResult<LyricsPayload> {
     let library_root = state.library_root()?;
     let connection = cache::open_database(&library_root.database_path()).map_err(database_error)?;
 
     remote_library::run_song_database_mutation_with_result(
-        &state,
-        &app_handle,
+        state,
+        app_handle,
         || {
-            let song = cache::get_song_by_hash(&connection, &song_id)
-                .map_err(|e| LyricsError::DatabaseUnavailable(e.to_string()))?
-                .ok_or(LyricsError::SongNotFound(song_id.clone()))?;
+            let result: Result<LyricsPayload, LyricsError> = match online_result {
+                Ok(Some(fetched)) => {
+                    let lines = lyrics::fetch::parse_lyrics_auto(&fetched.raw_lrc)
+                        .map_err(|e| LyricsError::LyricsNotReady(e.to_string()))?;
+                    let raw_lrc = fetched.raw_lrc.clone();
+                    let source = fetched.source.clone();
+                    let fetched_at = current_unix_timestamp()
+                        .map_err(|e| LyricsError::Internal(e.to_string()))?;
 
-            let lrclib_client = LrcLibClient::new_default();
-            let lrcapi_client = LrcApiClient::new_default();
-            let providers = [
-                TimedLyricsProvider::LrcLib(&lrclib_client),
-                TimedLyricsProvider::LrcApi(&lrcapi_client),
-            ];
-            let query = match lookup_query_from_song(&song) {
-                Some(q) => q,
-                None => {
-                    return Ok(LyricsPayload {
-                        song_id: song.hash,
-                        lines: Vec::new(),
-                        source: None,
+                    cache::lyrics::upsert_lyrics_cache_entry(
+                        &connection,
+                        &LyricsCacheEntry {
+                            song_hash: song_hash.to_owned(),
+                            lrc: fetched.raw_lrc,
+                            source: source.clone(),
+                            offset_ms: 0,
+                            fetched_at,
+                        },
+                    )
+                    .map_err(|e| LyricsError::DatabaseUnavailable(e.to_string()))?;
+
+                    Ok(LyricsPayload {
+                        song_id: song_hash.to_owned(),
+                        lines,
+                        source: Some(source),
                         offset_ms: 0,
-                        raw_lrc: String::new(),
-                    });
+                        raw_lrc,
+                    })
                 }
-            };
-
-            let Some(fetched) = fetch_online_timed_lyrics(&providers, &query)
-                .map_err(|e| LyricsError::NetworkUnavailable(e.to_string()))?
-            else {
-                return Ok(LyricsPayload {
-                    song_id: song.hash,
+                Ok(None) => Ok(LyricsPayload {
+                    song_id: song_hash.to_owned(),
                     lines: Vec::new(),
                     source: None,
                     offset_ms: 0,
                     raw_lrc: String::new(),
-                });
+                }),
+                Err(e) => Err(e),
             };
-
-            let lines = lyrics::fetch::parse_lyrics_auto(&fetched.raw_lrc)
-                .map_err(|e| LyricsError::LyricsNotReady(e.to_string()))?;
-
-            let fetched_at =
-                current_unix_timestamp().map_err(|e| LyricsError::Internal(e.to_string()))?;
-
-            cache::lyrics::upsert_lyrics_cache_entry(
-                &connection,
-                &LyricsCacheEntry {
-                    song_hash: song_id.clone(),
-                    lrc: fetched.raw_lrc.clone(),
-                    source: fetched.source.clone(),
-                    offset_ms: 0,
-                    fetched_at,
-                },
-            )
-            .map_err(|e| database_error(e.to_string()))?;
-
-            Ok(LyricsPayload {
-                song_id,
-                lines,
-                source: Some(fetched.source),
-                offset_ms: 0,
-                raw_lrc: fetched.raw_lrc,
-            })
+            result.map_err(Into::into)
         },
         |payload| payload.source.as_ref().map(|_| payload.song_id.clone()),
     )

--- a/src-tauri/src/commands/lyrics.rs
+++ b/src-tauri/src/commands/lyrics.rs
@@ -52,6 +52,26 @@ pub async fn fetch_lyrics(
 
     match phase1 {
         FetchLyricsPhase1::Ready(payload) => Ok(payload),
+        FetchLyricsPhase1::LocalLyrics { fetched, song_hash } => {
+            // Phase 3: parse + cache + remote sync (spawn_blocking — DB + remote I/O).
+            // Local lyrics must go through run_song_database_mutation so that
+            // prepare → sync_db → publish_song runs around the cache write,
+            // matching the original fetch_lyrics_from_connection behavior.
+            let state_for_phase3 = state.inner().clone();
+            let handle_for_phase3 = app_handle.clone();
+            let song_id_for_phase3 = song_id.clone();
+            tauri::async_runtime::spawn_blocking(move || {
+                fetch_lyrics_phase3(
+                    &state_for_phase3,
+                    &handle_for_phase3,
+                    &song_id_for_phase3,
+                    &song_hash,
+                    Ok(Some(fetched)),
+                )
+            })
+            .await
+            .map_err(|error| internal_error(format!("fetch_lyrics task failed: {error}")))?
+        }
         FetchLyricsPhase1::NeedOnline { query, song_hash } => {
             // Phase 2: online fetch (async — no spawn_blocking thread occupied).
             let lrclib_client = LrcLibClient::new_default();
@@ -83,10 +103,14 @@ pub async fn fetch_lyrics(
     }
 }
 
-/// Phase 1 result: either we have lyrics ready (cache hit or local source), or
-/// we need to fetch from the network.
+/// Phase 1 result: either we have lyrics ready (cache hit), we found local
+/// lyrics that need a cache write, or we need to fetch from the network.
 enum FetchLyricsPhase1 {
     Ready(LyricsPayload),
+    LocalLyrics {
+        fetched: LyricsFetchResult,
+        song_hash: String,
+    },
     NeedOnline {
         query: LyricsLookupQuery,
         song_hash: String,
@@ -94,9 +118,9 @@ enum FetchLyricsPhase1 {
 }
 
 // Phase 1: check SQLite cache, then read embedded/sidecar lyrics. All local
-// I/O — safe for a blocking worker thread. Does NOT call prepare/sync/publish
-// because those wrap the cache *write* in phase 3, and a stale cache miss just
-// means a redundant online fetch that gets corrected by the phase 3 cache write.
+// I/O — safe for a blocking worker thread. This phase is read-only: it does
+// NOT write the cache or call prepare/sync/publish. Cache writes and remote
+// sync happen in phase 3, wrapped in run_song_database_mutation.
 fn fetch_lyrics_phase1(state: &AppState, song_id: &str) -> CommandResult<FetchLyricsPhase1> {
     let library_root = state.library_root()?;
     let connection = cache::open_database(&library_root.database_path()).map_err(database_error)?;
@@ -105,7 +129,7 @@ fn fetch_lyrics_phase1(state: &AppState, song_id: &str) -> CommandResult<FetchLy
         .map_err(|e| database_error(e.to_string()))?
         .ok_or(LyricsError::SongNotFound(song_id.to_string()))?;
 
-    // Cache hit — return immediately.
+    // Cache hit — return immediately (no DB write, no remote sync needed).
     if let Some(cached) = cache::lyrics::get_lyrics_cache_entry(&connection, song_id)
         .map_err(|e| database_error(e.to_string()))?
     {
@@ -117,36 +141,17 @@ fn fetch_lyrics_phase1(state: &AppState, song_id: &str) -> CommandResult<FetchLy
     }
 
     // No cache — try local sources (embedded + sidecar) first.
+    // The cache write is deferred to phase 3 so it goes through
+    // run_song_database_mutation (prepare → sync_db → publish_song).
     if let Some(song_path) = song.file_path.as_deref() {
         let resolved_path = library_root.resolve(song_path);
         if let Some(fetched) = lyrics::fetch::fetch_lyrics_for_song_local(&song, &resolved_path)
             .map_err(|e| LyricsError::Internal(e.to_string()))?
         {
-            // Parse and cache locally, then return.
-            let lines = lyrics::fetch::parse_lyrics_auto(&fetched.raw_lrc)
-                .map_err(|e| LyricsError::LyricsNotReady(e.to_string()))?;
-            let raw_lrc = fetched.raw_lrc.clone();
-            let source = fetched.source.clone();
-            cache::lyrics::upsert_lyrics_cache_entry(
-                &connection,
-                &LyricsCacheEntry {
-                    song_hash: song.hash.clone(),
-                    lrc: fetched.raw_lrc,
-                    source: source.clone(),
-                    offset_ms: 0,
-                    fetched_at: current_unix_timestamp()
-                        .map_err(|e| LyricsError::Internal(e.to_string()))?,
-                },
-            )
-            .map_err(|e| database_error(e.to_string()))?;
-
-            return Ok(FetchLyricsPhase1::Ready(LyricsPayload {
-                song_id: song.hash,
-                lines,
-                source: Some(source),
-                offset_ms: 0,
-                raw_lrc,
-            }));
+            return Ok(FetchLyricsPhase1::LocalLyrics {
+                fetched,
+                song_hash: song.hash,
+            });
         }
     }
 

--- a/src-tauri/src/lyrics/fetch.rs
+++ b/src-tauri/src/lyrics/fetch.rs
@@ -89,6 +89,31 @@ pub fn fetch_lyrics_for_song(
     }
 
     // Local-first: embedded and sidecar lyrics must not wait on network timeouts.
+    if let Some(local) = fetch_lyrics_for_song_local(song, resolved_audio_path)? {
+        return Ok(Some(local));
+    }
+
+    if let Some(query) = lookup_query_from_song(song) {
+        if let Ok(Some(lyrics)) = fetch_online_timed_lyrics(providers, &query) {
+            return Ok(Some(lyrics));
+        }
+    }
+
+    Ok(None)
+}
+
+/// Local-only lyrics fetch: reads embedded tags and sidecar files without any
+/// network calls. Used by async IPC commands that handle the online fetch
+/// separately via `fetch_online_timed_lyrics_async`.
+pub fn fetch_lyrics_for_song_local(
+    song: &Song,
+    resolved_audio_path: &Path,
+) -> Result<Option<LyricsFetchResult>> {
+    if song.is_media_g_zip() {
+        return Ok(None);
+    }
+
+    // Local-first: embedded and sidecar lyrics must not wait on network timeouts.
     if let Some(embedded_lyrics) = read_embedded_lyrics(resolved_audio_path)? {
         return Ok(Some(LyricsFetchResult {
             source: LyricsSource::Embedded,
@@ -101,12 +126,6 @@ pub fn fetch_lyrics_for_song(
             source: sidecar_source,
             raw_lrc: sidecar_lyrics,
         }));
-    }
-
-    if let Some(query) = lookup_query_from_song(song) {
-        if let Ok(Some(lyrics)) = fetch_online_timed_lyrics(providers, &query) {
-            return Ok(Some(lyrics));
-        }
     }
 
     Ok(None)
@@ -141,6 +160,107 @@ pub fn fetch_online_timed_lyrics(
                 };
 
                 // Verify it has timed content
+                let has_timed = if source == LyricsSource::LrcApiTtml {
+                    ttml_parser::parse_ttml(&raw)
+                        .map(|lines| !lines.is_empty())
+                        .unwrap_or(false)
+                } else {
+                    has_timed_lines(&raw)
+                };
+
+                if has_timed {
+                    return Ok(Some(LyricsFetchResult {
+                        source,
+                        raw_lrc: raw,
+                    }));
+                }
+            }
+            Ok(None) => {}
+            Err(error) => {
+                last_error = Some(error);
+            }
+        }
+    }
+
+    if let Some(error) = last_error {
+        Err(error)
+    } else {
+        Ok(None)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Async variants — used by async Tauri commands so network I/O does not occupy
+// a `spawn_blocking` worker thread for the full request duration.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy)]
+pub enum TimedLyricsProviderAsync<'a> {
+    LrcLib(&'a LrcLibClient),
+    LrcApi(&'a LrcApiClient),
+}
+
+impl TimedLyricsProviderAsync<'_> {
+    fn source(self) -> LyricsSource {
+        match self {
+            Self::LrcLib(_) => LyricsSource::LrcLib,
+            Self::LrcApi(_) => LyricsSource::LrcApi,
+        }
+    }
+
+    async fn fetch_timed_lrc(self, query: &LyricsLookupQuery) -> Result<Option<String>> {
+        match self {
+            Self::LrcLib(client) => client
+                .fetch_by_track_async(query)
+                .await
+                .map(|result| {
+                    result.and_then(|lyrics| {
+                        lyrics
+                            .synced_lyrics
+                            .filter(|lyrics| !lyrics.trim().is_empty())
+                    })
+                })
+                .map_err(Into::into),
+            Self::LrcApi(client) => client
+                .fetch_by_track_async(query)
+                .await
+                .map(|result| {
+                    result.and_then(|lyrics| {
+                        // Prefer LRC, fall back to TTML
+                        let lrc = lyrics.lrc.trim();
+                        if !lrc.is_empty() {
+                            Some(lyrics.lrc)
+                        } else {
+                            lyrics.lrc_ttml.filter(|ttml| !ttml.trim().is_empty())
+                        }
+                    })
+                })
+                .map_err(Into::into),
+        }
+    }
+}
+
+/// Async variant of `fetch_online_timed_lyrics` for use in async Tauri
+/// commands. Avoids occupying a `spawn_blocking` thread for the duration of
+/// the network request.
+pub async fn fetch_online_timed_lyrics_async(
+    providers: &[TimedLyricsProviderAsync<'_>],
+    query: &LyricsLookupQuery,
+) -> Result<Option<LyricsFetchResult>> {
+    let mut last_error: Option<anyhow::Error> = None;
+
+    for provider in providers {
+        match (*provider).fetch_timed_lrc(query).await {
+            Ok(Some(raw)) => {
+                let trimmed = raw.trim();
+                let source = if (*provider).source() == LyricsSource::LrcApi
+                    && (trimmed.starts_with("<?xml") || trimmed.starts_with("<tt"))
+                {
+                    LyricsSource::LrcApiTtml
+                } else {
+                    (*provider).source()
+                };
+
                 let has_timed = if source == LyricsSource::LrcApiTtml {
                     ttml_parser::parse_ttml(&raw)
                         .map(|lines| !lines.is_empty())

--- a/src-tauri/src/lyrics/lrcapi.rs
+++ b/src-tauri/src/lyrics/lrcapi.rs
@@ -35,6 +35,7 @@ enum LrcApiResponse {
 pub struct LrcApiClient {
     base_url: String,
     http: reqwest::blocking::Client,
+    http_async: reqwest::Client,
 }
 
 impl LrcApiClient {
@@ -47,6 +48,12 @@ impl LrcApiClient {
                 .timeout(Duration::from_secs(6))
                 .build()
                 .expect("reqwest blocking client should build"),
+            http_async: reqwest::Client::builder()
+                .user_agent(USER_AGENT)
+                .connect_timeout(Duration::from_secs(3))
+                .timeout(Duration::from_secs(6))
+                .build()
+                .expect("reqwest async client should build"),
         }
     }
 
@@ -75,6 +82,51 @@ impl LrcApiClient {
             LyricsError::NetworkUnavailable(format!("LrcAPI returned a non-success response: {e}"))
         })?;
         let response = response.json::<LrcApiResponse>().map_err(|e| {
+            LyricsError::NetworkUnavailable(format!(
+                "failed to deserialize LrcAPI lyrics response: {e}"
+            ))
+        })?;
+
+        Ok(match response {
+            LrcApiResponse::Hits(entries) => entries
+                .into_iter()
+                .filter(|entry| !entry.lrc.trim().is_empty())
+                .max_by(|left, right| left.score.total_cmp(&right.score)),
+            LrcApiResponse::Miss(miss) => {
+                if miss.message.trim() == "未找到歌词" {
+                    None
+                } else {
+                    return Err(LyricsError::NetworkUnavailable(format!(
+                        "LrcAPI returned an unexpected response: {}",
+                        miss.message
+                    )));
+                }
+            }
+        })
+    }
+
+    /// Async variant of `fetch_by_track` for use in async Tauri commands.
+    pub async fn fetch_by_track_async(
+        &self,
+        query: &LyricsLookupQuery,
+    ) -> Result<Option<LrcApiLyrics>, LyricsError> {
+        let url = format!("{}/jsonapi", self.base_url);
+        let mut request = self.http_async.get(url).query(&[
+            ("title", query.track_name.as_str()),
+            ("artist", query.artist_name.as_str()),
+        ]);
+
+        if let Some(album_name) = query.album_name.as_deref() {
+            request = request.query(&[("album", album_name)]);
+        }
+
+        let response = request.send().await.map_err(|e| {
+            LyricsError::NetworkUnavailable(format!("failed to request lyrics from LrcAPI: {e}"))
+        })?;
+        let response = response.error_for_status().map_err(|e| {
+            LyricsError::NetworkUnavailable(format!("LrcAPI returned a non-success response: {e}"))
+        })?;
+        let response = response.json::<LrcApiResponse>().await.map_err(|e| {
             LyricsError::NetworkUnavailable(format!(
                 "failed to deserialize LrcAPI lyrics response: {e}"
             ))

--- a/src-tauri/src/lyrics/lrclib.rs
+++ b/src-tauri/src/lyrics/lrclib.rs
@@ -32,6 +32,7 @@ pub struct LrcLibLyrics {
 pub struct LrcLibClient {
     base_url: String,
     http: reqwest::blocking::Client,
+    http_async: reqwest::Client,
 }
 
 impl LrcLibClient {
@@ -44,6 +45,12 @@ impl LrcLibClient {
                 .timeout(Duration::from_secs(6))
                 .build()
                 .expect("reqwest blocking client should build"),
+            http_async: reqwest::Client::builder()
+                .user_agent(USER_AGENT)
+                .connect_timeout(Duration::from_secs(3))
+                .timeout(Duration::from_secs(6))
+                .build()
+                .expect("reqwest async client should build"),
         }
     }
 
@@ -80,6 +87,46 @@ impl LrcLibClient {
             LyricsError::NetworkUnavailable(format!("LRCLIB returned a non-success response: {e}"))
         })?;
         let lyrics = response.json::<LrcLibLyrics>().map_err(|e| {
+            LyricsError::NetworkUnavailable(format!(
+                "failed to deserialize LRCLIB lyrics response: {e}"
+            ))
+        })?;
+
+        Ok(Some(lyrics))
+    }
+
+    /// Async variant of `fetch_by_track` for use in async Tauri commands.
+    /// Avoids occupying a `spawn_blocking` thread for the duration of the
+    /// network request.
+    pub async fn fetch_by_track_async(
+        &self,
+        query: &LyricsLookupQuery,
+    ) -> Result<Option<LrcLibLyrics>, LyricsError> {
+        let url = format!("{}/api/get", self.base_url);
+        let mut request = self.http_async.get(url).query(&[
+            ("track_name", query.track_name.as_str()),
+            ("artist_name", query.artist_name.as_str()),
+        ]);
+
+        if let Some(album_name) = query.album_name.as_deref() {
+            request = request.query(&[("album_name", album_name)]);
+        }
+
+        if let Some(duration_seconds) = query.duration_seconds {
+            request = request.query(&[("duration", duration_seconds)]);
+        }
+
+        let response = request.send().await.map_err(|e| {
+            LyricsError::NetworkUnavailable(format!("failed to request lyrics from LRCLIB: {e}"))
+        })?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+
+        let response = response.error_for_status().map_err(|e| {
+            LyricsError::NetworkUnavailable(format!("LRCLIB returned a non-success response: {e}"))
+        })?;
+        let lyrics = response.json::<LrcLibLyrics>().await.map_err(|e| {
             LyricsError::NetworkUnavailable(format!(
                 "failed to deserialize LRCLIB lyrics response: {e}"
             ))


### PR DESCRIPTION
## Summary

- Lyrics IPC commands (`fetch_lyrics`, `fetch_lyrics_online`, `set_lyrics_offset`, `save_manual_lyrics`, `import_lyrics_files`, `extract_embedded_lyrics`) were synchronous Tauri commands, which Tauri 2 runs on the webview main thread. They performed blocking file I/O (lofty embedded-lyrics reads) and `reqwest::blocking` network calls (LRCLIB/LrcApi fetches plus remote-library revision checks, database sync, and song publish), causing a ~1s rainbow-cursor freeze on macOS when web-lyrics lookup failed and fell back to embedded lyrics.

- All six commands are now `async`. `fetch_lyrics` and `fetch_lyrics_online` use async `reqwest` for network I/O (no `spawn_blocking` thread occupied during HTTP requests) and `spawn_blocking` only for short DB/file operations. The other four commands use `spawn_blocking` for their blocking work, matching the existing `play` command pattern.

- `LrcLibClient` and `LrcApiClient` gained async `fetch_by_track_async` methods alongside the existing sync methods (kept for tests). New `TimedLyricsProviderAsync` enum and `fetch_online_timed_lyrics_async` function mirror the sync variants. `fetch_lyrics_for_song_local` was extracted from `fetch_lyrics_for_song` to separate local file I/O from network fetch.

#### Test plan

- [x] `cargo build` — PASS
- [x] `cargo clippy --lib -- -D warnings` — PASS
- [x] `cargo fmt --check` — PASS
- [x] `cargo test` — PASS (370 unit + all integration tests, 0 failures)
- [ ] `pnpm tauri build` — SKIPPED (Rust-only change, no frontend impact)
- [ ] Manual test: play a song with no web lyrics, verify embedded fallback no longer freezes UI

Generated with [Devin](https://devin.ai)