### PR TITLE
fix(ui): use accent blue for active Karaoke Library selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- Theme siblings keep monochrome _controls_ (surfaces, type, primary fills via `--color-control-primary`). A single accent blue returns for recognition only (selected stem/EP/model chips, library icons, links); destructive red stays for Danger Zone. Settings section titles use primary text + semibold so panels scan clearly without a second palette.
+- Theme siblings keep monochrome _controls_ (surfaces, type, primary fills via `--color-control-primary`). A single accent blue returns for recognition only (selected stem/EP/model chips, active Karaoke Library row, library icons, links); destructive red stays for Danger Zone. Settings section titles use primary text + semibold so panels scan clearly without a second palette.
+- Settings Karaoke Library active row uses the same accent selected chrome as stem/EP/model chips (`border-accent` + `bg-accent/15` + accent check) instead of monochrome `--color-control-selected-*`.
 - Stem detail popup portals to `document.body` with fixed positioning (z-70) so stage `overflow-hidden` and the settings overlay no longer clip it. Sub-stem rows reuse accompaniment `playback_bar` geometry and `inlineStemVolumeWidthClass` rails, and anchor `left` to the accompaniment icon+rail so icons and sliders stay column-aligned.
 - Global ←/→ seek is removed so lyrics are not keyboard-driven; lyrics font/page shortcuts are also removed. ↑/↓ continue to nudge master volume only.
 - Stem/master mute no longer paints selected `data-active` chrome; muted icons use the dimmer gray token so mute reads as off rather than pressed.

--- a/src/components/Settings/SettingsLibrarySection.test.tsx
+++ b/src/components/Settings/SettingsLibrarySection.test.tsx
@@ -117,4 +117,41 @@ describe("SettingsLibrarySection", () => {
     expect(markup).toContain("Failed to switch library");
     expect(markup).toContain("text-[var(--color-destructive)]");
   });
+
+  test("active library uses accent selected chrome like stem/EP chips", () => {
+    const value = createSettingsOverlayTestContextValue({
+      state: {
+        libraries: [
+          {
+            id: "local:/karaoke",
+            kind: "local",
+            display_name: "Main Library",
+            root_path: "/karaoke",
+          },
+          {
+            id: "local:/other",
+            kind: "local",
+            display_name: "Other Library",
+            root_path: "/other",
+          },
+        ],
+        activeLibraryId: "local:/karaoke",
+      },
+    });
+
+    const markup = renderToStaticMarkup(
+      <SettingsOverlayContext value={value}>
+        <SettingsLibrarySection />
+      </SettingsOverlayContext>,
+    );
+
+    // Match SettingsStemModeSection / SettingsModelVariantSection selected tokens.
+    expect(markup).toContain("border-[var(--color-accent)]");
+    expect(markup).toContain("bg-[var(--color-accent)]/15");
+    expect(markup).toContain("text-[var(--color-accent)]");
+    expect(markup).not.toContain(
+      "border-[var(--color-control-selected-border)]",
+    );
+    expect(markup).not.toContain("bg-[var(--color-control-selected-bg)]");
+  });
 });

--- a/src/components/Settings/SettingsLibrarySection.tsx
+++ b/src/components/Settings/SettingsLibrarySection.tsx
@@ -123,7 +123,7 @@ export function SettingsLibrarySection() {
                 key={library.id}
                 className={`flex w-full items-center gap-3 rounded-md border px-3 py-2 text-left transition-colors ${
                   isActive
-                    ? "border-[var(--color-control-selected-border)] bg-[var(--color-control-selected-bg)]"
+                    ? "border-[var(--color-accent)] bg-[var(--color-accent)]/15 text-[var(--color-text)]"
                     : "border-[var(--color-border-light)] bg-[var(--color-surface)] hover:bg-[var(--color-hover)]"
                 }`}
               >
@@ -154,7 +154,7 @@ export function SettingsLibrarySection() {
                   {isActive ? (
                     <CheckCircle2
                       size={14}
-                      className="shrink-0 text-[var(--color-control-primary)]"
+                      className="shrink-0 text-[var(--color-accent)]"
                     />
                   ) : null}
                 </button>


### PR DESCRIPTION
## Summary

- Active Karaoke Library row in Settings now uses the same accent selected chrome as stem / EP / model chips (`border-accent` + `bg-accent/15` + accent check icon).
- Replaces monochrome `--color-control-selected-*` / control-primary check so the active library is recognizable as selected, consistent with the rest of Settings option cards.

## Test plan

- [x] `pnpm exec vitest run src/components/Settings/SettingsLibrarySection.test.tsx`
- [ ] Open Settings → Karaoke Library with multiple libraries; confirm active row has blue border/fill and blue check
- [ ] Compare with Stem mode / Model variant selected chips; styles should match
- [ ] Light and dark appearance both show the same accent blue for the active library