### PR TITLE
fix(website): collapse gap between feature sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Cancel a pending library search debounce when the query is cleared, so a late `searchLibrary` result cannot overwrite `loadLibrary()` and hide songs again (Playwright webkit flake in `song-import` search filter). Cap Linux CI `CARGO_BUILD_JOBS` to reduce parallel `rust-lld` SIGBUS crashes while linking heavy Tauri test binaries.
 
-- Website landing: collapse the double vertical padding and soft separator between consecutive feature sections so the stem cards and the library block sit in one continuous band.
+- Website landing: collapse the soft separators and stacked padding after the stem cards and after the library cards (Synced lyrics / Portable library) so those blocks flow into the closing CTA as one continuous band.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Cancel a pending library search debounce when the query is cleared, so a late `searchLibrary` result cannot overwrite `loadLibrary()` and hide songs again (Playwright webkit flake in `song-import` search filter). Cap Linux CI `CARGO_BUILD_JOBS` to reduce parallel `rust-lld` SIGBUS crashes while linking heavy Tauri test binaries.
 
-- Website landing: collapse the soft separators and stacked padding after the stem cards and after the library cards (Synced lyrics / Portable library) so those blocks flow into the closing CTA as one continuous band; enlarge the closing Download / View source pills to match the hero CTA scale and optically center their labels (`line-height: 1` + a 1px top nudge for Inter).
+- Website landing: collapse the soft separators and stacked padding after the stem cards and after the library cards (Synced lyrics / Portable library) so those blocks flow into the closing CTA as one continuous band; enlarge the closing Download / View source pills to match the hero CTA scale and optically center their labels (`line-height: 1` + a `translateY` label nudge — asymmetric padding only half-shifts flex children).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Cancel a pending library search debounce when the query is cleared, so a late `searchLibrary` result cannot overwrite `loadLibrary()` and hide songs again (Playwright webkit flake in `song-import` search filter). Cap Linux CI `CARGO_BUILD_JOBS` to reduce parallel `rust-lld` SIGBUS crashes while linking heavy Tauri test binaries.
 
-- Website landing: collapse the soft separators and stacked padding after the stem cards and after the library cards (Synced lyrics / Portable library) so those blocks flow into the closing CTA as one continuous band; enlarge the closing Download / View source pills to match the hero CTA scale.
+- Website landing: collapse the soft separators and stacked padding after the stem cards and after the library cards (Synced lyrics / Portable library) so those blocks flow into the closing CTA as one continuous band; enlarge the closing Download / View source pills to match the hero CTA scale and optically center their labels (`line-height: 1` + a 1px top nudge for Inter).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Cancel a pending library search debounce when the query is cleared, so a late `searchLibrary` result cannot overwrite `loadLibrary()` and hide songs again (Playwright webkit flake in `song-import` search filter). Cap Linux CI `CARGO_BUILD_JOBS` to reduce parallel `rust-lld` SIGBUS crashes while linking heavy Tauri test binaries.
 
+- Website landing: collapse the double vertical padding and soft separator between consecutive feature sections so the stem cards and the library block sit in one continuous band.
+
 ### Changed
 
 - Website landing preview polish: tighten the product-mock halo so the under-glow sits close to the window tail (Linear-style side/bottom spacing), keep the light-mode halo below the mock top with a seamless fade into the stage gray, and keep all eight Built-with logos on one desktop row.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Cancel a pending library search debounce when the query is cleared, so a late `searchLibrary` result cannot overwrite `loadLibrary()` and hide songs again (Playwright webkit flake in `song-import` search filter). Cap Linux CI `CARGO_BUILD_JOBS` to reduce parallel `rust-lld` SIGBUS crashes while linking heavy Tauri test binaries.
 
-- Website landing: collapse the soft separators and stacked padding after the stem cards and after the library cards (Synced lyrics / Portable library) so those blocks flow into the closing CTA as one continuous band.
+- Website landing: collapse the soft separators and stacked padding after the stem cards and after the library cards (Synced lyrics / Portable library) so those blocks flow into the closing CTA as one continuous band; enlarge the closing Download / View source pills to match the hero CTA scale.
 
 ### Changed
 

--- a/website/src/LandingPage.tsx
+++ b/website/src/LandingPage.tsx
@@ -231,7 +231,7 @@ export function LandingPage() {
               className="pill pill-primary pill-small"
               href="https://github.com/thedavidweng/OpenKara/releases/latest"
             >
-              {copy.download}
+              <span className="pill-label">{copy.download}</span>
             </a>
           </div>
         </nav>
@@ -246,7 +246,9 @@ export function LandingPage() {
               className="pill pill-primary"
               href="https://github.com/thedavidweng/OpenKara/releases/latest"
             >
-              <Download size={16} /> {copy.primary}
+              <span className="pill-label">
+                <Download size={16} /> {copy.primary}
+              </span>
             </a>
             <a
               className="pill pill-secondary"
@@ -254,7 +256,9 @@ export function LandingPage() {
               target="_blank"
               rel="noreferrer"
             >
-              <Play size={15} fill="currentColor" /> {copy.secondary}
+              <span className="pill-label">
+                <Play size={15} fill="currentColor" /> {copy.secondary}
+              </span>
             </a>
             <span>{copy.platform}</span>
           </div>
@@ -326,7 +330,7 @@ export function LandingPage() {
               className="pill pill-primary"
               href="https://github.com/thedavidweng/OpenKara/releases/latest"
             >
-              {copy.download}
+              <span className="pill-label">{copy.download}</span>
             </a>
             <a
               className="pill pill-secondary"
@@ -334,7 +338,7 @@ export function LandingPage() {
               target="_blank"
               rel="noreferrer"
             >
-              {copy.source}
+              <span className="pill-label">{copy.source}</span>
             </a>
           </div>
         </section>

--- a/website/src/site.css
+++ b/website/src/site.css
@@ -209,6 +209,9 @@ a {
   align-items: center;
   justify-content: center;
   gap: 7px;
+  /* Landing sets line-height: 1.5; keep pills on a tight line box so flex
+     centering matches the glyph band instead of a tall inherited strut. */
+  line-height: 1;
   font-size: 13px;
   font-weight: 620;
   transition:
@@ -272,6 +275,8 @@ a {
 .hero-actions .pill {
   min-height: clamp(48px, 4.2vw, 56px);
   padding-inline: clamp(22px, 2vw, 28px);
+  /* Inter's em-box sits optically high in tall CTAs — nudge the label down. */
+  padding-block: 1px 0;
   font-size: clamp(15px, 1.3vw, 17px);
 }
 
@@ -649,6 +654,8 @@ a {
 .closing-actions .pill {
   min-height: clamp(48px, 4.2vw, 56px);
   padding-inline: clamp(22px, 2vw, 28px);
+  /* Same optical nudge as hero CTAs (Inter sits high in tall pills). */
+  padding-block: 1px 0;
   font-size: clamp(15px, 1.3vw, 17px);
 }
 

--- a/website/src/site.css
+++ b/website/src/site.css
@@ -644,6 +644,14 @@ a {
   gap: 12px;
 }
 
+/* Match hero CTA scale — the closing Download / View source pair is the
+   page's final conversion moment and should not read smaller than the hero. */
+.closing-actions .pill {
+  min-height: clamp(48px, 4.2vw, 56px);
+  padding-inline: clamp(22px, 2vw, 28px);
+  font-size: clamp(15px, 1.3vw, 17px);
+}
+
 .site-footer {
   border-top: 1px solid var(--landing-line);
   padding-top: clamp(72px, 8vw, 122px);

--- a/website/src/site.css
+++ b/website/src/site.css
@@ -220,6 +220,16 @@ a {
     background 160ms ease;
 }
 
+/* Optical vertical centering for CTA copy. Asymmetric padding-block only
+   shifts flex children by half the delta; translateY moves the label 1:1.
+   Latin sans (Inter / system ui-sans) reads high in tall pills. */
+.pill-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  transform: translateY(0.12em);
+}
+
 .pill:hover {
   transform: translateY(-1px);
 }
@@ -275,8 +285,7 @@ a {
 .hero-actions .pill {
   min-height: clamp(48px, 4.2vw, 56px);
   padding-inline: clamp(22px, 2vw, 28px);
-  /* Inter's em-box sits optically high in tall CTAs — nudge the label down. */
-  padding-block: 1px 0;
+  padding-block: 0;
   font-size: clamp(15px, 1.3vw, 17px);
 }
 
@@ -654,8 +663,7 @@ a {
 .closing-actions .pill {
   min-height: clamp(48px, 4.2vw, 56px);
   padding-inline: clamp(22px, 2vw, 28px);
-  /* Same optical nudge as hero CTAs (Inter sits high in tall pills). */
-  padding-block: 1px 0;
+  padding-block: 0;
   font-size: clamp(15px, 1.3vw, 17px);
 }
 

--- a/website/src/site.css
+++ b/website/src/site.css
@@ -536,9 +536,10 @@ a {
   border-bottom: 1px solid var(--landing-soft-line);
 }
 
-/* Adjacent feature blocks share one seam — avoid double padding + an extra
-   soft rule between the stem cards and the library section. */
-.feature-section:has(+ .feature-section) {
+/* Feature blocks share one continuous band — collapse the soft rule and
+   stacked padding between stem cards → library cards → closing CTA. */
+.feature-section:has(+ .feature-section),
+.feature-section:has(+ .closing-section) {
   padding-bottom: 0;
   border-bottom: none;
 }
@@ -618,7 +619,7 @@ a {
 .closing-section {
   width: min(620px, calc(100% - 48px));
   margin: 0 auto;
-  padding-block: clamp(132px, 16vw, 232px);
+  padding-block: clamp(72px, 8vw, 112px) clamp(132px, 16vw, 232px);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -960,7 +961,8 @@ a {
     padding-block: 64px;
   }
 
-  .feature-section:has(+ .feature-section) {
+  .feature-section:has(+ .feature-section),
+  .feature-section:has(+ .closing-section) {
     padding-bottom: 0;
   }
 
@@ -983,7 +985,7 @@ a {
 
   .closing-section {
     width: min(100% - 28px, 620px);
-    padding-block: 96px;
+    padding-block: 64px 96px;
     gap: 30px;
   }
 

--- a/website/src/site.css
+++ b/website/src/site.css
@@ -536,6 +536,17 @@ a {
   border-bottom: 1px solid var(--landing-soft-line);
 }
 
+/* Adjacent feature blocks share one seam — avoid double padding + an extra
+   soft rule between the stem cards and the library section. */
+.feature-section:has(+ .feature-section) {
+  padding-bottom: 0;
+  border-bottom: none;
+}
+
+.feature-section + .feature-section {
+  padding-top: clamp(48px, 5vw, 72px);
+}
+
 .section-heading {
   display: grid;
   grid-template-columns: 0.72fr 1.1fr 1fr;
@@ -947,6 +958,14 @@ a {
 
   .feature-section {
     padding-block: 64px;
+  }
+
+  .feature-section:has(+ .feature-section) {
+    padding-bottom: 0;
+  }
+
+  .feature-section + .feature-section {
+    padding-top: 40px;
   }
 
   .feature-grid {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Collapse stacked padding / soft separators between adjacent feature sections and before the closing CTA so the stem cards and library cards flow as one continuous band.
- Enlarge closing **Download** / **View source** pills to match the hero CTA scale.
- Optically center pill CTA labels: wrap copy in `.pill-label` and nudge with `translateY(0.12em)` (asymmetric `padding-block` only half-shifts flex children).

## Screenshots

### Feature section flow (light)
Before:
![Feature sections before](https://cursor.com/artifacts/c/art-2afbce6c-b4e0-4b11-985f-fd9bb52c9991)

After:
![Feature sections after](https://cursor.com/artifacts/c/art-88f8e292-f921-4075-99e9-c3c5a6661950)

### Library → closing CTA
![Library to closing after](https://cursor.com/artifacts/c/art-56e7e172-dcb2-4bcd-ade1-cd1093b43914)

### Closing CTA label centering
![Closing CTA buttons light](https://cursor.com/artifacts/c/art-6a9b73c9-1f32-4be6-a342-dcb70ec24d9a)
![Closing CTA buttons dark](https://cursor.com/artifacts/c/art-7fa25698-da7c-4d32-8dd2-0b6ca98f425c)
![Download ink guides](https://cursor.com/artifacts/c/art-685dcf40-078f-4c72-9c43-1825e3d5cce7)

## Verification
- [x] `pnpm docs:build` — PASS
- [x] Pre-push: format-check, lint, vitest (1713) + patch-coverage — PASS
- [ ] `pnpm tauri build` — SKIPPED (website-only)

## Residual risk
Optical centering is tuned for the current system/Inter stack and 48–56px CTA height; other font loads may need a small nudge retune.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7bf9-71df-7d17-ad75-3f802f973021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7bf9-71df-7d17-ad75-3f802f973021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

