### PR TITLE
chore: bump knip to 6.26 and update ignoreBinaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - Introduce `PlaybackCoordinator` as an independent control thread that serializes all control-plane mutations of `PlaybackController` (pause / resume / seek / set_volume / set_stem_volume / install_track / fail_load / attach_stems). Background decode/fetch threads now produce immutable `ReadyTrack` payloads and send `PlaybackCommand` messages to the coordinator instead of directly mutating the controller. The coordinator guarantees FIFO ordering, latest-request-wins guards, AirPlay epoch/generation bumps, CDG seek-reset, and output-thread startup — all on a single thread. Public Tauri command names, arguments, response shapes, and event names are unchanged.
+- Fix macOS being left outside the application's native-control color scheme and unify scrollbar visibility across platforms: `AppLayout` emits `data-window-chrome-platform="mac"` while the scrollbar/color-scheme rules only matched `desktop`, so the mac WebView received neither the intended dark native-control environment nor scrollbar variables. macOS now keeps its native overlay/autohide scrollbar under a dark `color-scheme` (`scrollbar-color/width: auto`, no author `::-webkit-scrollbar` geometry); Windows/Linux descendants get a thin semantic scrollbar from shared root tokens (`--scrollbar-thumb`/`-hover`/`-active`/`-track`) with a scoped `@supports not (scrollbar-color: auto)` WebKit fallback; and forced-colors returns scrollbar control to the system on every platform.
 
 ### Fixed
 

--- a/knip.json
+++ b/knip.json
@@ -3,6 +3,5 @@
   "entry": ["src-tauri/**/*.rs"],
   "project": ["src/**/*.{ts,tsx}"],
   "exclude": ["exports", "types"],
-  "ignoreDependencies": ["tailwindcss"],
-  "ignoreBinaries": ["xcrun"]
+  "ignoreBinaries": ["xcrun", "hdiutil"]
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@vitejs/plugin-react": "^6.0.3",
     "@vitest/coverage-v8": "4.1.10",
     "jsdom": "^29.1.1",
-    "knip": "^6.17.2",
+    "knip": "^6.26.0",
     "lefthook": "^2.1.9",
     "oxfmt": "^0.57.0",
     "oxlint": "^1.72.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,8 @@ importers:
         specifier: ^29.1.1
         version: 29.1.1
       knip:
-        specifier: ^6.17.2
-        version: 6.24.0
+        specifier: ^6.26.0
+        version: 6.26.0
       lefthook:
         specifier: ^2.1.9
         version: 2.1.9
@@ -1836,8 +1836,8 @@ packages:
       canvas:
         optional: true
 
-  knip@6.24.0:
-    resolution: {integrity: sha512-PokLlgeEjLh1rAsB7ts+52wZ37HBr1nDhE6NNONwEaXdeZGCJOkP7ZlIAI2Gtu8xohquzTWy75bc/1diI9shQw==}
+  knip@6.26.0:
+    resolution: {integrity: sha512-e9eELEEpBpGTd4H4HB7818/DYj9dMzMyUqAddfYwUN/EbSkgIjOuWEF96W/xHsmV0SDrsdXjIM+oZ2xpPzPsBA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -3907,7 +3907,7 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
-  knip@6.24.0:
+  knip@6.26.0:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       formatly: 0.3.0

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -185,6 +185,7 @@
     [data-window-chrome-platform],
     [data-window-chrome-platform] * {
       scrollbar-color: auto;
+      scrollbar-width: auto;
       forced-color-adjust: auto;
     }
   }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -67,6 +67,32 @@
     --sidebar-control-bg: rgba(255, 255, 255, 0.045);
     --chrome-floating-bg: rgba(255, 255, 255, 0.09);
     --chrome-floating-border: rgba(255, 255, 255, 0.11);
+    /*
+     * Semantic scrollbar tokens — neutral gray dark-theme defaults shared by every
+     * platform. #96 overrides these per resolved theme. Components never use
+     * platform-specific literal scrollbar colors; descendants consume these vars.
+     */
+    --scrollbar-thumb: #6e6e73;
+    --scrollbar-thumb-hover: #8e8e93;
+    --scrollbar-thumb-active: #aeaeb2;
+    --scrollbar-track: transparent;
+  }
+
+  /*
+   * macOS: let WKWebView render its native overlay scrollbar under the correct
+   * dark color-scheme. The explicit `auto` values are intentional — opting into
+   * author styling (::-webkit-scrollbar, scrollbar-width: thin, or a custom
+   * scrollbar-color) would change native overlay/autohide behavior. Do not add
+   * ::-webkit-scrollbar geometry under the mac selector.
+   */
+  [data-window-chrome-platform="mac"] {
+    color-scheme: dark;
+  }
+
+  [data-window-chrome-platform="mac"],
+  [data-window-chrome-platform="mac"] * {
+    scrollbar-color: auto;
+    scrollbar-width: auto;
   }
 
   [data-window-chrome-platform="desktop"] {
@@ -89,25 +115,30 @@
     --color-control-primary-foreground: #17191d;
     --color-ghost-hover: rgba(255, 255, 255, 0.06);
     --panel-blur: 12px;
-    /* WebView2 / WebKitGTK default to light classic scrollbars; align with dark chrome. */
-    --scrollbar-thumb: var(--color-border-light);
-    --scrollbar-thumb-hover: var(--color-text-dimmer);
-    --scrollbar-track: transparent;
     color-scheme: dark;
   }
 
-  /* Standard scrollbar props (WebView2 121+, Firefox). CSS layers on native appearance.
-     scrollbar-width/color do not inherit, and AppLayout is overflow-hidden — lists and
-     panels scroll on nested overflow-y-auto nodes, so descendants must set these too. */
-  @supports (scrollbar-width: thin) {
+  /*
+   * Windows/Linux: standard scrollbar properties (WebView2 121+, Firefox).
+   * scrollbar-width/color do not inherit, and AppLayout is overflow-hidden —
+   * lists and panels scroll on nested overflow-y-auto nodes, so descendants
+   * must set these too. Scoped only to desktop; never combine @supports not
+   * with the mac selector.
+   */
+  @supports (scrollbar-color: auto) {
     [data-window-chrome-platform="desktop"],
     [data-window-chrome-platform="desktop"] * {
-      scrollbar-width: thin;
       scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+      scrollbar-width: thin;
     }
   }
 
-  /* WebKit fallback for engines without scrollbar-color (older WebView2, WebKitGTK). */
+  /*
+   * WebKit fallback for engines without scrollbar-color (older WebView2,
+   * WebKitGTK). Scoped only to desktop. Hover/active/track/corner/button
+   * fallback states are complete; disabled/unsupported pseudo states degrade
+   * to the default thumb.
+   */
   @supports not (scrollbar-color: auto) {
     [data-window-chrome-platform="desktop"] ::-webkit-scrollbar {
       width: 10px;
@@ -129,6 +160,10 @@
       background-color: var(--scrollbar-thumb-hover);
     }
 
+    [data-window-chrome-platform="desktop"] ::-webkit-scrollbar-thumb:active {
+      background-color: var(--scrollbar-thumb-active);
+    }
+
     [data-window-chrome-platform="desktop"] ::-webkit-scrollbar-corner {
       background: var(--scrollbar-track);
     }
@@ -138,6 +173,19 @@
       display: none;
       height: 0;
       width: 0;
+    }
+  }
+
+  /*
+   * System high-contrast (forced-colors) always wins: return scrollbar control
+   * to the system and let forced-color-adjust apply. Applies to every platform
+   * marker so neither mac nor desktop author styling overrides the system.
+   */
+  @media (forced-colors: active) {
+    [data-window-chrome-platform],
+    [data-window-chrome-platform] * {
+      scrollbar-color: auto;
+      forced-color-adjust: auto;
     }
   }
 

--- a/tests/contract/scrollbar-contract.test.ts
+++ b/tests/contract/scrollbar-contract.test.ts
@@ -1,0 +1,130 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+/**
+ * Source/contract test for the platform scrollbar contract (#97).
+ *
+ * Protects the native-overlay decision for macOS from later global expansions:
+ * no selector beginning with the mac platform marker may install author
+ * scrollbar geometry (`::-webkit-scrollbar`), `scrollbar-width: thin`, or a
+ * custom `scrollbar-color` value. macOS must keep `scrollbar-color/width: auto`
+ * so WKWebView retains its native overlay/autohide behavior.
+ *
+ * This test reads the raw stylesheet from disk rather than importing it, so it
+ * is unaffected by Vitest's CSS stubbing. It lives under `tests/contract/`
+ * (outside `src/`) so the production `tsc` build does not type-check Node APIs.
+ */
+
+const GLOBALS_CSS = readFileSync(
+  fileURLToPath(new URL("../../src/styles/globals.css", import.meta.url)),
+  "utf8",
+);
+
+const MAC_SELECTOR = 'data-window-chrome-platform="mac"';
+
+/** Find the body of the rule block whose selector contains `selectorOccurrence`. */
+function blockBodyForSelectorAt(css: string, selectorIndex: number): string {
+  const braceOpen = css.indexOf("{", selectorIndex);
+  if (braceOpen === -1) {
+    return "";
+  }
+  let depth = 1;
+  let j = braceOpen + 1;
+  while (j < css.length && depth > 0) {
+    const c = css[j];
+    if (c === "{") {
+      depth++;
+    } else if (c === "}") {
+      depth--;
+    }
+    j++;
+  }
+  return css.slice(braceOpen + 1, j - 1);
+}
+
+describe("scrollbar platform contract", () => {
+  test("mac selector blocks contain no author scrollbar geometry or custom colors", () => {
+    const forbiddenGeometry = /::-webkit-scrollbar/;
+    const forbiddenThinWidth = /scrollbar-width\s*:\s*thin/i;
+    // Capture every scrollbar-color declaration value and require it to be
+    // exactly "auto". A negative-lookahead regex would backtrack past the
+    // optional whitespace, so capture-and-compare is the robust check.
+    const scrollbarColorDecls = /scrollbar-color\s*:\s*([^;]+)/gi;
+
+    let cursor = 0;
+    let foundMacBlock = false;
+    while (cursor < GLOBALS_CSS.length) {
+      const idx = GLOBALS_CSS.indexOf(MAC_SELECTOR, cursor);
+      if (idx === -1) {
+        break;
+      }
+      const body = blockBodyForSelectorAt(GLOBALS_CSS, idx);
+      foundMacBlock = true;
+
+      expect(
+        forbiddenGeometry.test(body),
+        `mac selector block must not contain ::-webkit-scrollbar, found in: ${body}`,
+      ).toBe(false);
+      expect(
+        forbiddenThinWidth.test(body),
+        `mac selector block must not set scrollbar-width: thin, found in: ${body}`,
+      ).toBe(false);
+      const matches = [...body.matchAll(scrollbarColorDecls)];
+      for (const match of matches) {
+        expect(
+          match[1].trim(),
+          `mac selector block must not set a custom scrollbar-color (only auto is allowed), found in: ${body}`,
+        ).toBe("auto");
+      }
+
+      cursor = idx + MAC_SELECTOR.length;
+    }
+
+    expect(
+      foundMacBlock,
+      "expected at least one mac platform selector block",
+    ).toBe(true);
+  });
+
+  test("mac platform applies dark color-scheme and native auto scrollbars", () => {
+    expect(GLOBALS_CSS).toContain(
+      '[data-window-chrome-platform="mac"] {\n    color-scheme: dark;',
+    );
+    expect(GLOBALS_CSS).toContain(
+      '[data-window-chrome-platform="mac"],\n  [data-window-chrome-platform="mac"] * {\n    scrollbar-color: auto;\n    scrollbar-width: auto;',
+    );
+  });
+
+  test("desktop thin scrollbar is scoped only to the desktop marker", () => {
+    const desktopThin =
+      /@supports\s*\(scrollbar-color:\s*auto\)\s*\{[^}]*\[data-window-chrome-platform="desktop"\][^}]*scrollbar-width:\s*thin/s;
+    expect(desktopThin.test(GLOBALS_CSS)).toBe(true);
+
+    // The @supports not fallback must not be combined with the mac selector.
+    const fallbackBlock =
+      /@supports\s*not\s*\(scrollbar-color:\s*auto\)\s*\{([\s\S]*?)\n\s*\}/;
+    const match = GLOBALS_CSS.match(fallbackBlock);
+    expect(
+      match,
+      "expected a desktop-scoped @supports not fallback",
+    ).not.toBeNull();
+    expect(match?.[1]).not.toContain('data-window-chrome-platform="mac"');
+  });
+
+  test("forced-colors returns scrollbar control to the system for every platform", () => {
+    expect(GLOBALS_CSS).toContain("@media (forced-colors: active)");
+    expect(GLOBALS_CSS).toContain("scrollbar-color: auto;");
+    expect(GLOBALS_CSS).toContain("forced-color-adjust: auto;");
+    expect(GLOBALS_CSS).toContain(
+      "[data-window-chrome-platform],\n    [data-window-chrome-platform] *",
+    );
+  });
+
+  test("semantic scrollbar tokens are defined at the application root", () => {
+    expect(GLOBALS_CSS).toContain("--scrollbar-thumb: #6e6e73;");
+    expect(GLOBALS_CSS).toContain("--scrollbar-thumb-hover: #8e8e93;");
+    expect(GLOBALS_CSS).toContain("--scrollbar-thumb-active: #aeaeb2;");
+    expect(GLOBALS_CSS).toContain("--scrollbar-track: transparent;");
+  });
+});

--- a/tests/contract/scrollbar-contract.test.ts
+++ b/tests/contract/scrollbar-contract.test.ts
@@ -102,8 +102,11 @@ describe("scrollbar platform contract", () => {
     expect(desktopThin.test(GLOBALS_CSS)).toBe(true);
 
     // The @supports not fallback must not be combined with the mac selector.
+    // Match the full @supports not block, including nested braces, by
+    // capturing until the closing brace at the same indentation as the
+    // opening @supports line.
     const fallbackBlock =
-      /@supports\s*not\s*\(scrollbar-color:\s*auto\)\s*\{([\s\S]*?)\n\s*\}/;
+      /@supports\s*not\s*\(scrollbar-color:\s*auto\)\s*\{([\s\S]*?)\n  \}/;
     const match = GLOBALS_CSS.match(fallbackBlock);
     expect(
       match,

--- a/tests/e2e/scrollbar.spec.ts
+++ b/tests/e2e/scrollbar.spec.ts
@@ -1,0 +1,209 @@
+import { test, expect } from "./fixtures/base-test";
+
+/**
+ * Scrollbar platform contract (#97).
+ *
+ * macOS keeps its native overlay scrollbar under a dark `color-scheme`
+ * (scrollbar-color/width: auto, no author ::-webkit-scrollbar geometry);
+ * Windows/Linux descendants get a thin semantic scrollbar from the root
+ * tokens. Forced colors return control to the system. These are CSS contract
+ * assertions — Playwright WebKit is an engine-level regression test, not
+ * evidence for macOS WKWebView system preference behavior, so the spec
+ * feature-detects serialization differences instead of asserting one
+ * rgb(...) spelling.
+ *
+ * The standard `scrollbar-width`/`scrollbar-color` properties are supported by
+ * Chromium but not by WebKit (which uses the `::-webkit-scrollbar` fallback).
+ * The `thin`/non-`auto` assertions are therefore Chromium-only; WebKit asserts
+ * the mac `auto` contract and `color-scheme`, and the desktop fallback is
+ * covered by the source/contract test plus Chromium.
+ */
+
+type PlatformMarker = "desktop" | "mac";
+
+async function setPlatformMarker(
+  page: import("@playwright/test").Page,
+  marker: PlatformMarker,
+) {
+  await page.evaluate((value) => {
+    const el = document.querySelector("[data-window-chrome-platform]");
+    if (el instanceof HTMLElement) {
+      el.setAttribute("data-window-chrome-platform", value);
+    }
+  }, marker);
+}
+
+async function readScrollbarStyles(
+  page: import("@playwright/test").Page,
+  selector: string,
+) {
+  return page.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    if (!(el instanceof HTMLElement)) {
+      return null;
+    }
+    const cs = getComputedStyle(el);
+    return {
+      scrollbarWidth: cs.scrollbarWidth,
+      scrollbarColor: cs.scrollbarColor,
+      colorScheme: cs.colorScheme,
+    };
+  }, selector);
+}
+
+function engineName(page: import("@playwright/test").Page): string {
+  return page.context().browser()?.browserType().name() ?? "";
+}
+
+/** True when the engine actually exposes a computed scrollbar property value. */
+function isExposed(value: unknown): value is string {
+  return typeof value === "string" && value !== "";
+}
+
+test.describe("scrollbar platform contract", () => {
+  test("desktop marker applies thin semantic scrollbar with transparent track", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await setPlatformMarker(page, "desktop");
+
+    const root = await readScrollbarStyles(
+      page,
+      "[data-window-chrome-platform='desktop']",
+    );
+    expect(root).not.toBeNull();
+    expect(root!.colorScheme).toContain("dark");
+
+    // The thin/non-auto contract is expressed through the standard properties,
+    // which Chromium supports. WebKit uses the ::-webkit-scrollbar fallback and
+    // reports "auto" for scrollbar-width, so only assert the standard contract
+    // where the engine actually exposes it.
+    const isChromium = engineName(page) === "chromium";
+    if (isChromium) {
+      expect(root!.scrollbarWidth).toBe("thin");
+      expect(root!.scrollbarColor).not.toBe("auto");
+      expect(root!.scrollbarColor.length).toBeGreaterThan(0);
+    }
+
+    // The root token resolves to the neutral default on every engine.
+    const token = await page.evaluate(() => {
+      return getComputedStyle(document.documentElement)
+        .getPropertyValue("--scrollbar-thumb")
+        .trim();
+    });
+    expect(token).toBe("#6e6e73");
+
+    // A nested scroll descendant inherits the desktop contract.
+    const nested = await readScrollbarStyles(page, "[data-testid='song-list']");
+    expect(nested).not.toBeNull();
+    if (isChromium) {
+      expect(nested!.scrollbarWidth).toBe("thin");
+      expect(nested!.scrollbarColor).not.toBe("auto");
+    }
+  });
+
+  test("mac marker keeps native auto scrollbar and dark color-scheme", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await setPlatformMarker(page, "mac");
+
+    const root = await readScrollbarStyles(
+      page,
+      "[data-window-chrome-platform='mac']",
+    );
+    expect(root).not.toBeNull();
+    expect(root!.colorScheme).toContain("dark");
+
+    // scrollbar-width/color must stay auto so WKWebView keeps native overlay
+    // behavior. Some engines do not expose the property at all — feature-detect
+    // rather than asserting a single serialization.
+    if (isExposed(root!.scrollbarWidth)) {
+      expect(root!.scrollbarWidth).toBe("auto");
+    }
+    if (isExposed(root!.scrollbarColor)) {
+      expect(root!.scrollbarColor).toBe("auto");
+    }
+
+    // Descendants inherit auto and must not receive author geometry.
+    const nested = await readScrollbarStyles(page, "[data-testid='song-list']");
+    expect(nested).not.toBeNull();
+    if (isExposed(nested!.scrollbarWidth)) {
+      expect(nested!.scrollbarWidth).toBe("auto");
+    }
+    if (isExposed(nested!.scrollbarColor)) {
+      expect(nested!.scrollbarColor).toBe("auto");
+    }
+  });
+
+  test("settings scroll surface produces real overflow and inherits the platform contract", async ({
+    page,
+  }) => {
+    // A shorter viewport forces the settings overlay (inset-0) to overflow so a
+    // real scroll container exists; the default 3-song fixture does not overflow
+    // the virtualized song list.
+    await page.setViewportSize({ width: 1280, height: 400 });
+    await page.goto("/");
+    await setPlatformMarker(page, "desktop");
+
+    // Open the settings overlay — it has many sections and scrolls.
+    await page.getByRole("button", { name: "Settings" }).click();
+    const heading = page.getByRole("heading", { name: "Preferences" });
+    await expect(heading).toBeVisible();
+    // The overlay root is the overflow-y-auto ancestor of the title.
+    const overlay = page
+      .locator("div.overflow-y-auto")
+      .filter({ has: heading });
+    await expect(overlay).toBeVisible();
+
+    const overflow = await overlay.evaluate((el) => ({
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+    }));
+    expect(overflow.scrollHeight).toBeGreaterThan(overflow.clientHeight);
+
+    // Programmatic scroll moves the thumb.
+    await overlay.evaluate((el) => {
+      el.scrollTop = 120;
+    });
+    const after = await overlay.evaluate((el) => el.scrollTop);
+    expect(after).toBeGreaterThan(0);
+
+    // The overlay inherits the desktop thin contract where the engine exposes
+    // the standard properties (Chromium).
+    if (engineName(page) === "chromium") {
+      const styles = await overlay.evaluate((el) => {
+        const cs = getComputedStyle(el);
+        return {
+          scrollbarWidth: cs.scrollbarWidth,
+          scrollbarColor: cs.scrollbarColor,
+        };
+      });
+      expect(styles.scrollbarWidth).toBe("thin");
+      expect(styles.scrollbarColor).not.toBe("auto");
+    }
+  });
+
+  test("forced colors return scrollbar control to the system", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await setPlatformMarker(page, "desktop");
+
+    // Forced-colors emulation is supported in Chromium; WebKit skips gracefully.
+    test.skip(
+      engineName(page) !== "chromium",
+      "forced-colors emulation is Chromium-only",
+    );
+
+    await page.emulateMedia({ forcedColors: "active" });
+    const root = await readScrollbarStyles(
+      page,
+      "[data-window-chrome-platform='desktop']",
+    );
+    expect(root).not.toBeNull();
+    if (isExposed(root!.scrollbarColor)) {
+      expect(root!.scrollbarColor).toBe("auto");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Bump knip from `^6.17.2` to `^6.26.0`
- Add `hdiutil` to `ignoreBinaries` in `knip.json` (new unlisted binary surfaced by 6.26.0 in `scripts/clean-macos-bundle.mjs`)
- Remove `tailwindcss` from `ignoreDependencies` (no longer needed with 6.26.0)

#### Test plan
- [x] `pnpm knip --no-progress` exits 0
- [x] `pnpm install` succeeds
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thedavidweng/openkara/pull/119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->