### PR TITLE
fix(website): 修复桌面 mock 右侧空缺并保留手机出血

### DIFF
--- a/website/src/site.css
+++ b/website/src/site.css
@@ -419,25 +419,15 @@ a {
     0 18px 44px var(--preview-window-shadow),
     0 10px 36px color-mix(in srgb, var(--preview-halo) 28%, transparent);
   corner-shape: squircle;
-  container-type: inline-size;
-  container-name: product-preview;
 }
 
-/* Keep the embedded app at a fixed desktop design size and scale it into the
-   frame. On wide frames the scale is 1; on narrower frames the whole UI shrinks
-   to fit. Mobile overrides this to show only the left half (right clips). */
+/* Desktop: let the embedded app fill the wide preview frame. Only enforce a
+   minimum so narrow frames don't collapse the layout below the design width.
+   Fixed 920px width + scale belongs to the mobile bleed rules below — applying
+   it here left a blank strip on the right of wide desktop frames. */
 .product-preview > * {
-  width: var(--preview-design-width);
   min-width: var(--preview-design-width);
   height: 100%;
-  transform-origin: top left;
-}
-
-@container product-preview (max-width: 919px) {
-  .product-preview > * {
-    height: calc(var(--preview-design-width) * 9 / 16);
-    transform: scale(calc(100cqi / var(--preview-design-width)));
-  }
 }
 
 /* The global `button, a { font-family: inherit }` above only carries


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

修复 #141 合并后桌面端 preview mock 右侧大块空缺：宽屏下嵌入应用被误设为固定 `920px` 宽。恢复桌面端铺满预览窗，同时保留手机端左侧 inset、右侧出血裁切。

## 原因

`.product-preview > *` 被写成固定 `width: 920px`。宽屏预览框（可达 ~1368px）里应用只占 920px，右侧留白。

## 修复

- **桌面**：恢复为仅 `min-width: 920px`，让应用随预览框铺满；去掉会强制缩放的 container query。
- **手机（≤640px）**：保持左 inset + `scale` 使设计左半边覆盖到屏幕右缘，窗口本身宽于视口、右侧出血。

## 截图验证

**桌面 1440×900 — 首屏**

![桌面端落地页首屏](https://cursor.com/artifacts/c/art-b91cd677-9f0f-4906-b13d-25f8344bd874)

**桌面 — mock 特写（应用铺满预览窗，`rightGapInsideFrame=0`）**

![桌面端 mock 铺满](https://cursor.com/artifacts/c/art-8a035f6c-1841-41e7-aa30-6c734decc68d)

**手机 iPhone 13 — 首屏**

![手机端落地页首屏](https://cursor.com/artifacts/c/art-1dca84df-25d1-4a35-b187-83952cf64adc)

**手机 — mock 特写（左侧 inset，右侧贴边出血，`rightGapViewport=0`）**

![手机端 mock 右缘出血](https://cursor.com/artifacts/c/art-8b77c96b-4e44-459d-8376-2ba80c6a1f32)

## Verification

- [x] `pnpm docs:build` — PASS
- [x] Playwright 桌面：`fillsFrame=true`，`rightGapInsideFrame=0`，child `1368px` = frame
- [x] Playwright 手机：`bleedsPastViewport=true`，`rightGapViewport=0`，`leftInset=20`
- [x] 截图像素：桌面/手机 mock 右缘均无异常空隙
- [x] pre-push 全量测试 — PASS（1778）

## Residual risk

无。手机端仍加载完整交互预览 chunk（与 #141 相同取舍）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7d6a-db36-713a-a774-a2f40a76dde8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7d6a-db36-713a-a774-a2f40a76dde8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

