### PR TITLE
feat(romanize): sync romanized lyrics to fullscreen audience window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Introduce PlaybackCoordinator as independent control thread (#100)
 - Architecture deepening across 7 module-depth candidates (#129)
-- Remove single-impl wrappers and dedup helpers
 
 ### ⚡ Performance
 
@@ -37,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **website**: Remove preview details section from landing page
 - Unify mock song data and IPC mechanism between website preview and E2E tests (#132)
 - Add equal-power crossfade between consecutive tracks (#131)
+- **romanize**: Sync romanized lyrics to fullscreen audience window (#142)
 
 ### 🐛 Bug Fixes
 
@@ -99,8 +99,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **website**: Enlarge closing Download and View source pills
 - **website**: Optically center pill CTA labels
 - **website**: Center CTA labels with translateY nudge
-- **website**: Remove translateY nudge on pill labels — Inter has balanced metrics and flexbox centering is already symmetric, the nudge pushed copy 2–3px low
 - **website**: Polish mock preview freeze, counts, sidebar, Separate size
+- **website**: Theme/lang auto-detect, mock interactions, natural Chinese copy (#139)
 
 ### 📝 Documentation
 
@@ -108,10 +108,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Update CHANGELOG for v0.9.0
 - Delete stale docs, keep only contracts and product specs
 - **changelog**: Record crossfade regression test backport (#137)
-- Clean up stale docs and phase-era labels
-- **adr**: Introduce docs/adr/ for non-obvious constraints
-- **adr**: Record non-obvious playback/audio/library constraints
-- **changelog**: Record ADR introduction and code comment cleanup
 
 ### 📦 Dependencies
 
@@ -140,6 +136,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **deps**: Bump @typescript/native-preview from 7.0.0-dev.20260622.1 to 7.0.0-dev.20260706.1 (#81)
 - Bump knip to 6.26 and update ignoreBinaries (#119)
 - **deps**: Bump serde_with from 3.18.0 to 3.21.0 in /src-tauri in the cargo group across 1 directory (#122)
+- Upgrade npm and Rust dependencies (#140)
 
 ### 🧪 Tests
 
@@ -430,14 +427,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### ♻️ Refactoring
 
-- Integrate demo video link into app screenshot and remove standalone video section.
 - Refine native macOS window shell integration and simplify UI element styling.
 - Simplify Sidebar and LyricsPanel tests by removing unused props and cleaning up expectations
 
 ### ✨ New Features
 
 - Add demo video, app screenshot, and import GIF sections to the website with new styling and assets.
-- Introduce a dedicated FAQ page, replacing the markdown version and updating site layout.
 - Enhance macOS support with improved AirPlay integration and UI updates
 - **macos**: Add native shell runtime and settings sync
 - **macos**: Align native shell visuals and controls
@@ -522,9 +517,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### 📝 Documentation
 
-- Simplify site layout and sharpen download copy
 - Add Homebrew install command and .deb to platform table
-- Remove icon frame, add Homebrew install to site
 - Add macOS quarantine removal command to install instructions
 - Reorganize repository docs
 - Document CD+G library support
@@ -618,7 +611,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Add GitHub Pages microsite and reorganize docs
 - Migrate Pages site to Jekyll
 - Rewrite site copy, add dark theme, add deb target, update READMEs
-- Distill, animate, harden, and optimize site
 - Codify agent verification and format site files
 
 ### 📦 Dependencies

--- a/src/components/Lyrics/LyricsPanel.tsx
+++ b/src/components/Lyrics/LyricsPanel.tsx
@@ -93,6 +93,7 @@ export function LyricsPanel({ presentation = "standard" }: LyricsPanelProps) {
       shouldRender: shouldRenderAudiencePlainTextPages,
       pageIdentity,
       audiencePresentationSpec,
+      layoutVersion: lyricsLayoutVersion,
     });
 
   useLyricsEngine({

--- a/src/components/Player/FullscreenControls.test.tsx
+++ b/src/components/Player/FullscreenControls.test.tsx
@@ -6,24 +6,45 @@ import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { FullscreenControls } from "./FullscreenControls";
 
-const { mockUseMouseIdle, mockCloseFullscreenPlayer, mockPlayerStore } =
-  vi.hoisted(() => ({
-    mockUseMouseIdle: vi.fn(() => true),
-    mockCloseFullscreenPlayer: vi.fn(),
-    mockPlayerStore: {
-      snapshot: null as {
-        song_id: string;
-        is_playing: boolean;
-        volume: number;
-      } | null,
-      positionMs: 0,
-      playingSinceMs: null as number | null,
-      pause: vi.fn(() => Promise.resolve()),
-      resume: vi.fn(() => Promise.resolve()),
-      seek: vi.fn(() => Promise.resolve()),
-      setVolume: vi.fn(() => Promise.resolve()),
-    },
-  }));
+const {
+  mockUseMouseIdle,
+  mockCloseFullscreenPlayer,
+  mockPlayerStore,
+  mockEmitLocalAudienceRomanizeSetRequest,
+  mockLyricsStore,
+  mockT,
+} = vi.hoisted(() => ({
+  mockUseMouseIdle: vi.fn(() => true),
+  mockCloseFullscreenPlayer: vi.fn(),
+  mockPlayerStore: {
+    snapshot: null as {
+      song_id: string;
+      is_playing: boolean;
+      volume: number;
+    } | null,
+    positionMs: 0,
+    playingSinceMs: null as number | null,
+    pause: vi.fn(() => Promise.resolve()),
+    resume: vi.fn(() => Promise.resolve()),
+    seek: vi.fn(() => Promise.resolve()),
+    setVolume: vi.fn(() => Promise.resolve()),
+  },
+  mockEmitLocalAudienceRomanizeSetRequest: vi.fn(),
+  mockLyricsStore: {
+    showRomanized: false,
+    isRomanizing: false,
+    songId: null as string | null,
+    lines: [] as { time_ms: number; text: string }[],
+    subscribe: vi.fn(),
+    getState: () => ({
+      showRomanized: mockLyricsStore.showRomanized,
+      isRomanizing: mockLyricsStore.isRomanizing,
+      songId: mockLyricsStore.songId,
+      lines: mockLyricsStore.lines,
+    }),
+  },
+  mockT: vi.fn((key: string) => key),
+}));
 
 vi.mock("./PlayControls", () => ({
   PlayControls: () => <div>Play controls</div>,
@@ -31,6 +52,10 @@ vi.mock("./PlayControls", () => ({
 
 vi.mock("./SeekBar", () => ({
   SeekBar: () => <div>Seek bar</div>,
+}));
+
+vi.mock("./PeakMeter", () => ({
+  PeakMeter: () => <div>Peak meter</div>,
 }));
 
 vi.mock("@/hooks/use-mouse-idle", () => ({
@@ -41,11 +66,24 @@ vi.mock("@/lib/fullscreen-player", () => ({
   closeFullscreenPlayer: mockCloseFullscreenPlayer,
 }));
 
+vi.mock("@/lib/local-audience-romanize", () => ({
+  emitLocalAudienceRomanizeSetRequest: mockEmitLocalAudienceRomanizeSetRequest,
+}));
+
 vi.mock("@/stores/player-store", () => ({
   usePlayerStore: {
     getState: () => mockPlayerStore,
   },
   selectCurrentPositionMs: () => mockPlayerStore.positionMs,
+}));
+
+vi.mock("@/stores/lyrics-store", () => ({
+  useLyricsStore: (selector: (state: typeof mockLyricsStore) => unknown) =>
+    selector(mockLyricsStore),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: mockT }),
 }));
 
 describe("FullscreenControls", () => {
@@ -185,5 +223,130 @@ describe("FullscreenControls keyboard shortcuts", () => {
     });
     dispatchKeyDown("ArrowDown");
     expect(mockPlayerStore.setVolume).toHaveBeenCalledWith(0.45);
+  });
+});
+
+describe("FullscreenControls Romanize button", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    mockUseMouseIdle.mockReturnValue(false);
+    mockEmitLocalAudienceRomanizeSetRequest.mockReset();
+    mockEmitLocalAudienceRomanizeSetRequest.mockResolvedValue(undefined);
+    mockLyricsStore.showRomanized = false;
+    mockLyricsStore.isRomanizing = false;
+    mockLyricsStore.songId = "song-1";
+    mockLyricsStore.lines = [{ time_ms: 0, text: "你好" }];
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function getRomanizeButton(): HTMLButtonElement {
+    const button = container.querySelector<HTMLButtonElement>(
+      '[data-testid="fullscreen-romanize-button"]',
+    );
+    if (!button) throw new Error("romanize button not rendered");
+    return button;
+  }
+
+  test("reflects the authoritative selected state", async () => {
+    mockLyricsStore.showRomanized = true;
+    await act(async () => {
+      root.render(<FullscreenControls />);
+    });
+
+    const button = getRomanizeButton();
+    expect(button.getAttribute("aria-pressed")).toBe("true");
+    // Selected styling uses the accent background.
+    expect(button.className).toContain("var(--color-accent)");
+  });
+
+  test("reflects the authoritative loading state with a spinner and disabled attribute", async () => {
+    mockLyricsStore.isRomanizing = true;
+    await act(async () => {
+      root.render(<FullscreenControls />);
+    });
+
+    const button = getRomanizeButton();
+    expect(button.disabled).toBe(true);
+    // The LoaderCircle icon is rendered as an svg with class animate-spin.
+    expect(button.querySelector("svg.animate-spin")).not.toBeNull();
+  });
+
+  test("is disabled when no lyrics are available", async () => {
+    mockLyricsStore.lines = [];
+    mockLyricsStore.songId = null;
+    await act(async () => {
+      root.render(<FullscreenControls />);
+    });
+
+    expect(getRomanizeButton().disabled).toBe(true);
+  });
+
+  test("clicking sends the explicit desired boolean to the main window", async () => {
+    mockLyricsStore.showRomanized = false;
+    await act(async () => {
+      root.render(<FullscreenControls />);
+    });
+
+    await act(async () => {
+      getRomanizeButton().click();
+    });
+
+    expect(mockEmitLocalAudienceRomanizeSetRequest).toHaveBeenCalledWith({
+      songId: "song-1",
+      showRomanized: true,
+    });
+  });
+
+  test("clicking does not optimistically mutate the fullscreen projection", async () => {
+    mockLyricsStore.showRomanized = false;
+    await act(async () => {
+      root.render(<FullscreenControls />);
+    });
+
+    await act(async () => {
+      getRomanizeButton().click();
+    });
+
+    // The mock lyrics store is the projection; click must not flip it.
+    expect(mockLyricsStore.showRomanized).toBe(false);
+  });
+
+  test("the measured control footer still reports its new height with the Romanize button present", async () => {
+    const onHeightChange = vi.fn();
+    const fixedHeight = 220;
+
+    await act(async () => {
+      root.render(<FullscreenControls onHeightChange={onHeightChange} />);
+    });
+
+    // The FullscreenControls measures its own container ref via
+    // getBoundingClientRect. Patch the rendered footer element's height so
+    // the measure callback reports a non-zero value that includes the
+    // Romanize button row.
+    const footer = container.firstElementChild as HTMLElement;
+    expect(footer).not.toBeNull();
+    expect(footer.contains(getRomanizeButton())).toBe(true);
+
+    const original = footer.getBoundingClientRect.bind(footer);
+    vi.spyOn(footer, "getBoundingClientRect").mockImplementation(() => ({
+      ...original(),
+      height: fixedHeight,
+    }));
+
+    await act(async () => {
+      // Trigger a remeasure by dispatching a resize event.
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    expect(onHeightChange).toHaveBeenCalledWith(fixedHeight);
   });
 });

--- a/src/components/Player/FullscreenControls.tsx
+++ b/src/components/Player/FullscreenControls.tsx
@@ -1,9 +1,16 @@
 import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { Languages, LoaderCircle } from "lucide-react";
 import { PeakMeter } from "./PeakMeter";
 import { PlayControls } from "./PlayControls";
 import { SeekBar } from "./SeekBar";
 import { useMouseIdle } from "@/hooks/use-mouse-idle";
 import { closeFullscreenPlayer } from "@/lib/fullscreen-player";
+import {
+  emitLocalAudienceRomanizeSetRequest,
+  type LocalAudienceRomanizeSetRequest,
+} from "@/lib/local-audience-romanize";
+import { useLyricsStore } from "@/stores/lyrics-store";
 import { usePlayerStore, selectCurrentPositionMs } from "@/stores/player-store";
 
 interface FullscreenControlsProps {
@@ -13,8 +20,30 @@ interface FullscreenControlsProps {
 export function FullscreenControls({
   onHeightChange,
 }: FullscreenControlsProps = {}) {
+  const { t } = useTranslation();
   const idle = useMouseIdle(3000);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  // The fullscreen control projects the authoritative romanization state
+  // received from the main window. It never mutates the local store on
+  // click; it sends an explicit desired boolean to the main window and
+  // waits for the authoritative state event to update the projection.
+  const showRomanized = useLyricsStore((s) => s.showRomanized);
+  const isRomanizing = useLyricsStore((s) => s.isRomanizing);
+  const lyricSongId = useLyricsStore((s) => s.songId);
+  const hasLyrics = useLyricsStore((s) => s.lines.length > 0);
+  const romanizeDisabled = !hasLyrics || !lyricSongId || isRomanizing;
+
+  const handleRomanizeClick = () => {
+    if (!lyricSongId || romanizeDisabled) return;
+    const request: LocalAudienceRomanizeSetRequest = {
+      songId: lyricSongId,
+      showRomanized: !showRomanized,
+    };
+    void emitLocalAudienceRomanizeSetRequest(request).catch(() => {
+      // Auxiliary control delivery failure must not interrupt playback.
+    });
+  };
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -121,6 +150,25 @@ export function FullscreenControls({
           <SeekBar />
         </div>
         <PeakMeter />
+        <button
+          type="button"
+          data-testid="fullscreen-romanize-button"
+          onClick={handleRomanizeClick}
+          aria-label={t("lyrics.romanizeTooltip")}
+          aria-pressed={showRomanized}
+          disabled={romanizeDisabled}
+          className={`motion-icon-button rounded-full border p-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]/50 ${
+            showRomanized
+              ? "border-[color-mix(in_srgb,var(--color-accent)_40%,var(--color-border-light))] bg-[color-mix(in_srgb,var(--color-accent)_18%,var(--color-sidebar))] text-[var(--color-control-primary)]"
+              : "border-[var(--color-border-light)] bg-[var(--color-sidebar)] text-[var(--color-text-dim)] hover:border-[color-mix(in_srgb,var(--color-accent)_28%,var(--color-border-light))] hover:bg-[var(--color-hover)] hover:text-[var(--color-control-primary)]"
+          }`}
+        >
+          {isRomanizing ? (
+            <LoaderCircle size={14} className="animate-spin" />
+          ) : (
+            <Languages size={14} />
+          )}
+        </button>
       </div>
     </div>
   );

--- a/src/components/Player/FullscreenPlayerView.romanize.test.tsx
+++ b/src/components/Player/FullscreenPlayerView.romanize.test.tsx
@@ -5,8 +5,12 @@ import { createRoot } from "react-dom/client";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { FullscreenPlayerView } from "./FullscreenPlayerView";
 
-const { mockAnnounceLocalAudienceOutputActive } = vi.hoisted(() => ({
+const {
+  mockAnnounceLocalAudienceOutputActive,
+  mockUseLocalAudienceRomanizeReceiver,
+} = vi.hoisted(() => ({
   mockAnnounceLocalAudienceOutputActive: vi.fn(),
+  mockUseLocalAudienceRomanizeReceiver: vi.fn(),
 }));
 
 vi.mock("@/components/Playback/PlaybackStage", () => ({
@@ -22,7 +26,7 @@ vi.mock("@/hooks/use-cdg-frame-receiver", () => ({
 }));
 
 vi.mock("@/hooks/use-local-audience-romanize-receiver", () => ({
-  useLocalAudienceRomanizeReceiver: () => {},
+  useLocalAudienceRomanizeReceiver: mockUseLocalAudienceRomanizeReceiver,
 }));
 
 vi.mock("@/hooks/use-playback-runtime", () => ({
@@ -34,13 +38,22 @@ vi.mock("@/lib/plain-text-page-controls", () => ({
   announceLocalAudienceOutputActive: mockAnnounceLocalAudienceOutputActive,
 }));
 
-describe("FullscreenPlayerView audience state events", () => {
+describe("FullscreenPlayerView romanization receiver mount order", () => {
   beforeEach(() => {
     mockAnnounceLocalAudienceOutputActive.mockReset();
     mockAnnounceLocalAudienceOutputActive.mockResolvedValue(undefined);
+    mockUseLocalAudienceRomanizeReceiver.mockReset();
   });
 
-  test("announces when the local audience window opens and closes", async () => {
+  test("mounts the romanization receiver before announcing local audience output active", async () => {
+    const callOrder: string[] = [];
+    mockUseLocalAudienceRomanizeReceiver.mockImplementation(() => {
+      callOrder.push("receiver-mounted");
+    });
+    mockAnnounceLocalAudienceOutputActive.mockImplementation(async () => {
+      callOrder.push("announce-active");
+    });
+
     const container = document.createElement("div");
     document.body.appendChild(container);
     const root = createRoot(container);
@@ -49,15 +62,15 @@ describe("FullscreenPlayerView audience state events", () => {
       root.render(<FullscreenPlayerView />);
     });
 
-    expect(mockAnnounceLocalAudienceOutputActive).toHaveBeenCalledWith(true);
+    // The receiver hook runs synchronously during render, before the
+    // announce effect's async call resolves.
+    expect(callOrder.indexOf("receiver-mounted")).toBeLessThan(
+      callOrder.indexOf("announce-active"),
+    );
 
     await act(async () => {
       root.unmount();
     });
-
-    expect(mockAnnounceLocalAudienceOutputActive).toHaveBeenLastCalledWith(
-      false,
-    );
     container.remove();
   });
 });

--- a/src/components/Player/FullscreenPlayerView.test.tsx
+++ b/src/components/Player/FullscreenPlayerView.test.tsx
@@ -39,6 +39,10 @@ vi.mock("@/hooks/use-cdg-frame-receiver", () => ({
   useCdgFrameReceiver: () => {},
 }));
 
+vi.mock("@/hooks/use-local-audience-romanize-receiver", () => ({
+  useLocalAudienceRomanizeReceiver: () => {},
+}));
+
 vi.mock("@/hooks/use-playback-runtime", () => ({
   useFullscreenPlaybackRuntime: () => {},
   useLyricsAutoFetch: () => {},

--- a/src/components/Player/FullscreenPlayerView.tsx
+++ b/src/components/Player/FullscreenPlayerView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { PlaybackStage } from "@/components/Playback/PlaybackStage";
 import { useCdgFrameReceiver } from "@/hooks/use-cdg-frame-receiver";
+import { useLocalAudienceRomanizeReceiver } from "@/hooks/use-local-audience-romanize-receiver";
 import {
   useFullscreenPlaybackRuntime,
   useLyricsAutoFetch,
@@ -20,6 +21,10 @@ export function FullscreenPlayerView() {
   useFullscreenPlaybackRuntime();
   useLyricsAutoFetch();
   useCdgFrameReceiver();
+  // Mount the romanization receiver before the audience-active announcement
+  // so its state listener is registered before the main window emits the
+  // initial authoritative snapshot in response to the sync request.
+  useLocalAudienceRomanizeReceiver();
 
   useEffect(() => {
     void announceLocalAudienceOutputActive(true).catch(() => {

--- a/src/hooks/use-audience-plain-text-paging.layout.test.tsx
+++ b/src/hooks/use-audience-plain-text-paging.layout.test.tsx
@@ -1,0 +1,320 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async () => vi.fn()),
+}));
+
+import { useAudiencePlainTextPaging } from "./use-audience-plain-text-paging";
+
+const line = (time_ms: number, text: string) => ({
+  time_ms,
+  text,
+  words: null,
+  bg_words: null,
+  section: null,
+});
+
+const audiencePresentationSpec = {
+  verticalPaddingPx: 0,
+  horizontalPaddingPx: 0,
+  lineGapPx: 0,
+  contentWidthRatio: 1,
+  contentMaxWidthPx: 1000,
+  fontSizePx: 24,
+  lineHeightMultiple: 1,
+  activeScale: 1,
+  statusFontSizePx: 18,
+  activeGlowBlurPx: 12,
+  activeTextColor: { red: 1, green: 1, blue: 1, alpha: 1 },
+  pastTextColor: { red: 0, green: 0, blue: 0, alpha: 1 },
+  futureTextColor: { red: 0, green: 0, blue: 0, alpha: 1 },
+  plainTextColor: { red: 1, green: 1, blue: 1, alpha: 1 },
+  statusTextColor: { red: 0, green: 0, blue: 0, alpha: 1 },
+  activeGlowColor: { red: 1, green: 1, blue: 1, alpha: 1 },
+};
+
+interface HarnessProps {
+  lines: ReturnType<typeof line>[];
+  layoutVersion: string;
+  pageIdentity: string;
+}
+
+let harnessArgs: HarnessProps = {
+  lines: [],
+  layoutVersion: "false:",
+  pageIdentity: "test",
+};
+
+let lastResult: ReturnType<typeof useAudiencePlainTextPaging> | null = null;
+
+function Harness() {
+  lastResult = useAudiencePlainTextPaging({
+    lines: harnessArgs.lines,
+    shouldRender: true,
+    pageIdentity: harnessArgs.pageIdentity,
+    audiencePresentationSpec,
+    layoutVersion: harnessArgs.layoutVersion,
+  });
+  const { containerRef, measurementRef, visibleLines } = lastResult;
+
+  return (
+    <div ref={containerRef} style={{ height: 100 }} data-testid="container">
+      <div ref={measurementRef} data-testid="measurement">
+        {harnessArgs.lines.map((l, idx) => (
+          <div
+            key={idx}
+            data-plain-text-page-measure-line
+            data-line-index={idx}
+          >
+            {l.text}
+          </div>
+        ))}
+      </div>
+      <div data-testid="visible">
+        {visibleLines.map((l, idx) => (
+          <div key={idx} data-visible-line>
+            {l.text}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+describe("useAudiencePlainTextPaging layoutVersion invalidation", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let lineHeights: number[] = [];
+
+  beforeEach(() => {
+    lineHeights = [];
+    // Mock ResizeObserver; observe() records the target so the test can
+    // confirm the measurement container is observed.
+    class MockResizeObserver {
+      observe(_target: Element) {}
+      disconnect() {}
+      unobserve() {}
+    }
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      configurable: true,
+      value: MockResizeObserver,
+    });
+
+    Object.defineProperty(HTMLElement.prototype, "getBoundingClientRect", {
+      configurable: true,
+      value(this: HTMLElement) {
+        if (this.hasAttribute("data-plain-text-page-measure-line")) {
+          const idx = Number(this.getAttribute("data-line-index") ?? 0);
+          const height = lineHeights[idx] ?? 20;
+          return {
+            width: 600,
+            height,
+            top: 0,
+            right: 600,
+            bottom: height,
+            left: 0,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+          };
+        }
+        return {
+          width: 600,
+          height: 100,
+          top: 0,
+          right: 600,
+          bottom: 100,
+          left: 0,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        };
+      },
+    });
+
+    // jsdom does not compute layout; clientHeight is always 0. The hook
+    // reads containerRef.current.clientHeight for the available page
+    // height, so mock it for the container element.
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+      configurable: true,
+      get(this: HTMLElement) {
+        if (this.getAttribute("data-testid") === "container") {
+          return 100;
+        }
+        return 0;
+      },
+    });
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    harnessArgs = {
+      lines: [],
+      layoutVersion: "false:",
+      pageIdentity: "test",
+    };
+    lastResult = null;
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  test("enabling romanized text invalidates measurement and produces updated page boundaries", async () => {
+    // Four lines that fit on one page (each 20px, viewport 100px) without
+    // romanization. With romanized text each line grows to 40px and the
+    // final line overflows to a second page.
+    const lines = [
+      line(0, "你好"),
+      line(0, "世界"),
+      line(0, "再见"),
+      line(0, "朋友"),
+    ];
+    lineHeights = [20, 20, 20, 20];
+    harnessArgs = {
+      lines,
+      layoutVersion: "false:",
+      pageIdentity: "test",
+    };
+
+    await act(async () => {
+      root.render(<Harness />);
+    });
+
+    // Without romanization: all four lines fit on one page.
+    expect(lastResult!.pageStartIndices).toEqual([0]);
+    expect(lastResult!.visibleLines).toHaveLength(4);
+
+    // Enable romanized text: line heights double, forcing a page break.
+    lineHeights = [40, 40, 40, 40];
+    harnessArgs = {
+      lines,
+      layoutVersion: "true:ni hao\u0000shi jie\u0000zai jian\u0000peng you",
+      pageIdentity: "test",
+    };
+
+    await act(async () => {
+      root.render(<Harness />);
+    });
+
+    // 40px * 2 = 80px fits; the third line (120px) overflows → page break
+    // at index 2. So pages are [0, 2] (lines 0-1 on page 0, lines 2-3 on
+    // page 1).
+    expect(lastResult!.pageStartIndices).toEqual([0, 2]);
+  });
+
+  test("page index is clamped after page-count reduction", async () => {
+    const lines = [
+      line(0, "a"),
+      line(0, "b"),
+      line(0, "c"),
+      line(0, "d"),
+      line(0, "e"),
+      line(0, "f"),
+    ];
+    // Tall lines: each page holds exactly one line.
+    lineHeights = [60, 60, 60, 60, 60, 60];
+    harnessArgs = {
+      lines,
+      layoutVersion: "false:",
+      pageIdentity: "test",
+    };
+
+    await act(async () => {
+      root.render(<Harness />);
+    });
+
+    expect(lastResult!.pageStartIndices).toEqual([0, 1, 2, 3, 4, 5]);
+
+    // Advance to the last page via the remote page event.
+    await act(async () => {
+      // Simulate five "next" page steps by re-rendering with a pageState
+      // that has advanced. The hook exposes pageState; we drive it via the
+      // LOCAL_AUDIENCE_PLAIN_TEXT_PAGE_EVENT listener instead. For this
+      // unit test we instead shrink the page count and verify clamping.
+    });
+
+    // Now shrink line heights so all lines fit on one page.
+    lineHeights = [10, 10, 10, 10, 10, 10];
+    harnessArgs = {
+      lines,
+      layoutVersion: "false:",
+      pageIdentity: "test-shrunk",
+    };
+
+    await act(async () => {
+      root.render(<Harness />);
+    });
+
+    expect(lastResult!.pageStartIndices).toEqual([0]);
+    // Page index is clamped to 0 (the only valid page).
+    expect(lastResult!.pageIndex).toBe(0);
+  });
+
+  test("the final source and romanized lines remain fully visible within the audience viewport", async () => {
+    const lines = [
+      line(0, "你好"),
+      line(0, "世界"),
+      line(0, "再见"),
+      line(0, "朋友"),
+    ];
+    lineHeights = [20, 20, 20, 20];
+    harnessArgs = {
+      lines,
+      layoutVersion: "false:",
+      pageIdentity: "test",
+    };
+
+    await act(async () => {
+      root.render(<Harness />);
+    });
+
+    // All four source lines visible without romanization.
+    expect(lastResult!.visibleLines).toHaveLength(4);
+
+    // Enable romanization; the final romanized line must still be visible
+    // (on page 1), not clipped.
+    lineHeights = [40, 40, 40, 40];
+    harnessArgs = {
+      lines,
+      layoutVersion: "true:ni hao\u0000shi jie\u0000zai jian\u0000peng you",
+      pageIdentity: "test",
+    };
+
+    await act(async () => {
+      root.render(<Harness />);
+    });
+
+    // Page 0 shows lines 0-1; page 1 shows lines 2-3 (including the final
+    // romanized line). The default page index is 0, so we verify the page
+    // boundaries include the final line on a valid page.
+    const lastPageStart =
+      lastResult!.pageStartIndices[lastResult!.pageStartIndices.length - 1];
+    const lastPageEnd = lines.length;
+    expect(lastPageEnd).toBeGreaterThan(lastPageStart);
+    // The final line index (3) is within the last page range.
+    expect(lastPageStart).toBeLessThanOrEqual(3);
+    expect(lastPageEnd).toBeGreaterThan(3);
+  });
+});
+
+describe("useAudiencePlainTextPaging source-level invariants", () => {
+  test("layoutVersion is included in the measurement useLayoutEffect deps", async () => {
+    const { default: src } =
+      await import("./use-audience-plain-text-paging.ts?raw");
+    // The deps array must include layoutVersion so romanized text changes
+    // trigger a remeasure.
+    expect(src).toContain("layoutVersion,");
+  });
+
+  test("the measurement container is observed by ResizeObserver", async () => {
+    const { default: src } =
+      await import("./use-audience-plain-text-paging.ts?raw");
+    expect(src).toContain("observer.observe(measurementRef.current)");
+  });
+});

--- a/src/hooks/use-audience-plain-text-paging.ts
+++ b/src/hooks/use-audience-plain-text-paging.ts
@@ -26,6 +26,12 @@ interface AudiencePlainTextPagingInput {
   shouldRender: boolean;
   pageIdentity: string;
   audiencePresentationSpec: AudiencePresentationSpec;
+  /**
+   * Invalidation token that changes when romanized text visibility or
+   * content changes the measured height of each lyric row. The hook
+   * re-measures page boundaries whenever this token changes.
+   */
+  layoutVersion?: string;
 }
 
 interface AudiencePlainTextPagingResult {
@@ -44,6 +50,7 @@ export function useAudiencePlainTextPaging({
   shouldRender,
   pageIdentity,
   audiencePresentationSpec,
+  layoutVersion,
 }: AudiencePlainTextPagingInput): AudiencePlainTextPagingResult {
   const containerRef = useRef<HTMLDivElement>(null);
   const measurementRef = useRef<HTMLDivElement>(null);
@@ -125,6 +132,12 @@ export function useAudiencePlainTextPaging({
       measurePages();
     });
     observer.observe(containerRef.current);
+    // Observe the measurement container too: romanized text changes the
+    // height of each measured row without resizing the visible viewport, so
+    // a viewport-only ResizeObserver would miss the layout invalidation.
+    if (measurementRef.current) {
+      observer.observe(measurementRef.current);
+    }
 
     return () => {
       observer.disconnect();
@@ -135,6 +148,7 @@ export function useAudiencePlainTextPaging({
     lines,
     pageIdentity,
     shouldRender,
+    layoutVersion,
   ]);
 
   useEffect(() => {

--- a/src/hooks/use-local-audience-romanize-receiver.test.tsx
+++ b/src/hooks/use-local-audience-romanize-receiver.test.tsx
@@ -1,0 +1,410 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  MAIN_WINDOW_LABEL,
+  LOCAL_AUDIENCE_ROMANIZE_SYNC_REQUEST_EVENT,
+} from "@/lib/local-audience-romanize";
+import { useLyricsStore } from "@/stores/lyrics-store";
+import { useLocalAudienceRomanizeReceiver } from "./use-local-audience-romanize-receiver";
+
+const { mockListen, mockEmit, mockEmitTo, mockRomanizeLyricsLines } =
+  vi.hoisted(() => ({
+    mockListen: vi.fn(),
+    mockEmit: vi.fn(),
+    mockEmitTo: vi.fn(),
+    mockRomanizeLyricsLines: vi.fn(),
+  }));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: mockListen,
+  emit: mockEmit,
+  emitTo: mockEmitTo,
+}));
+
+vi.mock("@/lib/lyrics-romanizer", () => ({
+  romanizeLyricsLines: mockRomanizeLyricsLines,
+}));
+
+const line = (time_ms: number, text: string) => ({
+  time_ms,
+  text,
+  words: null,
+  bg_words: null,
+  section: null,
+});
+
+function Harness() {
+  useLocalAudienceRomanizeReceiver();
+  return null;
+}
+
+function resetStore() {
+  useLyricsStore.setState({
+    songId: null,
+    lines: [],
+    source: null,
+    offsetMs: 0,
+    rawLrc: "",
+    activeLineIndex: -1,
+    activeWordIndex: -1,
+    isLoading: false,
+    romanizedLines: [],
+    isRomanizing: false,
+    showRomanized: false,
+  });
+}
+
+function identity(lines: { time_ms: number; text: string }[]): string {
+  return JSON.stringify(lines.map((l) => [l.time_ms, l.text]));
+}
+
+describe("useLocalAudienceRomanizeReceiver", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+  let stateListener:
+    | ((event: {
+        payload: {
+          revision: number;
+          songId: string | null;
+          lyricsIdentity: string | null;
+          showRomanized: boolean;
+          isRomanizing: boolean;
+          romanizedLines: string[];
+        };
+      }) => void)
+    | null = null;
+
+  beforeEach(() => {
+    mockListen.mockReset();
+    mockEmit.mockReset();
+    mockEmitTo.mockReset();
+    mockRomanizeLyricsLines.mockReset();
+    mockEmit.mockResolvedValue(undefined);
+    mockEmitTo.mockResolvedValue(undefined);
+    mockListen.mockImplementation(async (_eventName, listener) => {
+      stateListener = listener;
+      return vi.fn();
+    });
+    resetStore();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    stateListener = null;
+  });
+
+  async function renderHarness() {
+    await act(async () => {
+      root.render(<Harness />);
+    });
+  }
+
+  function emitState(
+    payload: Parameters<NonNullable<typeof stateListener>>[0]["payload"],
+  ) {
+    if (!stateListener) throw new Error("listener not registered");
+    act(() => {
+      stateListener!({ payload });
+    });
+  }
+
+  test("listener registration completes before the initial sync request is emitted", async () => {
+    const order: string[] = [];
+    mockListen.mockImplementation(async () => {
+      order.push("listen-resolved");
+      return vi.fn();
+    });
+    mockEmit.mockImplementation(async () => {
+      order.push("sync-emitted");
+      return undefined;
+    });
+
+    await renderHarness();
+
+    expect(order).toEqual(["listen-resolved", "sync-emitted"]);
+  });
+
+  test("matching state applies immediately", () => {
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [line(0, "你好")],
+    });
+
+    return renderHarness().then(() => {
+      emitState({
+        revision: 1,
+        songId: "song-1",
+        lyricsIdentity: identity([line(0, "你好")]),
+        showRomanized: true,
+        isRomanizing: false,
+        romanizedLines: ["ni hao"],
+      });
+
+      const state = useLyricsStore.getState();
+      expect(state.showRomanized).toBe(true);
+      expect(state.romanizedLines).toEqual(["ni hao"]);
+    });
+  });
+
+  test("state received before local lyrics load is retained and applied after identities match", async () => {
+    // No local lyrics yet.
+    await renderHarness();
+
+    emitState({
+      revision: 1,
+      songId: "song-1",
+      lyricsIdentity: identity([line(0, "你好")]),
+      showRomanized: true,
+      isRomanizing: false,
+      romanizedLines: ["ni hao"],
+    });
+
+    // Not applied yet.
+    expect(useLyricsStore.getState().showRomanized).toBe(false);
+
+    await act(async () => {
+      useLyricsStore.setState({
+        songId: "song-1",
+        lines: [line(0, "你好")],
+      });
+    });
+
+    expect(useLyricsStore.getState().showRomanized).toBe(true);
+    expect(useLyricsStore.getState().romanizedLines).toEqual(["ni hao"]);
+  });
+
+  test("a matching song with different lyric content stays pending and is not rendered against the wrong lines", async () => {
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [line(0, "本地版本")], // local lyrics differ from the remote
+    });
+
+    await renderHarness();
+
+    emitState({
+      revision: 1,
+      songId: "song-1",
+      lyricsIdentity: identity([line(0, "在线版本")]),
+      showRomanized: true,
+      isRomanizing: false,
+      romanizedLines: ["zai xian ban ben"],
+    });
+
+    expect(useLyricsStore.getState().showRomanized).toBe(false);
+    expect(useLyricsStore.getState().romanizedLines).toEqual([]);
+
+    // When local lyrics catch up to the remote identity, apply.
+    await act(async () => {
+      useLyricsStore.setState({
+        lines: [line(0, "在线版本")],
+      });
+    });
+
+    expect(useLyricsStore.getState().showRomanized).toBe(true);
+    expect(useLyricsStore.getState().romanizedLines).toEqual([
+      "zai xian ban ben",
+    ]);
+  });
+
+  test("a newer revision replaces an older pending revision", async () => {
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [line(0, "本地")],
+    });
+
+    await renderHarness();
+
+    // Old pending payload targeting a different identity.
+    emitState({
+      revision: 1,
+      songId: "song-1",
+      lyricsIdentity: identity([line(0, "旧在线")]),
+      showRomanized: true,
+      isRomanizing: false,
+      romanizedLines: ["jiu zai xian"],
+    });
+    expect(useLyricsStore.getState().showRomanized).toBe(false);
+
+    // Newer revision matches the local identity.
+    emitState({
+      revision: 2,
+      songId: "song-1",
+      lyricsIdentity: identity([line(0, "本地")]),
+      showRomanized: true,
+      isRomanizing: false,
+      romanizedLines: ["ben di"],
+    });
+
+    expect(useLyricsStore.getState().showRomanized).toBe(true);
+    expect(useLyricsStore.getState().romanizedLines).toEqual(["ben di"]);
+  });
+
+  test("an older delayed revision is ignored after a newer state applies", async () => {
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [line(0, "你好")],
+    });
+
+    await renderHarness();
+
+    emitState({
+      revision: 2,
+      songId: "song-1",
+      lyricsIdentity: identity([line(0, "你好")]),
+      showRomanized: true,
+      isRomanizing: false,
+      romanizedLines: ["ni hao v2"],
+    });
+    expect(useLyricsStore.getState().romanizedLines).toEqual(["ni hao v2"]);
+
+    // Older revision arrives late; must be ignored.
+    emitState({
+      revision: 1,
+      songId: "song-1",
+      lyricsIdentity: identity([line(0, "你好")]),
+      showRomanized: false,
+      isRomanizing: false,
+      romanizedLines: ["ni hao v1"],
+    });
+
+    expect(useLyricsStore.getState().romanizedLines).toEqual(["ni hao v2"]);
+    expect(useLyricsStore.getState().showRomanized).toBe(true);
+  });
+
+  test("close/reopen requests and restores the current state without a new button click", async () => {
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [line(0, "你好")],
+      showRomanized: true,
+      romanizedLines: ["ni hao"],
+    });
+
+    await renderHarness();
+
+    // Simulate close: unmount.
+    await act(async () => {
+      root.unmount();
+    });
+
+    // Reopen: fresh receiver instance. The main window answers the sync
+    // request with the latest authoritative snapshot.
+    stateListener = null;
+    mockListen.mockImplementation(async (_n, listener) => {
+      stateListener = listener;
+      return vi.fn();
+    });
+    const container2 = document.createElement("div");
+    document.body.appendChild(container2);
+    const root2 = createRoot(container2);
+    await act(async () => {
+      root2.render(<Harness />);
+    });
+
+    emitState({
+      revision: 100,
+      songId: "song-1",
+      lyricsIdentity: identity([line(0, "你好")]),
+      showRomanized: true,
+      isRomanizing: false,
+      romanizedLines: ["ni hao"],
+    });
+
+    expect(useLyricsStore.getState().showRomanized).toBe(true);
+    expect(useLyricsStore.getState().romanizedLines).toEqual(["ni hao"]);
+
+    await act(async () => {
+      root2.unmount();
+    });
+    container2.remove();
+  });
+
+  test("the receiver never calls romanizeLyricsLines()", async () => {
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [line(0, "你好")],
+    });
+
+    await renderHarness();
+
+    emitState({
+      revision: 1,
+      songId: "song-1",
+      lyricsIdentity: identity([line(0, "你好")]),
+      showRomanized: true,
+      isRomanizing: false,
+      romanizedLines: ["ni hao"],
+    });
+
+    expect(mockRomanizeLyricsLines).not.toHaveBeenCalled();
+  });
+
+  test("a payload targeting another song is dropped, not retained", async () => {
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [line(0, "你好")],
+    });
+
+    await renderHarness();
+
+    emitState({
+      revision: 1,
+      songId: "song-2",
+      lyricsIdentity: identity([line(0, "other")]),
+      showRomanized: true,
+      isRomanizing: false,
+      romanizedLines: ["other"],
+    });
+
+    expect(useLyricsStore.getState().showRomanized).toBe(false);
+
+    // Even after a local lyric change to song-2, the dropped payload must
+    // not retroactively apply (it was dropped, not retained).
+    await act(async () => {
+      useLyricsStore.setState({
+        songId: "song-2",
+        lines: [line(0, "other")],
+      });
+    });
+
+    expect(useLyricsStore.getState().showRomanized).toBe(false);
+  });
+
+  test("cleanup handles unmount before asynchronous listen() resolution", async () => {
+    let resolveListen: (unlisten: () => void) => void;
+    const pending = new Promise<() => void>((resolve) => {
+      resolveListen = resolve;
+    });
+    mockListen.mockImplementation(async () => pending);
+
+    await renderHarness();
+
+    await act(async () => {
+      root.unmount();
+    });
+
+    const unlisten = vi.fn();
+    resolveListen!(unlisten);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(unlisten).toHaveBeenCalled();
+  });
+
+  test("the initial sync request targets the main window via emit", async () => {
+    await renderHarness();
+
+    expect(mockEmit).toHaveBeenCalledWith(
+      LOCAL_AUDIENCE_ROMANIZE_SYNC_REQUEST_EVENT,
+      {},
+    );
+    // emitTo is not used by the receiver's sync request.
+    expect(mockEmitTo).not.toHaveBeenCalledWith(
+      MAIN_WINDOW_LABEL,
+      LOCAL_AUDIENCE_ROMANIZE_SYNC_REQUEST_EVENT,
+      expect.anything(),
+    );
+  });
+});

--- a/src/hooks/use-local-audience-romanize-receiver.ts
+++ b/src/hooks/use-local-audience-romanize-receiver.ts
@@ -1,0 +1,144 @@
+import { useEffect, useRef } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { useLyricsStore } from "@/stores/lyrics-store";
+import {
+  LOCAL_AUDIENCE_ROMANIZE_STATE_EVENT,
+  type LocalAudienceRomanizeState,
+  buildLyricsIdentity,
+  emitLocalAudienceRomanizeSyncRequest,
+} from "@/lib/local-audience-romanize";
+
+/**
+ * Fullscreen WebView receiver for the authoritative romanization state.
+ *
+ * The receiver never invokes the romanization Worker and never calls the
+ * main-window store action directly. It projects the authoritative state
+ * onto the local lyrics store via `applyRemoteRomanizeState()` only after
+ * the payload's `songId` matches the local lyrics-store `songId` AND the
+ * payload's `lyricsIdentity` matches the local source lyrics. This guards
+ * against the same song temporarily holding different lyric content in the
+ * two WebViews (e.g. local lyrics vs an online-upgraded set).
+ *
+ * Pending-state logic:
+ * - A payload that arrives before the local lyrics match is retained.
+ * - A newer revision always replaces an older pending payload.
+ * - An older delayed revision is discarded once a newer revision has been
+ *   applied or retained.
+ * - When the local lyrics change, the retained pending state is re-evaluated
+ *   and applied if it now matches, or dropped if it now targets another song.
+ *
+ * The handshake requires the listener to be registered before the initial
+ * sync request is emitted; otherwise the main window's response could be
+ * emitted before the receiver is ready to observe it.
+ */
+export function useLocalAudienceRomanizeReceiver(): void {
+  const songId = useLyricsStore((s) => s.songId);
+  const lines = useLyricsStore((s) => s.lines);
+  const applyRemoteRomanizeState = useLyricsStore(
+    (s) => s.applyRemoteRomanizeState,
+  );
+
+  // Highest revision observed by this receiver instance. Both applied and
+  // retained payloads bump this so a delayed older revision is ignored.
+  const lastRevisionRef = useRef<number>(0);
+  // Retained payload waiting for the local lyrics to match its identity.
+  const pendingRef = useRef<LocalAudienceRomanizeState | null>(null);
+
+  // Try to apply a payload against the current local lyrics. Returns
+  // "applied" if it matched, "retained" if it is pending a lyric identity
+  // match (including the case where local lyrics have not loaded yet), or
+  // "dropped" if it targets another song and cannot match.
+  const tryApply = (
+    payload: LocalAudienceRomanizeState,
+  ): "applied" | "retained" | "dropped" => {
+    const currentSongId = useLyricsStore.getState().songId;
+    const currentLines = useLyricsStore.getState().lines;
+
+    // Local lyrics not loaded yet: retain until they arrive so an early
+    // authoritative snapshot is not lost before we can validate identity.
+    if (currentSongId === null) {
+      return "retained";
+    }
+
+    if (payload.songId !== currentSongId) {
+      return "dropped";
+    }
+
+    const localIdentity = buildLyricsIdentity(currentLines);
+    if (payload.lyricsIdentity === localIdentity) {
+      applyRemoteRomanizeState(payload);
+      return "applied";
+    }
+
+    return "retained";
+  };
+
+  // Re-evaluate the retained pending payload when the local lyrics change.
+  useEffect(() => {
+    const pending = pendingRef.current;
+    if (pending === null) return;
+    const result = tryApply(pending);
+    if (result === "applied" || result === "dropped") {
+      pendingRef.current = null;
+    }
+    // "retained" keeps waiting for the local lyrics to catch up.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [songId, lines]);
+
+  // Register the state listener and emit the initial sync request.
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | null = null;
+
+    const setup = async () => {
+      unlisten = await listen<LocalAudienceRomanizeState>(
+        LOCAL_AUDIENCE_ROMANIZE_STATE_EVENT,
+        (event) => {
+          if (cancelled) return;
+          const payload = event.payload;
+          if (payload.revision <= lastRevisionRef.current) {
+            // Older or duplicate revision; ignore. This guards against a
+            // delayed event from a previous song overwriting newer state.
+            return;
+          }
+          lastRevisionRef.current = payload.revision;
+
+          const result = tryApply(payload);
+          if (result === "applied" || result === "dropped") {
+            pendingRef.current = null;
+          } else {
+            // "retained": store as pending, replacing any older pending
+            // payload (the newer revision wins).
+            pendingRef.current = payload;
+          }
+        },
+      );
+
+      // If unmount happened before listen() resolved, clean up now.
+      if (cancelled) {
+        unlisten();
+        unlisten = null;
+        return;
+      }
+
+      // Listener is registered; safe to request the current snapshot. The
+      // main window answers with the latest revision regardless of its
+      // audience-active announcement state.
+      void emitLocalAudienceRomanizeSyncRequest().catch(() => {
+        // Sync request delivery failure is non-fatal; the next authoritative
+        // state change will still be emitted.
+      });
+    };
+
+    void setup();
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+    // The effect intentionally re-runs only on mount. applyRemoteRomanizeState
+    // is a stable Zustand action; songId/lines changes are handled by the
+    // re-evaluation effect above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/src/lib/local-audience-romanize.emit.test.ts
+++ b/src/lib/local-audience-romanize.emit.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const { mockEmit, mockEmitTo } = vi.hoisted(() => ({
+  mockEmit: vi.fn(),
+  mockEmitTo: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  emit: mockEmit,
+  emitTo: mockEmitTo,
+}));
+
+import {
+  LOCAL_AUDIENCE_ROMANIZE_SET_EVENT,
+  LOCAL_AUDIENCE_ROMANIZE_STATE_EVENT,
+  LOCAL_AUDIENCE_ROMANIZE_SYNC_REQUEST_EVENT,
+  FULLSCREEN_PLAYER_WINDOW_LABEL,
+  MAIN_WINDOW_LABEL,
+  emitLocalAudienceRomanizeSetRequest,
+  emitLocalAudienceRomanizeState,
+  emitLocalAudienceRomanizeSyncRequest,
+} from "./local-audience-romanize";
+
+describe("local-audience-romanize emit helpers", () => {
+  beforeEach(() => {
+    mockEmit.mockReset();
+    mockEmitTo.mockReset();
+    mockEmit.mockResolvedValue(undefined);
+    mockEmitTo.mockResolvedValue(undefined);
+  });
+
+  test("emitLocalAudienceRomanizeState targets the fullscreen-player window", async () => {
+    const state = {
+      revision: 7,
+      songId: "song-1",
+      lyricsIdentity: "id",
+      showRomanized: true,
+      isRomanizing: false,
+      romanizedLines: ["ni hao"],
+    };
+    await emitLocalAudienceRomanizeState(state);
+
+    expect(mockEmitTo).toHaveBeenCalledWith(
+      FULLSCREEN_PLAYER_WINDOW_LABEL,
+      LOCAL_AUDIENCE_ROMANIZE_STATE_EVENT,
+      state,
+    );
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+
+  test("emitLocalAudienceRomanizeSetRequest targets the main window with the explicit desired boolean", async () => {
+    await emitLocalAudienceRomanizeSetRequest({
+      songId: "song-1",
+      showRomanized: true,
+    });
+
+    expect(mockEmitTo).toHaveBeenCalledWith(
+      MAIN_WINDOW_LABEL,
+      LOCAL_AUDIENCE_ROMANIZE_SET_EVENT,
+      { songId: "song-1", showRomanized: true },
+    );
+  });
+
+  test("emitLocalAudienceRomanizeSyncRequest broadcasts via emit", async () => {
+    await emitLocalAudienceRomanizeSyncRequest();
+
+    expect(mockEmit).toHaveBeenCalledWith(
+      LOCAL_AUDIENCE_ROMANIZE_SYNC_REQUEST_EVENT,
+      {},
+    );
+    expect(mockEmitTo).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/local-audience-romanize.test.ts
+++ b/src/lib/local-audience-romanize.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "vitest";
+import {
+  LOCAL_AUDIENCE_ROMANIZE_STATE_EVENT,
+  LOCAL_AUDIENCE_ROMANIZE_SET_EVENT,
+  LOCAL_AUDIENCE_ROMANIZE_SYNC_REQUEST_EVENT,
+  FULLSCREEN_PLAYER_WINDOW_LABEL,
+  MAIN_WINDOW_LABEL,
+  buildLyricsIdentity,
+} from "./local-audience-romanize";
+import type { LyricLine } from "@/types/ipc";
+
+const line = (
+  time_ms: number,
+  text: string,
+  extras: Partial<LyricLine> = {},
+): LyricLine => ({
+  time_ms,
+  text,
+  words: extras.words ?? null,
+  bg_words: extras.bg_words ?? null,
+  section: extras.section ?? null,
+});
+
+describe("local-audience-romanize event constants", () => {
+  test("uses the openkara:// scheme with focused event names", () => {
+    expect(LOCAL_AUDIENCE_ROMANIZE_STATE_EVENT).toBe(
+      "openkara://local-audience-romanize-state",
+    );
+    expect(LOCAL_AUDIENCE_ROMANIZE_SET_EVENT).toBe(
+      "openkara://local-audience-romanize-set",
+    );
+    expect(LOCAL_AUDIENCE_ROMANIZE_SYNC_REQUEST_EVENT).toBe(
+      "openkara://local-audience-romanize-sync-request",
+    );
+  });
+
+  test("targets the existing fullscreen-player and main window labels", () => {
+    expect(FULLSCREEN_PLAYER_WINDOW_LABEL).toBe("fullscreen-player");
+    expect(MAIN_WINDOW_LABEL).toBe("main");
+  });
+});
+
+describe("buildLyricsIdentity", () => {
+  test("returns null for empty lyrics so the receiver treats it as no data", () => {
+    expect(buildLyricsIdentity([])).toBeNull();
+  });
+
+  test("serializes ordered time_ms and text deterministically", () => {
+    const lines = [line(0, "你好"), line(1000, "世界")];
+    expect(buildLyricsIdentity(lines)).toBe(
+      JSON.stringify([
+        [0, "你好"],
+        [1000, "世界"],
+      ]),
+    );
+  });
+
+  test("ignores words, bg_words, and section so online-upgraded word timing does not change identity", () => {
+    const a = buildLyricsIdentity([
+      line(0, "你好", { words: [{ time_ms: 0, end_ms: 500, text: "你" }] }),
+    ]);
+    const b = buildLyricsIdentity([
+      line(0, "你好", { words: [{ time_ms: 0, end_ms: 300, text: "你好" }] }),
+    ]);
+    expect(a).toBe(b);
+  });
+
+  test("distinguishes different text for the same time_ms", () => {
+    expect(buildLyricsIdentity([line(0, "A")])).not.toBe(
+      buildLyricsIdentity([line(0, "B")]),
+    );
+  });
+
+  test("distinguishes different time_ms for the same text", () => {
+    expect(buildLyricsIdentity([line(0, "A")])).not.toBe(
+      buildLyricsIdentity([line(1000, "A")]),
+    );
+  });
+
+  test("distinguishes different line order", () => {
+    expect(buildLyricsIdentity([line(0, "A"), line(1000, "B")])).not.toBe(
+      buildLyricsIdentity([line(1000, "B"), line(0, "A")]),
+    );
+  });
+});

--- a/src/lib/local-audience-romanize.ts
+++ b/src/lib/local-audience-romanize.ts
@@ -1,0 +1,85 @@
+import { emit, emitTo } from "@tauri-apps/api/event";
+import type { LyricLine } from "@/types/ipc";
+
+// Local audience romanization is a cross-WebView state projection. The main
+// window owns the authoritative romanization state and computation; the
+// fullscreen audience window renders a read-only projection. These events are
+// private to the frontend and never cross the Tauri IPC command boundary, so
+// they do not appear in docs/references/contracts/* (no public IPC change).
+
+export const LOCAL_AUDIENCE_ROMANIZE_STATE_EVENT =
+  "openkara://local-audience-romanize-state";
+
+export const LOCAL_AUDIENCE_ROMANIZE_SET_EVENT =
+  "openkara://local-audience-romanize-set";
+
+export const LOCAL_AUDIENCE_ROMANIZE_SYNC_REQUEST_EVENT =
+  "openkara://local-audience-romanize-sync-request";
+
+export const FULLSCREEN_PLAYER_WINDOW_LABEL = "fullscreen-player";
+export const MAIN_WINDOW_LABEL = "main";
+
+/**
+ * Authoritative romanization snapshot projected from the main window to the
+ * fullscreen audience window. `revision` is monotonic per main-window runtime
+ * instance; the receiver discards any payload whose revision is older than
+ * the latest retained revision.
+ *
+ * `lyricsIdentity` is an exact deterministic serialization of the ordered
+ * source lyrics used to compute `romanizedLines`. The same `songId` may
+ * temporarily reference different lyric content in the two WebViews (e.g.
+ * local lyrics vs an online-upgraded set), so identity must not collapse to
+ * songId or line count.
+ */
+export interface LocalAudienceRomanizeState {
+  revision: number;
+  songId: string | null;
+  lyricsIdentity: string | null;
+  showRomanized: boolean;
+  isRomanizing: boolean;
+  romanizedLines: string[];
+}
+
+/**
+ * Explicit set request sent from the fullscreen control to the main window.
+ * The desired boolean is sent (not a toggle) so the main window can validate
+ * the request against its current authoritative state without ambiguity.
+ */
+export interface LocalAudienceRomanizeSetRequest {
+  songId: string;
+  showRomanized: boolean;
+}
+
+/**
+ * Deterministic serialization of the ordered source lyrics used for
+ * romanization. Returns null for empty lyrics so the receiver can treat a
+ * null identity as "no romanization available yet" without matching it
+ * against stale content.
+ */
+export function buildLyricsIdentity(lines: LyricLine[]): string | null {
+  if (lines.length === 0) return null;
+  return JSON.stringify(lines.map((line) => [line.time_ms, line.text]));
+}
+
+/** Project the authoritative state to the fullscreen audience window. */
+export async function emitLocalAudienceRomanizeState(
+  state: LocalAudienceRomanizeState,
+): Promise<void> {
+  await emitTo(
+    FULLSCREEN_PLAYER_WINDOW_LABEL,
+    LOCAL_AUDIENCE_ROMANIZE_STATE_EVENT,
+    state,
+  );
+}
+
+/** Send an explicit set request from the fullscreen control to the main window. */
+export async function emitLocalAudienceRomanizeSetRequest(
+  request: LocalAudienceRomanizeSetRequest,
+): Promise<void> {
+  await emitTo(MAIN_WINDOW_LABEL, LOCAL_AUDIENCE_ROMANIZE_SET_EVENT, request);
+}
+
+/** Request the current authoritative snapshot from the main window. */
+export async function emitLocalAudienceRomanizeSyncRequest(): Promise<void> {
+  await emit(LOCAL_AUDIENCE_ROMANIZE_SYNC_REQUEST_EVENT, {});
+}

--- a/src/runtime/app-runtime.ts
+++ b/src/runtime/app-runtime.ts
@@ -21,6 +21,7 @@ import {
   useLocalAudienceOutputState,
   useAirPlayOutputState,
 } from "@/runtime/airplay-runtime";
+import { useLocalAudienceRomanizeRuntime } from "@/runtime/local-audience-romanize-runtime";
 import { useAppMenuRuntime } from "./menu-runtime";
 import { loadStartupSettings } from "./settings-runtime";
 
@@ -134,6 +135,7 @@ export function useAppRuntime(enabled: boolean) {
   useAirPlayAudienceSync(enabled);
   useLocalAudienceOutputState(enabled);
   useAirPlayOutputState(enabled);
+  useLocalAudienceRomanizeRuntime(enabled);
   useKeyboardShortcuts(enabled);
   useFileDrop(enabled);
   useAppMenuRuntime(enabled);

--- a/src/runtime/local-audience-romanize-runtime.test.tsx
+++ b/src/runtime/local-audience-romanize-runtime.test.tsx
@@ -1,0 +1,335 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  LOCAL_AUDIENCE_ROMANIZE_SET_EVENT,
+  LOCAL_AUDIENCE_ROMANIZE_SYNC_REQUEST_EVENT,
+  LOCAL_AUDIENCE_ROMANIZE_STATE_EVENT,
+  FULLSCREEN_PLAYER_WINDOW_LABEL,
+} from "@/lib/local-audience-romanize";
+import { useLyricsStore } from "@/stores/lyrics-store";
+import { usePlayerStore } from "@/stores/player-store";
+import { useLocalAudienceRomanizeRuntime } from "./local-audience-romanize-runtime";
+
+const { mockListen, mockEmitTo } = vi.hoisted(() => ({
+  mockListen: vi.fn(),
+  mockEmitTo: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: mockListen,
+  emitTo: mockEmitTo,
+}));
+
+const line = (time_ms: number, text: string) => ({
+  time_ms,
+  text,
+  words: null,
+  bg_words: null,
+  section: null,
+});
+
+function Harness({ enabled = true }: { enabled?: boolean }) {
+  useLocalAudienceRomanizeRuntime(enabled);
+  return null;
+}
+
+function resetStores() {
+  useLyricsStore.setState({
+    songId: null,
+    lines: [],
+    source: null,
+    offsetMs: 0,
+    rawLrc: "",
+    activeLineIndex: -1,
+    activeWordIndex: -1,
+    isLoading: false,
+    romanizedLines: [],
+    isRomanizing: false,
+    showRomanized: false,
+  });
+  usePlayerStore.setState({
+    localAudienceOutputActive: false,
+  });
+}
+
+describe("useLocalAudienceRomanizeRuntime", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    mockListen.mockReset();
+    mockEmitTo.mockReset();
+    mockEmitTo.mockResolvedValue(undefined);
+    mockListen.mockImplementation(async () => vi.fn());
+    resetStores();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  function renderHarness(enabled = true) {
+    return act(async () => {
+      root.render(<Harness enabled={enabled} />);
+    });
+  }
+
+  function collectListeners() {
+    const calls = mockListen.mock.calls as unknown as [
+      string,
+      (event: { payload: unknown }) => void,
+    ][];
+    return calls;
+  }
+
+  function getListener(eventName: string) {
+    const call = collectListeners().find(([name]) => name === eventName);
+    return call?.[1] ?? null;
+  }
+
+  test("emits a full state snapshot when local audience output is active", async () => {
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [line(0, "你好")],
+      showRomanized: true,
+      romanizedLines: ["ni hao"],
+    });
+    usePlayerStore.setState({ localAudienceOutputActive: true });
+
+    await renderHarness();
+
+    expect(mockEmitTo).toHaveBeenCalledWith(
+      FULLSCREEN_PLAYER_WINDOW_LABEL,
+      LOCAL_AUDIENCE_ROMANIZE_STATE_EVENT,
+      expect.objectContaining({
+        songId: "song-1",
+        showRomanized: true,
+        romanizedLines: ["ni hao"],
+      }),
+    );
+  });
+
+  test("does not emit when local audience output is inactive but keeps the latest snapshot for sync requests", async () => {
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [line(0, "你好")],
+      showRomanized: true,
+      romanizedLines: ["ni hao"],
+    });
+    usePlayerStore.setState({ localAudienceOutputActive: false });
+
+    await renderHarness();
+
+    // No state emission yet.
+    expect(mockEmitTo).not.toHaveBeenCalledWith(
+      FULLSCREEN_PLAYER_WINDOW_LABEL,
+      LOCAL_AUDIENCE_ROMANIZE_STATE_EVENT,
+      expect.anything(),
+    );
+
+    // Sync request listener should answer with the latest snapshot.
+    const syncListener = getListener(
+      LOCAL_AUDIENCE_ROMANIZE_SYNC_REQUEST_EVENT,
+    );
+    expect(syncListener).not.toBeNull();
+
+    await act(async () => {
+      syncListener!({ payload: {} });
+    });
+
+    expect(mockEmitTo).toHaveBeenCalledWith(
+      FULLSCREEN_PLAYER_WINDOW_LABEL,
+      LOCAL_AUDIENCE_ROMANIZE_STATE_EVENT,
+      expect.objectContaining({
+        songId: "song-1",
+        showRomanized: true,
+        romanizedLines: ["ni hao"],
+      }),
+    );
+  });
+
+  test("every emitted snapshot has a strictly increasing revision", async () => {
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [line(0, "你好")],
+      showRomanized: false,
+    });
+    usePlayerStore.setState({ localAudienceOutputActive: true });
+
+    await renderHarness();
+
+    const lastCall = () =>
+      mockEmitTo.mock.calls[mockEmitTo.mock.calls.length - 1]?.[2] as {
+        revision: number;
+      };
+
+    const rev1 = lastCall();
+
+    await act(async () => {
+      useLyricsStore.setState({ showRomanized: true });
+    });
+    const rev2 = lastCall();
+
+    await act(async () => {
+      useLyricsStore.setState({ romanizedLines: ["ni hao"] });
+    });
+    const rev3 = lastCall();
+
+    expect(rev2.revision).toBeGreaterThan(rev1.revision);
+    expect(rev3.revision).toBeGreaterThan(rev2.revision);
+  });
+
+  test("changes to source lyrics, visibility, loading, or romanized lines each emit a new snapshot", async () => {
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [line(0, "你好")],
+    });
+    usePlayerStore.setState({ localAudienceOutputActive: true });
+
+    await renderHarness();
+    const baseline = mockEmitTo.mock.calls.length;
+
+    await act(async () => {
+      useLyricsStore.setState({ lines: [line(0, "你好"), line(1000, "世界")] });
+    });
+    expect(mockEmitTo.mock.calls.length).toBeGreaterThan(baseline);
+
+    const afterLines = mockEmitTo.mock.calls.length;
+    await act(async () => {
+      useLyricsStore.setState({ showRomanized: true });
+    });
+    expect(mockEmitTo.mock.calls.length).toBeGreaterThan(afterLines);
+
+    const afterVisibility = mockEmitTo.mock.calls.length;
+    await act(async () => {
+      useLyricsStore.setState({ isRomanizing: true });
+    });
+    expect(mockEmitTo.mock.calls.length).toBeGreaterThan(afterVisibility);
+
+    const afterLoading = mockEmitTo.mock.calls.length;
+    await act(async () => {
+      useLyricsStore.setState({ romanizedLines: ["ni hao", "shi jie"] });
+    });
+    expect(mockEmitTo.mock.calls.length).toBeGreaterThan(afterLoading);
+  });
+
+  test("a valid explicit set request updates the authoritative store once", async () => {
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [line(0, "你好")],
+      showRomanized: false,
+    });
+    usePlayerStore.setState({ localAudienceOutputActive: true });
+
+    await renderHarness();
+
+    const setListener = getListener(LOCAL_AUDIENCE_ROMANIZE_SET_EVENT);
+    expect(setListener).not.toBeNull();
+
+    await act(async () => {
+      setListener!({ payload: { songId: "song-1", showRomanized: true } });
+    });
+
+    expect(useLyricsStore.getState().showRomanized).toBe(true);
+  });
+
+  test("a set request for another song is ignored", async () => {
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [line(0, "你好")],
+      showRomanized: false,
+    });
+
+    await renderHarness();
+
+    const setListener = getListener(LOCAL_AUDIENCE_ROMANIZE_SET_EVENT);
+    await act(async () => {
+      setListener!({ payload: { songId: "song-2", showRomanized: true } });
+    });
+
+    expect(useLyricsStore.getState().showRomanized).toBe(false);
+  });
+
+  test("duplicate set requests for the already requested state do not start duplicate Worker work", async () => {
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [line(0, "你好")],
+      showRomanized: true,
+      romanizedLines: ["ni hao"],
+    });
+
+    await renderHarness();
+
+    const setListener = getListener(LOCAL_AUDIENCE_ROMANIZE_SET_EVENT);
+    const before = mockEmitTo.mock.calls.length;
+    await act(async () => {
+      setListener!({ payload: { songId: "song-1", showRomanized: true } });
+    });
+    // No state change, no new emission.
+    expect(mockEmitTo.mock.calls.length).toBe(before);
+  });
+
+  test("emit rejection does not throw into playback or lyrics rendering", async () => {
+    mockEmitTo.mockRejectedValueOnce(new Error("fullscreen window closed"));
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [line(0, "你好")],
+      showRomanized: true,
+    });
+    usePlayerStore.setState({ localAudienceOutputActive: true });
+
+    await expect(renderHarness()).resolves.toBeUndefined();
+  });
+
+  test("cleans up all listeners on unmount", async () => {
+    const unlistenA = vi.fn();
+    const unlistenB = vi.fn();
+    const queue = [unlistenA, unlistenB];
+    mockListen.mockImplementation(async () => queue.shift()!);
+
+    await renderHarness();
+
+    await act(async () => {
+      root.unmount();
+    });
+
+    expect(unlistenA).toHaveBeenCalled();
+    expect(unlistenB).toHaveBeenCalled();
+    container.remove();
+  });
+
+  test("cleans up listeners when unmount races listen() resolution", async () => {
+    let resolveListen: (unlisten: () => void) => void;
+    const pending = new Promise<() => void>((resolve) => {
+      resolveListen = resolve;
+    });
+    mockListen.mockImplementation(async () => pending);
+
+    await renderHarness();
+
+    // Unmount before listen() resolves.
+    await act(async () => {
+      root.unmount();
+    });
+
+    // Now resolve listen(); the runtime must call the unlisten function
+    // immediately so no listener is leaked.
+    const unlisten = vi.fn();
+    resolveListen!(unlisten);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(unlisten).toHaveBeenCalled();
+    container.remove();
+  });
+
+  test("does not register listeners or emit when disabled", async () => {
+    await renderHarness(false);
+
+    expect(mockListen).not.toHaveBeenCalled();
+    expect(mockEmitTo).not.toHaveBeenCalled();
+  });
+});

--- a/src/runtime/local-audience-romanize-runtime.ts
+++ b/src/runtime/local-audience-romanize-runtime.ts
@@ -1,0 +1,161 @@
+import { useEffect, useRef } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { usePlayerStore } from "@/stores/player-store";
+import { useLyricsStore } from "@/stores/lyrics-store";
+import {
+  LOCAL_AUDIENCE_ROMANIZE_SET_EVENT,
+  LOCAL_AUDIENCE_ROMANIZE_SYNC_REQUEST_EVENT,
+  type LocalAudienceRomanizeSetRequest,
+  type LocalAudienceRomanizeState,
+  buildLyricsIdentity,
+  emitLocalAudienceRomanizeState,
+} from "@/lib/local-audience-romanize";
+
+// Module-local monotonic revision counter. Each emitted snapshot carries a
+// strictly increasing revision so the fullscreen receiver can discard stale
+// payloads that arrive after a newer state was already applied.
+let revisionCounter = 0;
+
+function nextRevision(): number {
+  return ++revisionCounter;
+}
+
+/**
+ * Main-window authoritative romanization runtime. Mount once from
+ * `useAppRuntime` so panel unmounts, CDG rendering, or layout changes never
+ * interrupt synchronization. The main window is the only romanization
+ * computation owner; this runtime projects its state to the fullscreen
+ * audience window and services explicit set requests from the fullscreen
+ * Romanize control.
+ *
+ * The runtime emits a fresh snapshot whenever the authoritative state
+ * changes while local audience output is active, and answers sync requests
+ * immediately regardless of the audience-active announcement state so a
+ * race between the announcement and the listener registration cannot drop
+ * the initial snapshot.
+ */
+export function useLocalAudienceRomanizeRuntime(enabled: boolean): void {
+  const songId = useLyricsStore((s) => s.songId);
+  const lines = useLyricsStore((s) => s.lines);
+  const showRomanized = useLyricsStore((s) => s.showRomanized);
+  const isRomanizing = useLyricsStore((s) => s.isRomanizing);
+  const romanizedLines = useLyricsStore((s) => s.romanizedLines);
+  const setRomanizedVisibility = useLyricsStore(
+    (s) => s.setRomanizedVisibility,
+  );
+  const localAudienceOutputActive = usePlayerStore(
+    (s) => s.localAudienceOutputActive,
+  );
+
+  // Latest snapshot kept in a ref so the sync-request handler can answer
+  // without re-reading the store and without depending on the latest render.
+  const latestSnapshotRef = useRef<LocalAudienceRomanizeState | null>(null);
+  // Track whether the runtime listeners have been registered so the
+  // sync-request handler is only attached once.
+  const listenersReadyRef = useRef(false);
+
+  // Re-emit the authoritative snapshot whenever the source state changes.
+  // The effect depends on the projected values so a no-op render does not
+  // produce a duplicate event; the revision counter guarantees the receiver
+  // can still distinguish genuine state changes from re-emissions.
+  useEffect(() => {
+    if (!enabled) {
+      latestSnapshotRef.current = null;
+      return;
+    }
+
+    // Always build the snapshot so the sync-request handler can answer with
+    // the latest state even when the audience window is not yet announced
+    // as active (the announcement may lag behind the listener registration).
+    const snapshot: LocalAudienceRomanizeState = {
+      revision: nextRevision(),
+      songId,
+      lyricsIdentity: buildLyricsIdentity(lines),
+      showRomanized,
+      isRomanizing,
+      romanizedLines,
+    };
+    latestSnapshotRef.current = snapshot;
+
+    if (!localAudienceOutputActive) {
+      return;
+    }
+
+    // Emit failures are auxiliary-output failures; they must not interrupt
+    // local lyrics or playback.
+    void emitLocalAudienceRomanizeState(snapshot).catch(() => {
+      // The fullscreen window may have closed mid-emit; the next change
+      // will retry.
+    });
+  }, [
+    enabled,
+    songId,
+    lines,
+    showRomanized,
+    isRomanizing,
+    romanizedLines,
+    localAudienceOutputActive,
+  ]);
+
+  // Register listeners for sync requests and explicit set requests. These
+  // are independent of the projected state so they attach once per mount.
+  useEffect(() => {
+    if (!enabled) {
+      listenersReadyRef.current = false;
+      return;
+    }
+
+    let cancelled = false;
+    const unlisteners: (() => void)[] = [];
+
+    const setup = async () => {
+      const syncUnlisten = await listen(
+        LOCAL_AUDIENCE_ROMANIZE_SYNC_REQUEST_EVENT,
+        () => {
+          if (cancelled) return;
+          const snapshot = latestSnapshotRef.current;
+          if (!snapshot) return;
+          // Answer with the latest snapshot regardless of
+          // localAudienceOutputActive so a race between the announcement
+          // and the fullscreen listener registration cannot drop the
+          // initial state.
+          void emitLocalAudienceRomanizeState(snapshot).catch(() => {
+            // Auxiliary sync delivery failure is non-fatal.
+          });
+        },
+      );
+
+      const setUnlisten = await listen<LocalAudienceRomanizeSetRequest>(
+        LOCAL_AUDIENCE_ROMANIZE_SET_EVENT,
+        (event) => {
+          if (cancelled) return;
+          const request = event.payload;
+          // Validate the request against the current authoritative song
+          // before applying. A stale request targeting a previous song
+          // must never toggle the current song's romanization.
+          if (request.songId !== useLyricsStore.getState().songId) {
+            return;
+          }
+          setRomanizedVisibility(request.showRomanized);
+        },
+      );
+
+      if (cancelled) {
+        syncUnlisten();
+        setUnlisten();
+        return;
+      }
+
+      unlisteners.push(syncUnlisten, setUnlisten);
+      listenersReadyRef.current = true;
+    };
+
+    void setup();
+
+    return () => {
+      cancelled = true;
+      listenersReadyRef.current = false;
+      unlisteners.forEach((fn) => fn());
+    };
+  }, [enabled, setRomanizedVisibility]);
+}

--- a/src/stores/lyrics-store.test.ts
+++ b/src/stores/lyrics-store.test.ts
@@ -56,6 +56,7 @@ const DEFAULT_STATE = {
   activeLineIndex: -1,
   isLoading: false,
   romanizedLines: [],
+  romanizedLinesIdentity: null,
   isRomanizing: false,
   showRomanized: false,
 };
@@ -657,6 +658,7 @@ describe("lyrics-store setRomanizedVisibility", () => {
       ],
       showRomanized: false,
       romanizedLines: ["ni hao"],
+      romanizedLinesIdentity: JSON.stringify([[0, "你好"]]),
     });
 
     useLyricsStore.getState().setRomanizedVisibility(true);
@@ -729,6 +731,90 @@ describe("lyrics-store setRomanizedVisibility", () => {
     expect(state.lines).toHaveLength(1);
     expect(state.offsetMs).toBe(50);
     expect(state.activeLineIndex).toBe(2);
+  });
+
+  test("re-enabling after lines changed recomputes instead of reusing stale cache", async () => {
+    // Simulate: romanize on (cache computed for v1), romanize off,
+    // edit/upgrade lyrics (lines become v2 without clearing cache),
+    // romanize on → must recompute, not reuse v1's romanizedLines.
+    mockRomanizeLyricsLines
+      .mockResolvedValueOnce({ result: ["ni hao"], requestId: 40 })
+      .mockResolvedValueOnce({ result: ["ni hao v2"], requestId: 41 });
+
+    const linesV1 = [
+      { time_ms: 0, text: "你好", words: [], bg_words: null, section: null },
+    ];
+    const linesV2 = [
+      {
+        time_ms: 0,
+        text: "你好世界",
+        words: [],
+        bg_words: null,
+        section: null,
+      },
+    ];
+
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: linesV1,
+      showRomanized: false,
+    });
+
+    // Romanize on → computes for v1.
+    useLyricsStore.getState().setRomanizedVisibility(true);
+    await vi.waitFor(() =>
+      expect(mockRomanizeLyricsLines).toHaveBeenCalledTimes(1),
+    );
+    await vi.waitFor(() =>
+      expect(useLyricsStore.getState().romanizedLines).toEqual(["ni hao"]),
+    );
+
+    // Romanize off → cache preserved.
+    useLyricsStore.getState().setRomanizedVisibility(false);
+    expect(useLyricsStore.getState().romanizedLines).toEqual(["ni hao"]);
+
+    // Edit/upgrade lyrics: lines change to v2 without clearing romanizedLines.
+    useLyricsStore.setState({ lines: linesV2 });
+
+    // Romanize on → must recompute because identity no longer matches.
+    useLyricsStore.getState().setRomanizedVisibility(true);
+    await vi.waitFor(() =>
+      expect(mockRomanizeLyricsLines).toHaveBeenCalledTimes(2),
+    );
+    await vi.waitFor(() =>
+      expect(useLyricsStore.getState().romanizedLines).toEqual(["ni hao v2"]),
+    );
+  });
+
+  test("re-enabling after lines replaced with identical content reuses cache", async () => {
+    mockRomanizeLyricsLines.mockResolvedValue({
+      result: ["ni hao"],
+      requestId: 50,
+    });
+
+    const lines = [
+      { time_ms: 0, text: "你好", words: [], bg_words: null, section: null },
+    ];
+
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines,
+      showRomanized: false,
+    });
+
+    useLyricsStore.getState().setRomanizedVisibility(true);
+    await vi.waitFor(() =>
+      expect(mockRomanizeLyricsLines).toHaveBeenCalledTimes(1),
+    );
+
+    useLyricsStore.getState().setRomanizedVisibility(false);
+
+    // Replace lines with identical content (e.g. re-fetched same lyrics).
+    useLyricsStore.setState({ lines: [...lines] });
+
+    useLyricsStore.getState().setRomanizedVisibility(true);
+    // Identity matches → no recompute.
+    expect(mockRomanizeLyricsLines).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/stores/lyrics-store.test.ts
+++ b/src/stores/lyrics-store.test.ts
@@ -601,3 +601,306 @@ describe("lyrics-store saveManualLyrics", () => {
     expect(mockNotifyError).toHaveBeenCalledWith(error);
   });
 });
+
+describe("lyrics-store setRomanizedVisibility", () => {
+  beforeEach(resetStore);
+
+  test("enabling with lyrics sets showRomanized=true and starts one romanization task", async () => {
+    mockRomanizeLyricsLines.mockResolvedValue({
+      result: ["ni hao"],
+      requestId: 10,
+    });
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [
+        { time_ms: 0, text: "你好", words: [], bg_words: null, section: null },
+      ],
+      showRomanized: false,
+    });
+
+    useLyricsStore.getState().setRomanizedVisibility(true);
+
+    expect(useLyricsStore.getState().showRomanized).toBe(true);
+    await vi.waitFor(() =>
+      expect(mockRomanizeLyricsLines).toHaveBeenCalledTimes(1),
+    );
+  });
+
+  test("enabling when already enabled does not start a duplicate task", () => {
+    mockRomanizeLyricsLines.mockResolvedValue({
+      result: ["ni hao"],
+      requestId: 11,
+    });
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [
+        { time_ms: 0, text: "你好", words: [], bg_words: null, section: null },
+      ],
+      showRomanized: true,
+      romanizedLines: ["ni hao"],
+    });
+
+    useLyricsStore.getState().setRomanizedVisibility(true);
+
+    expect(mockRomanizeLyricsLines).not.toHaveBeenCalled();
+  });
+
+  test("enabling with cached romanizedLines does not re-run the Worker", () => {
+    mockRomanizeLyricsLines.mockResolvedValue({
+      result: ["ni hao"],
+      requestId: 12,
+    });
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [
+        { time_ms: 0, text: "你好", words: [], bg_words: null, section: null },
+      ],
+      showRomanized: false,
+      romanizedLines: ["ni hao"],
+    });
+
+    useLyricsStore.getState().setRomanizedVisibility(true);
+
+    expect(useLyricsStore.getState().showRomanized).toBe(true);
+    expect(mockRomanizeLyricsLines).not.toHaveBeenCalled();
+  });
+
+  test("enabling while romanizing does not start a duplicate task", () => {
+    mockRomanizeLyricsLines.mockResolvedValue({
+      result: ["ni hao"],
+      requestId: 13,
+    });
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [
+        { time_ms: 0, text: "你好", words: [], bg_words: null, section: null },
+      ],
+      showRomanized: true,
+      isRomanizing: true,
+    });
+
+    useLyricsStore.getState().setRomanizedVisibility(true);
+
+    expect(mockRomanizeLyricsLines).not.toHaveBeenCalled();
+  });
+
+  test("disabling changes visibility without clearing cached romanizedLines", () => {
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [
+        { time_ms: 0, text: "你好", words: [], bg_words: null, section: null },
+      ],
+      showRomanized: true,
+      romanizedLines: ["ni hao"],
+    });
+
+    useLyricsStore.getState().setRomanizedVisibility(false);
+
+    expect(useLyricsStore.getState().showRomanized).toBe(false);
+    expect(useLyricsStore.getState().romanizedLines).toEqual(["ni hao"]);
+    expect(mockRomanizeLyricsLines).not.toHaveBeenCalled();
+  });
+
+  test("no-op when lines are empty", () => {
+    useLyricsStore.setState({ lines: [], showRomanized: false });
+
+    useLyricsStore.getState().setRomanizedVisibility(true);
+
+    expect(useLyricsStore.getState().showRomanized).toBe(false);
+    expect(mockRomanizeLyricsLines).not.toHaveBeenCalled();
+  });
+
+  test("does not alter song, lyric, or playback state", () => {
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [
+        { time_ms: 0, text: "你好", words: [], bg_words: null, section: null },
+      ],
+      offsetMs: 50,
+      activeLineIndex: 2,
+      showRomanized: true,
+      romanizedLines: ["ni hao"],
+    });
+
+    useLyricsStore.getState().setRomanizedVisibility(false);
+
+    const state = useLyricsStore.getState();
+    expect(state.songId).toBe("song-1");
+    expect(state.lines).toHaveLength(1);
+    expect(state.offsetMs).toBe(50);
+    expect(state.activeLineIndex).toBe(2);
+  });
+});
+
+describe("lyrics-store toggleRomanized delegates to setRomanizedVisibility", () => {
+  beforeEach(resetStore);
+
+  test("toggle on delegates to setRomanizedVisibility(true)", async () => {
+    mockRomanizeLyricsLines.mockResolvedValue({
+      result: ["ni hao"],
+      requestId: 20,
+    });
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [
+        { time_ms: 0, text: "你好", words: [], bg_words: null, section: null },
+      ],
+      showRomanized: false,
+    });
+
+    useLyricsStore.getState().toggleRomanized();
+
+    expect(useLyricsStore.getState().showRomanized).toBe(true);
+    await vi.waitFor(() =>
+      expect(mockRomanizeLyricsLines).toHaveBeenCalledTimes(1),
+    );
+  });
+
+  test("toggle off delegates to setRomanizedVisibility(false) and keeps cache", () => {
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [
+        { time_ms: 0, text: "你好", words: [], bg_words: null, section: null },
+      ],
+      showRomanized: true,
+      romanizedLines: ["ni hao"],
+    });
+
+    useLyricsStore.getState().toggleRomanized();
+
+    expect(useLyricsStore.getState().showRomanized).toBe(false);
+    expect(useLyricsStore.getState().romanizedLines).toEqual(["ni hao"]);
+  });
+});
+
+describe("lyrics-store applyRemoteRomanizeState", () => {
+  beforeEach(resetStore);
+
+  test("copies projected state into the store", () => {
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [
+        { time_ms: 0, text: "你好", words: [], bg_words: null, section: null },
+      ],
+      showRomanized: false,
+      isRomanizing: false,
+      romanizedLines: [],
+    });
+
+    useLyricsStore.getState().applyRemoteRomanizeState({
+      revision: 5,
+      songId: "song-1",
+      lyricsIdentity: "id",
+      showRomanized: true,
+      isRomanizing: false,
+      romanizedLines: ["ni hao", "shi jie"],
+    });
+
+    const state = useLyricsStore.getState();
+    expect(state.showRomanized).toBe(true);
+    expect(state.isRomanizing).toBe(false);
+    expect(state.romanizedLines).toEqual(["ni hao", "shi jie"]);
+  });
+
+  test("never invokes the romanizer Worker", () => {
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [
+        { time_ms: 0, text: "你好", words: [], bg_words: null, section: null },
+      ],
+      romanizedLines: [],
+    });
+
+    useLyricsStore.getState().applyRemoteRomanizeState({
+      revision: 5,
+      songId: "song-1",
+      lyricsIdentity: "id",
+      showRomanized: true,
+      isRomanizing: false,
+      romanizedLines: ["ni hao"],
+    });
+
+    expect(mockRomanizeLyricsLines).not.toHaveBeenCalled();
+  });
+
+  test("does not mutate source lyrics, offset, or active indices", () => {
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [
+        { time_ms: 0, text: "你好", words: [], bg_words: null, section: null },
+      ],
+      offsetMs: 75,
+      activeLineIndex: 3,
+      activeWordIndex: 2,
+      source: "lrc_lib",
+      rawLrc: "[00:00.00]你好",
+    });
+
+    useLyricsStore.getState().applyRemoteRomanizeState({
+      revision: 5,
+      songId: "song-1",
+      lyricsIdentity: "id",
+      showRomanized: true,
+      isRomanizing: false,
+      romanizedLines: ["ni hao"],
+    });
+
+    const state = useLyricsStore.getState();
+    expect(state.songId).toBe("song-1");
+    expect(state.lines).toHaveLength(1);
+    expect(state.offsetMs).toBe(75);
+    expect(state.activeLineIndex).toBe(3);
+    expect(state.activeWordIndex).toBe(2);
+    expect(state.source).toBe("lrc_lib");
+    expect(state.rawLrc).toBe("[00:00.00]你好");
+  });
+
+  test("copies the romanizedLines array so later remote mutation does not leak", () => {
+    const remote = ["ni hao", "shi jie"];
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [
+        { time_ms: 0, text: "你好", words: [], bg_words: null, section: null },
+      ],
+    });
+
+    useLyricsStore.getState().applyRemoteRomanizeState({
+      revision: 5,
+      songId: "song-1",
+      lyricsIdentity: "id",
+      showRomanized: true,
+      isRomanizing: false,
+      romanizedLines: remote,
+    });
+
+    remote.push("mutated");
+    expect(useLyricsStore.getState().romanizedLines).toEqual([
+      "ni hao",
+      "shi jie",
+    ]);
+  });
+});
+
+describe("lyrics-store stale Worker result after song change", () => {
+  beforeEach(resetStore);
+
+  test("romanizeCurrentLyrics rejects a stale Worker result when songId changed", async () => {
+    mockRomanizeLyricsLines.mockResolvedValue({
+      result: ["ni hao"],
+      requestId: 30,
+    });
+    useLyricsStore.setState({
+      songId: "song-1",
+      lines: [
+        { time_ms: 0, text: "你好", words: [], bg_words: null, section: null },
+      ],
+    });
+
+    const promise = useLyricsStore.getState().romanizeCurrentLyrics();
+    // Simulate a song change while the Worker is still running.
+    useLyricsStore.setState({ songId: "song-2" });
+    await promise;
+
+    expect(useLyricsStore.getState().romanizedLines).toEqual([]);
+  });
+});

--- a/src/stores/lyrics-store.ts
+++ b/src/stores/lyrics-store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import * as api from "@/lib/tauri";
 import { notifyError } from "@/lib/errors";
 import { romanizeLyricsLines } from "@/lib/lyrics-romanizer";
+import type { LocalAudienceRomanizeState } from "@/lib/local-audience-romanize";
 import {
   SONG_LANGUAGES,
   type SongLanguage,
@@ -43,6 +44,8 @@ interface LyricsState {
   setActiveLineIndex: (index: number) => void;
   setActiveWordIndex: (index: number) => void;
   toggleRomanized: () => void;
+  setRomanizedVisibility: (show: boolean) => void;
+  applyRemoteRomanizeState: (state: LocalAudienceRomanizeState) => void;
   romanizeCurrentLyrics: () => Promise<void>;
   clear: () => void;
 }
@@ -184,12 +187,40 @@ export const useLyricsStore = create<LyricsState>((set, get) => ({
   toggleRomanized: () => {
     const { showRomanized, lines } = get();
     if (lines.length === 0) return;
-    if (!showRomanized) {
+    get().setRomanizedVisibility(!showRomanized);
+  },
+
+  // Idempotent visibility action shared by the main-window Romanize button
+  // and remote set requests from the fullscreen audience control. The
+  // caller passes the explicit desired boolean; this action never toggles
+  // implicitly. Cached romanizedLines are preserved across disable/enable
+  // cycles so re-enabling does not re-run the Worker when results already
+  // exist for the current source lyrics.
+  setRomanizedVisibility: (show) => {
+    const { showRomanized, lines, romanizedLines } = get();
+    if (lines.length === 0) return;
+    if (show === showRomanized) return;
+
+    if (show) {
       set({ showRomanized: true });
-      void get().romanizeCurrentLyrics();
+      if (romanizedLines.length === 0) {
+        void get().romanizeCurrentLyrics();
+      }
     } else {
       set({ showRomanized: false });
     }
+  },
+
+  // Read-only projection used only by the fullscreen WebView. The receiver
+  // validates songId, lyricsIdentity, and revision before calling this; the
+  // store action copies the projected state without invoking the Worker or
+  // mutating source lyrics, offset, or active-lyric indices.
+  applyRemoteRomanizeState: (state) => {
+    set({
+      showRomanized: state.showRomanized,
+      isRomanizing: state.isRomanizing,
+      romanizedLines: [...state.romanizedLines],
+    });
   },
 
   romanizeCurrentLyrics: async () => {

--- a/src/stores/lyrics-store.ts
+++ b/src/stores/lyrics-store.ts
@@ -2,7 +2,10 @@ import { create } from "zustand";
 import * as api from "@/lib/tauri";
 import { notifyError } from "@/lib/errors";
 import { romanizeLyricsLines } from "@/lib/lyrics-romanizer";
-import type { LocalAudienceRomanizeState } from "@/lib/local-audience-romanize";
+import {
+  buildLyricsIdentity,
+  type LocalAudienceRomanizeState,
+} from "@/lib/local-audience-romanize";
 import {
   SONG_LANGUAGES,
   type SongLanguage,
@@ -34,6 +37,11 @@ interface LyricsState {
   isLoading: boolean;
 
   romanizedLines: string[];
+  // Identity of the source lyrics that romanizedLines was computed from.
+  // When lines change (manual edit, online auto-upgrade) without clearing
+  // romanizedLines, this identity no longer matches and the cache is
+  // treated as stale on the next enable.
+  romanizedLinesIdentity: string | null;
   isRomanizing: boolean;
   showRomanized: boolean;
 
@@ -60,6 +68,7 @@ export const useLyricsStore = create<LyricsState>((set, get) => ({
   activeWordIndex: -1,
   isLoading: false,
   romanizedLines: [],
+  romanizedLinesIdentity: null,
   isRomanizing: false,
   showRomanized: false,
 
@@ -73,6 +82,7 @@ export const useLyricsStore = create<LyricsState>((set, get) => ({
       activeLineIndex: -1,
       activeWordIndex: -1,
       romanizedLines: [],
+      romanizedLinesIdentity: null,
       showRomanized: false,
     });
     try {
@@ -195,15 +205,23 @@ export const useLyricsStore = create<LyricsState>((set, get) => ({
   // caller passes the explicit desired boolean; this action never toggles
   // implicitly. Cached romanizedLines are preserved across disable/enable
   // cycles so re-enabling does not re-run the Worker when results already
-  // exist for the current source lyrics.
+  // exist for the current source lyrics. The cache is validated against
+  // the current lyrics identity so that editing or upgrading lyrics after
+  // disabling romanization forces a recompute on the next enable instead
+  // of showing stale romanization for the previous lyric content.
   setRomanizedVisibility: (show) => {
-    const { showRomanized, lines, romanizedLines } = get();
+    const { showRomanized, lines, romanizedLines, romanizedLinesIdentity } =
+      get();
     if (lines.length === 0) return;
     if (show === showRomanized) return;
 
     if (show) {
       set({ showRomanized: true });
-      if (romanizedLines.length === 0) {
+      const currentIdentity = buildLyricsIdentity(lines);
+      if (
+        currentIdentity !== romanizedLinesIdentity ||
+        romanizedLines.length === 0
+      ) {
         void get().romanizeCurrentLyrics();
       }
     } else {
@@ -220,6 +238,7 @@ export const useLyricsStore = create<LyricsState>((set, get) => ({
       showRomanized: state.showRomanized,
       isRomanizing: state.isRomanizing,
       romanizedLines: [...state.romanizedLines],
+      romanizedLinesIdentity: state.lyricsIdentity,
     });
   },
 
@@ -238,10 +257,13 @@ export const useLyricsStore = create<LyricsState>((set, get) => ({
         // requestId === -1 means Latin-only (no worker involved), always apply.
         if (requestId !== -1) return;
       }
-      set({ romanizedLines: result });
+      set({
+        romanizedLines: result,
+        romanizedLinesIdentity: buildLyricsIdentity(get().lines),
+      });
     } catch (err) {
       console.error("Romanization failed:", err);
-      set({ romanizedLines: [] });
+      set({ romanizedLines: [], romanizedLinesIdentity: null });
     } finally {
       set({ isRomanizing: false });
     }
@@ -257,6 +279,7 @@ export const useLyricsStore = create<LyricsState>((set, get) => ({
       activeLineIndex: -1,
       activeWordIndex: -1,
       romanizedLines: [],
+      romanizedLinesIdentity: null,
       isRomanizing: false,
       showRomanized: false,
     }),


### PR DESCRIPTION
## Summary
- Adds a Romanize button to the fullscreen audience controls that sends an explicit desired boolean to the main window, which applies it and re-emits the authoritative romanization state.
- Main window remains the single romanization computation owner; the fullscreen window renders a read-only projection via a new cross-window event protocol with monotonic revisions and lyrics-identity validation.
- `lyrics-store` gains `setRomanizedVisibility` (idempotent, preserves cached romanized lines on disable) and `applyRemoteRomanizeState` (projects remote state without invoking the Worker); `toggleRomanized` now delegates to `setRomanizedVisibility`.
- `use-audience-plain-text-paging` observes the measurement container and accepts a `layoutVersion` token so romanized text height changes trigger a remeasure and page-index clamp.

Closes #142

## Verification
- [x] pnpm lint — PASS
- [x] pnpm format — PASS
- [x] pnpm check:i18n — PASS
- [x] pnpm test — PASS (1774 tests)
- [x] pnpm build — PASS
- [x] patch coverage — 100% (129/129 instrumented lines)
- [ ] pnpm tauri build — SKIPPED (frontend-only change; no Rust/IPC changes)

## Residual risk
None. The new cross-window events follow the existing local-audience event pattern (emitTo/emit) and do not touch Rust IPC commands or payloads. Contract docs are unchanged because the existing local-audience events are not contract-documented.