### PR TITLE
fix(website): polish mock preview freeze, playlist counts, sidebar, Separate size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Cancel a pending library search debounce when the query is cleared, so a late `searchLibrary` result cannot overwrite `loadLibrary()` and hide songs again (Playwright webkit flake in `song-import` search filter). Cap Linux CI `CARGO_BUILD_JOBS` to reduce parallel `rust-lld` SIGBUS crashes while linking heavy Tauri test binaries.
 
+- Website product mock polish: freeze playback on Earfquake at a real lyric timestamp (`59.56s`) so the seekbar and lyrics panel stay mid-song; derive playlist `song_count` from membership (Favorites/Friday night = 4 each); allow clicking Toggle Sidebar in preview while still blocking Import; reset unlayered `font: inherit` inside `.product-preview` so shared `SongListItem` Separate buttons keep their app `text-[10px]` size instead of inheriting the landing 15px type.
+
 ### Changed
 
 - Website landing preview polish: tighten the product-mock halo so the under-glow sits close to the window tail (Linear-style side/bottom spacing), keep the light-mode halo below the mock top with a seamless fade into the stage gray, and keep all eight Built-with logos on one desktop row.

--- a/src/components/Layout/AppLayout.preview.test.tsx
+++ b/src/components/Layout/AppLayout.preview.test.tsx
@@ -300,6 +300,22 @@ describe("AppLayout preview mode", () => {
     expect(onPointerDown).toHaveBeenCalledTimes(1);
   });
 
+  it("allows click interactions on sidebar-toggle targets in preview mode", () => {
+    const onClick = vi.fn();
+    const { container } = render(
+      <AppLayout initialWindowShellState={macShellState} previewMode />,
+    );
+
+    const outer = container.firstElementChild as HTMLElement;
+    const sidebarToggle = document.createElement("button");
+    sidebarToggle.setAttribute("data-preview-sidebar-toggle", "true");
+    sidebarToggle.addEventListener("click", onClick);
+    outer.appendChild(sidebarToggle);
+
+    fireEvent.click(sidebarToggle);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
   it("blocks context menu in preview mode", () => {
     const onContext = vi.fn();
     const { container } = render(

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -31,15 +31,16 @@ const PREVIEW_WINDOW_SHELL_STATE: WindowShellState =
   getNativeWindowShellState();
 
 // Preview-mode interaction whitelist. The landing-page mock blocks all
-// interactions except: (1) playlist switches in the sidebar, and (2) lyrics
-// scrolling + the Follow button inside the lyrics panel. The lyrics exception
-// lets visitors browse the lyrics and jump back to the current line even
-// though playback itself is frozen.
+// interactions except: (1) playlist switches in the sidebar, (2) lyrics
+// scrolling + the Follow button inside the lyrics panel, and (3) the toolbar
+// sidebar toggle (keyboard already works via window shortcuts). Import and
+// other mutating actions stay blocked.
 function isPreviewAllowedTarget(target: EventTarget | null): boolean {
   return (
     target instanceof Element &&
     (target.closest("[data-preview-playlist-switch='true']") != null ||
-      target.closest("[data-preview-lyrics-interactive='true']") != null)
+      target.closest("[data-preview-lyrics-interactive='true']") != null ||
+      target.closest("[data-preview-sidebar-toggle='true']") != null)
   );
 }
 

--- a/src/components/Layout/Toolbar.test.tsx
+++ b/src/components/Layout/Toolbar.test.tsx
@@ -138,6 +138,7 @@ describe("Toolbar drag region", () => {
 
     expect(markup).toContain('data-preview-traffic-lights="true"');
     expect(markup).toContain('data-airplay-preview="true"');
+    expect(markup).toContain('data-preview-sidebar-toggle="true"');
   });
 
   test("can omit the leading sidebar/import controls for native split shells", () => {

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -89,6 +89,7 @@ export function Toolbar({
             <button
               onClick={onToggleSidebar}
               aria-label={t("toolbar.toggleSidebar")}
+              data-preview-sidebar-toggle={previewMode ? "true" : undefined}
               className={`motion-icon-button rounded-xl p-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]/50 ${
                 sidebarVisible
                   ? "bg-[color-mix(in_srgb,var(--color-hover)_86%,transparent)] text-[var(--color-text)] shadow-[0_10px_24px_rgba(0,0,0,0.16)]"

--- a/src/mock/tauri-mock-data.ts
+++ b/src/mock/tauri-mock-data.ts
@@ -24,32 +24,44 @@ import type { MockData } from "@/mock/tauri-mock-impl";
  */
 export const MOCK_SIDEBAR_WIDTH = 280;
 
+export const MOCK_PLAYLIST_SONGS: Record<string, string[]> = {
+  favorites: ["earfquake", "see-you-again", "counting-stars", "feel-good-inc"],
+  party: ["all-the-love", "three-empty-words", "earfquake", "see-you-again"],
+};
+
 /**
- * Playlists for the website preview.  E2E tests use an empty list — tests
- * that need playlists create them via the mock IPC's `create_playlist`
- * command at runtime.
+ * Playlists for the website preview.  `song_count` must match membership in
+ * {@link MOCK_PLAYLIST_SONGS} — the preview seeds the playlist store directly
+ * and never re-counts via IPC.  E2E tests use an empty list — tests that need
+ * playlists create them via the mock IPC's `create_playlist` command at runtime.
  */
 export const MOCK_PLAYLISTS = [
   {
     id: "favorites",
     name: "Favorites",
-    song_count: 12,
+    song_count: MOCK_PLAYLIST_SONGS.favorites.length,
     created_at: 1,
     updated_at: 1,
   },
   {
     id: "party",
     name: "Friday night",
-    song_count: 28,
+    song_count: MOCK_PLAYLIST_SONGS.party.length,
     created_at: 1,
     updated_at: 1,
   },
 ];
 
-export const MOCK_PLAYLIST_SONGS: Record<string, string[]> = {
-  favorites: ["earfquake", "see-you-again", "counting-stars", "feel-good-inc"],
-  party: ["all-the-love", "three-empty-words", "earfquake", "see-you-again"],
-};
+/**
+ * Freeze the website mock on this Earfquake lyric timestamp so the seekbar
+ * and lyrics panel show a real mid-song line instead of an idle blank state.
+ * Matches `Don't leave, it's my fault (Girl)` in `PREVIEW_LYRICS.earfquake`.
+ */
+export const PREVIEW_FROZEN_POSITION_MS = 59560;
+
+const PRIMARY_PREVIEW_DURATION_MS =
+  PREVIEW_SONGS.find((song) => song.hash === PRIMARY_PREVIEW_SONG_HASH)
+    ?.duration_ms ?? 0;
 
 /**
  * The shared mock data payload.  Both the website preview and E2E fixture
@@ -117,18 +129,23 @@ export const MOCK_DATA: MockData = {
     theme_preference: "dark",
   },
 
+  // Website preview freezes on the primary song at a real lyric timestamp so
+  // the seekbar and lyrics panel look mid-session. E2E overrides this back to
+  // idle via {@link E2E_MOCK_DATA} so playback specs start from a clean slate.
   playbackSnapshot: {
     transport_generation: 0,
-    song_id: null,
-    state: "idle",
+    song_id: PRIMARY_PREVIEW_SONG_HASH,
+    // Pause is `is_playing: false` with a non-idle transport state — keeps the
+    // player chrome populated while the clock stays frozen for the mock.
+    state: "playing",
     is_playing: false,
-    position_ms: 0,
-    duration_ms: 0,
-    buffered_ms: 0,
+    position_ms: PREVIEW_FROZEN_POSITION_MS,
+    duration_ms: PRIMARY_PREVIEW_DURATION_MS,
+    buffered_ms: PRIMARY_PREVIEW_DURATION_MS,
     volume: 0.8,
     stem_volumes: { vocals: 1, drums: 1, bass: 1, other: 1 },
-    has_stems: false,
-    stem_mode: null,
+    has_stems: true,
+    stem_mode: "two_stem",
   },
 
   bootstrapStatus: {
@@ -153,10 +170,24 @@ export const MOCK_DATA: MockData = {
 
 /**
  * E2E-specific mock data: same as {@link MOCK_DATA} but with empty playlists
- * (E2E tests create playlists at runtime via mock IPC commands).
+ * (E2E tests create playlists at runtime via mock IPC commands) and an idle
+ * playback snapshot so specs control transport from a known starting state.
  */
 export const E2E_MOCK_DATA: MockData = {
   ...MOCK_DATA,
   playlists: [],
   playlistSongs: {},
+  playbackSnapshot: {
+    transport_generation: 0,
+    song_id: null,
+    state: "idle",
+    is_playing: false,
+    position_ms: 0,
+    duration_ms: 0,
+    buffered_ms: 0,
+    volume: 0.8,
+    stem_volumes: { vocals: 1, drums: 1, bass: 1, other: 1 },
+    has_stems: false,
+    stem_mode: null,
+  },
 };

--- a/website/src/site.css
+++ b/website/src/site.css
@@ -409,6 +409,14 @@ a {
   min-width: 920px;
 }
 
+/* Unlayered `button, a { font: inherit }` above would otherwise force the
+   landing 15px type into the embedded app and enlarge Tailwind text-[10px]
+   controls like Separate. Reset so app utilities own font sizing again. */
+.product-preview button,
+.product-preview a {
+  font: unset;
+}
+
 .product-preview [data-preview-interaction-mode="playlist-only"] {
   user-select: none;
 }
@@ -417,7 +425,7 @@ a {
   [data-preview-interaction-mode="playlist-only"]
   button:not([data-preview-playlist-switch="true"]):not(
     [data-preview-lyrics-interactive="true"]
-  ),
+  ):not([data-preview-sidebar-toggle="true"]),
 .product-preview [data-preview-interaction-mode="playlist-only"] input,
 .product-preview
   [data-preview-interaction-mode="playlist-only"]
@@ -428,7 +436,10 @@ a {
 
 .product-preview
   [data-preview-interaction-mode="playlist-only"]
-  [data-preview-playlist-switch="true"] {
+  [data-preview-playlist-switch="true"],
+.product-preview
+  [data-preview-interaction-mode="playlist-only"]
+  [data-preview-sidebar-toggle="true"] {
   cursor: pointer;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Website product mock polish after the shared mock-data migration:

1. **Frozen lyrics + seekbar** — `MOCK_DATA.playbackSnapshot` now loads Earfquake paused at `59.56s` (real lyric line *Don't leave, it's my fault (Girl)*). `E2E_MOCK_DATA` keeps an idle snapshot so Playwright specs are unchanged.
2. **Playlist counts** — Favorites / Friday night `song_count` derived from `MOCK_PLAYLIST_SONGS` membership (4 / 4) instead of hardcoded 12 / 28.
3. **Toggle Sidebar clickable** — preview whitelist + CSS allow `data-preview-sidebar-toggle`; Import stays blocked.
4. **Separate button size** — same `SongListItem` code; unlayered landing `button { font: inherit }` was overriding Tailwind `text-[10px]` inside the preview. Reset `font` under `.product-preview`.

## Verification

- [x] `pnpm lint` — PASS
- [x] `pnpm test` (pre-push patch-coverage / vitest) — PASS (1714 tests)
- [x] `pnpm build` — PASS
- [ ] `pnpm tauri build` — SKIPPED (website/frontend mock polish only)
- [ ] E2E — SKIPPED (E2E mock playback left idle; no e2e fixture changes)

## Residual risk

Visual confirmation of the live landing mock still recommended in the deployed site preview.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7bf9-71df-7d17-ad75-3f802f973021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7bf9-71df-7d17-ad75-3f802f973021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

