### PR TITLE
fix(ci): stabilize Playwright search flake and Linux rust-lld SIGBUS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,6 +360,11 @@ jobs:
 
       - name: Run Rust tests
         working-directory: src-tauri
+        env:
+          # Parallel rust-lld of many heavy Tauri integration-test binaries has
+          # hit SIGBUS (Bus error) on GitHub Linux runners. Cap build jobs so
+          # concurrent linkers do not collide under memory pressure.
+          CARGO_BUILD_JOBS: "2"
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
             cargo nextest run --no-fail-fast

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Cancel a pending library search debounce when the query is cleared, so a late `searchLibrary` result cannot overwrite `loadLibrary()` and hide songs again (Playwright webkit flake in `song-import` search filter). Cap Linux CI `CARGO_BUILD_JOBS` to reduce parallel `rust-lld` SIGBUS crashes while linking heavy Tauri test binaries.
+
 ### Changed
 
 - Website landing preview polish: tighten the product-mock halo so the under-glow sits close to the window tail (Linear-style side/bottom spacing), keep the light-mode halo below the mock top with a seamless fade into the stage gray, and keep all eight Built-with logos on one desktop row.

--- a/src/stores/library-store.test.ts
+++ b/src/stores/library-store.test.ts
@@ -945,6 +945,63 @@ describe("library-store setSearchQuery debounce race (F2)", () => {
     // Slow results must NOT overwrite the fast "a" results
     expect(useLibraryStore.getState().songs).toEqual([songA]);
   });
+
+  test("clearing search cancels a pending debounce before it can overwrite loadLibrary", async () => {
+    const filtered = {
+      hash: "see-you",
+      title: "See You Again",
+      artist: "Tyler, The Creator",
+      album: null,
+      file_path: "/music/see-you.m4a",
+      audio_source_kind: "original" as const,
+      cdg_path: null,
+      media_g_container: null,
+      instrumental: false,
+      language: null,
+      duration_ms: 100000,
+      cover_art: null,
+      has_cover_art: false,
+      imported_at: 0,
+      original_ext: null,
+    };
+    const fullLibrary = [
+      {
+        hash: "earfquake",
+        title: "Earfquake",
+        artist: "Tyler, The Creator",
+        album: null,
+        file_path: "/music/earfquake.m4a",
+        audio_source_kind: "original" as const,
+        cdg_path: null,
+        media_g_container: null,
+        instrumental: false,
+        language: null,
+        duration_ms: 100000,
+        cover_art: null,
+        has_cover_art: false,
+        imported_at: 1,
+        original_ext: null,
+      },
+      filtered,
+    ];
+
+    mockSearchLibrary.mockResolvedValue([filtered]);
+    mockGetLibrary.mockResolvedValue(fullLibrary);
+    mockGetActiveLibrary.mockResolvedValue(null);
+    mockGetAllSeparationStatuses.mockResolvedValue([]);
+    mockGetAllUploadStatuses.mockResolvedValue([]);
+
+    // Schedule a debounced search, then clear before the 300ms window elapses.
+    useLibraryStore.getState().setSearchQuery("See You");
+    useLibraryStore.getState().setSearchQuery("");
+
+    await vi.advanceTimersByTimeAsync(300);
+    await Promise.resolve();
+
+    expect(mockSearchLibrary).not.toHaveBeenCalled();
+    expect(mockGetLibrary).toHaveBeenCalled();
+    expect(useLibraryStore.getState().songs).toEqual(fullLibrary);
+  });
 });
 
 // ─── resolveCdgChoicePrompt ─────────────────────────────────

--- a/src/stores/library-store.ts
+++ b/src/stores/library-store.ts
@@ -13,12 +13,27 @@ import type {
   UploadStatusSnapshot,
 } from "@/types/ipc";
 
-function debounce<T extends (...args: never[]) => void>(fn: T, ms: number): T {
+function debounce<T extends (...args: never[]) => void>(
+  fn: T,
+  ms: number,
+): T & { cancel: () => void } {
   let timer: ReturnType<typeof setTimeout> | null = null;
-  return ((...args: Parameters<T>) => {
+  const wrapped = ((...args: Parameters<T>) => {
     if (timer) clearTimeout(timer);
-    timer = setTimeout(() => fn(...args), ms);
-  }) as T;
+    timer = setTimeout(() => {
+      timer = null;
+      fn(...args);
+    }, ms);
+  }) as T & { cancel: () => void };
+  // Clear must cancel a pending timer: otherwise a late debounced search can
+  // overwrite loadLibrary() results when the user clears within the window.
+  wrapped.cancel = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+  return wrapped;
 }
 
 interface LibraryState {
@@ -196,6 +211,7 @@ export const useLibraryStore = create<LibraryState>((set, get) => ({
     if (query.trim()) {
       debouncedSearch(query);
     } else {
+      debouncedSearch.cancel();
       searchGeneration++;
       get().loadLibrary();
     }

--- a/tests/e2e/song-import.spec.ts
+++ b/tests/e2e/song-import.spec.ts
@@ -33,22 +33,17 @@ test.describe("Song import workflow", () => {
   });
 
   test("search box filters the song list", async ({ page }) => {
-    // Find the search input
-    const searchBox = page.getByRole("textbox");
-    await expect(searchBox.first()).toBeVisible();
+    const searchBox = page.getByRole("textbox", { name: /search/i });
+    const songList = page.getByTestId("song-list");
+    await expect(searchBox).toBeVisible();
 
-    // Type a search query
-    await searchBox.first().fill("See You");
+    await searchBox.fill("See You");
+    // Wait for the store's 300ms debounce to apply before asserting filter.
+    await expect(songList.getByText("Earfquake")).not.toBeVisible();
+    await expect(songList.getByText("See You Again")).toBeVisible();
 
-    // Only matching songs should remain visible
-    await expect(page.getByText("See You Again")).toBeVisible();
-
-    // Non-matching songs should be hidden (or the filter should be active)
-    // Note: exact assertion depends on whether filtering hides or dims
-
-    // Clear search
-    await searchBox.first().clear();
-    await expect(page.getByText("Earfquake")).toBeVisible();
+    await searchBox.clear();
+    await expect(songList.getByText("Earfquake")).toBeVisible();
   });
 
   test("empty library state is not shown when songs exist", async ({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Proactive CI stability fixes for failures observed on `main` / recent runs (independent of the website halo PR).

### Playwright `song-import` search (webkit)
- **Root cause:** clearing the search box within the 300ms debounce window did not cancel the pending timer. The late `searchLibrary` result overwrote `loadLibrary()` and hid songs again (`Earfquake` not found after clear).
- **Fix:** `debouncedSearch.cancel()` on empty query; unit test for the race; e2e now asserts filtering actually applied (`Earfquake` not visible while filtered).

### Linux `Rust tests` rust-lld Bus error
- **Root cause:** parallel `rust-lld` of many heavy Tauri integration-test binaries hit `SIGBUS` on GHA Linux (flaky infrastructure, not product code).
- **Mitigation:** set `CARGO_BUILD_JOBS=2` on the rust-test job to cap concurrent linkers.

### Already fixed on main (not in this PR)
- `previewLabel` TS2339 and related website type errors from earlier website commits.

## Verification
- [x] `pnpm lint` — PASS
- [x] `pnpm test` — PASS (1712 tests, including new debounce-clear race)
- [x] patch coverage 100%
- [ ] Playwright full suite — left to CI (targeted e2e assertion updated)
- [ ] `pnpm tauri build` — SKIPPED (no Rust product changes)

## Test plan
- [ ] CI Playwright UI smoke green on this branch
- [ ] CI Rust tests (Linux) green (no rust-lld SIGBUS)
- [ ] Manually: type in library search, clear quickly within ~300ms — full library restores and stays restored

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7bf9-71df-7d17-ad75-3f802f973021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7bf9-71df-7d17-ad75-3f802f973021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

