### PR TITLE
fix(rotation): shuffle within equal-size singer tiers so repeated Shuffle presses vary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changelog
+
+- Record romanize fullscreen sync (#142)
+
 ### ♻️ Refactoring
 
 - Introduce PlaybackCoordinator as independent control thread (#100)
@@ -101,6 +105,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **website**: Center CTA labels with translateY nudge
 - **website**: Polish mock preview freeze, counts, sidebar, Separate size
 - **website**: Theme/lang auto-detect, mock interactions, natural Chinese copy (#139)
+- **audio**: Replace per-stem rendering with source-domain mix bus (#144)
+- **romanize**: Invalidate stale romanizedLines cache when source lyrics change
+- **rotation**: Shuffle within equal-size singer tiers so repeated Shuffle presses vary
 
 ### 📝 Documentation
 

--- a/src/stores/rotation-store.test.ts
+++ b/src/stores/rotation-store.test.ts
@@ -313,5 +313,65 @@ describe("rotation-store", () => {
       const result = mockSetQueue.mock.calls[0][0];
       expect(result.sort()).toEqual(["x", "y", "z"]);
     });
+
+    test("repeated shuffles produce varied orderings with one song per singer (#145)", () => {
+      // Every singer has exactly one song, so all groups are size 1 (same
+      // tier). The old code sorted by descending size with a stable sort,
+      // preserving Map insertion order and yielding one deterministic order
+      // on every press. The fix shuffles within equal-size tiers.
+      mockQueueState.queue = ["a1", "b1", "c1", "d1"];
+      useRotationStore.setState({
+        queueSingers: new Map([
+          ["a1", "Alice"],
+          ["b1", "Bob"],
+          ["c1", "Charlie"],
+          ["d1", "Diana"],
+        ]),
+      });
+
+      const orderings = new Set<string>();
+      for (let i = 0; i < 30; i++) {
+        mockSetQueue.mockClear();
+        useRotationStore.getState().shuffleQueue();
+        const result = mockSetQueue.mock.calls[0][0];
+        orderings.add(result.join(","));
+      }
+      // 4! = 24 possible orders; require at least 2 distinct across 30
+      // presses. The old code produced exactly 1.
+      expect(orderings.size).toBeGreaterThan(1);
+    });
+
+    test("repeated shuffles still avoid back-to-back with unequal group sizes", () => {
+      // A(3), B(2): distinct sizes, so the tier shuffle must keep A before B
+      // to preserve the no-back-to-back guarantee.
+      mockQueueState.queue = ["a1", "a2", "a3", "b1", "b2"];
+      useRotationStore.setState({
+        queueSingers: new Map([
+          ["a1", "Alice"],
+          ["a2", "Alice"],
+          ["a3", "Alice"],
+          ["b1", "Bob"],
+          ["b2", "Bob"],
+        ]),
+      });
+
+      for (let run = 0; run < 30; run++) {
+        mockSetQueue.mockClear();
+        useRotationStore.getState().shuffleQueue();
+        const result = mockSetQueue.mock.calls[0][0];
+
+        for (let i = 1; i < result.length; i++) {
+          const prevSinger = useRotationStore
+            .getState()
+            .queueSingers.get(result[i - 1]);
+          const currSinger = useRotationStore
+            .getState()
+            .queueSingers.get(result[i]);
+          if (prevSinger && currSinger) {
+            expect(prevSinger).not.toBe(currSinger);
+          }
+        }
+      }
+    });
   });
 });

--- a/src/stores/rotation-store.ts
+++ b/src/stores/rotation-store.ts
@@ -191,10 +191,27 @@ export const useRotationStore = create<RotationState>((set, get) => ({
     for (const group of groups.values()) shuffle(group);
     shuffle(unassigned);
 
-    // Round-robin placement, starting with the largest group
+    // Round-robin placement, starting with the largest group.
+    // Sort by descending group size so bigger groups lead every round (this
+    // is what avoids back-to-back same-singer runs when sizes differ), but
+    // shuffle within each equal-size tier so repeated presses produce
+    // different singer orders. Without the tier shuffle, single-song-per-
+    // singer queues collapse to one deterministic order every press (#145).
     const sorted = [...groups.entries()].sort(
       (a, b) => b[1].length - a[1].length,
     );
+    for (let i = 0; i < sorted.length;) {
+      let j = i + 1;
+      while (j < sorted.length && sorted[j][1].length === sorted[i][1].length) {
+        j++;
+      }
+      // Fisher-Yates within the equal-size tier [i, j)
+      for (let k = j - 1; k > i; k--) {
+        const r = i + Math.floor(Math.random() * (k - i + 1));
+        [sorted[k], sorted[r]] = [sorted[r], sorted[k]];
+      }
+      i = j;
+    }
     const result: string[] = [];
     let hasMore = true;
     while (hasMore) {


### PR DESCRIPTION
## Summary
- Fixes #145: the singer-rotation **Shuffle** button only produced a new ordering on the first press; subsequent presses (especially with one song per singer) yielded the identical queue.
- Root cause: the assigned-singer branch of `shuffleQueue` sorted singer groups by descending size with a stable sort and always iterated that fixed order in the round-robin loop. When every singer had one song, all groups were size 1 (same tier), so the stable sort preserved `Map` insertion order and the result was deterministic.
- Fix: after sorting groups by descending size, Fisher-Yates shuffle within each equal-size tier before the round-robin. Larger groups still lead every round, so the no-back-to-back guarantee is preserved for unequal group sizes; equal-size groups now vary their relative order across presses.

## Verification
- [x] `pnpm lint` — PASS (0 warnings, 0 errors)
- [x] `pnpm build` — PASS (built in 3.46s)
- [x] `pnpm test` — PASS (1778 tests, 164 files)
- [x] pre-push hooks — PASS (lint, format-check, cargo-fmt-check, patch-coverage 100%)
- [ ] `pnpm tauri build` — SKIPPED (frontend-only store change; no Rust/IPC changes)

## Tests added
- `repeated shuffles produce varied orderings with one song per singer (#145)` — calls `shuffleQueue` 30 times with 4 single-song singers and asserts more than 1 distinct ordering (old code produced exactly 1).
- `repeated shuffles still avoid back-to-back with unequal group sizes` — A(3), B(2) across 30 runs asserts no two adjacent songs share a singer (tier shuffle must keep the larger group first).

## Residual risk
None. The change is localized to `shuffleQueue`'s assigned-singer branch; the unassigned-only branch and all other rotation behavior are untouched. No IPC contracts or public payloads changed.
