### PR TITLE
fix(cover-art): resolve ambience backdrop revocation race on song change

### DIFF
--- a/src/components/Playback/PlaybackStage.test.tsx
+++ b/src/components/Playback/PlaybackStage.test.tsx
@@ -1,9 +1,17 @@
+// @vitest-environment jsdom
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, test, vi } from "vitest";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { PlaybackStage } from "./PlaybackStage";
 import type { Song } from "@/types/ipc";
 
-const { mockCdgState, mockPlayerState, mockLibraryState } = vi.hoisted(() => ({
+const {
+  mockCdgState,
+  mockPlayerState,
+  mockLibraryState,
+  mockGetCoverArtPreview,
+} = vi.hoisted(() => ({
   mockCdgState: { hasCdg: false },
   mockPlayerState: {
     snapshot: {
@@ -30,6 +38,7 @@ const { mockCdgState, mockPlayerState, mockLibraryState } = vi.hoisted(() => ({
       },
     ] as Song[],
   },
+  mockGetCoverArtPreview: vi.fn<(hash: string) => Promise<number[] | null>>(),
 }));
 
 vi.mock("@/stores/cdg-store", () => ({
@@ -59,6 +68,19 @@ vi.mock("@/components/Cdg/CdgCanvas", () => ({
 vi.mock("@/components/Lyrics/LyricsPanel", () => ({
   LyricsPanel: () => <div data-testid="lyrics-panel">Lyrics</div>,
 }));
+
+vi.mock("@/lib/tauri/library", () => ({
+  getCoverArtPreview: mockGetCoverArtPreview,
+}));
+
+vi.mock("@/stores/settings-store", () => ({
+  useSettingsStore: (selector: (s: { coverArtBackdrop: boolean }) => unknown) =>
+    selector({ coverArtBackdrop: true }),
+}));
+
+afterEach(() => {
+  mockGetCoverArtPreview.mockReset();
+});
 
 describe("PlaybackStage", () => {
   test("renders the CDG canvas when the current song metadata has CDG media", () => {
@@ -117,5 +139,42 @@ describe("PlaybackStage", () => {
     expect(markup).toContain('data-stage-visual-variant="default"');
     expect(markup).not.toContain('data-native-stage-backdrop="true"');
     expect(markup).toContain("lyrics-panel");
+  });
+
+  test("clears stale fetched cover art and fetches on mount when cover_art is absent", async () => {
+    mockCdgState.hasCdg = false;
+    mockLibraryState.songs = [
+      {
+        hash: "song-fetch",
+        file_path: "song.mp3",
+        audio_source_kind: "original",
+        cdg_path: null,
+        media_g_container: null,
+        instrumental: false,
+        title: "Fetch",
+        artist: null,
+        album: null,
+        duration_ms: 1000,
+        cover_art: null,
+        has_cover_art: true,
+        imported_at: 0,
+        original_ext: "mp3",
+      },
+    ] as Song[];
+    mockPlayerState.snapshot = { song_id: "song-fetch" };
+    mockGetCoverArtPreview.mockResolvedValue([0xff, 0xd8, 0x00]);
+
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(<PlaybackStage />);
+    });
+
+    // The effect clears stale bytes then fetches the preview derivative.
+    expect(mockGetCoverArtPreview).toHaveBeenCalledWith("song-fetch");
+
+    await act(async () => {
+      root.unmount();
+    });
   });
 });

--- a/src/components/Playback/PlaybackStage.tsx
+++ b/src/components/Playback/PlaybackStage.tsx
@@ -33,8 +33,10 @@ export function PlaybackStage({
     null,
   );
   useEffect(() => {
+    // Clear stale bytes from a previous song on every dep change so the
+    // ambience backdrop never briefly paints the predecessor's cover.
+    setFetchedCoverArt(null);
     if (currentSong?.cover_art != null || !currentSong?.has_cover_art) {
-      setFetchedCoverArt(null);
       return;
     }
     let cancelled = false;
@@ -74,14 +76,16 @@ export function PlaybackStage({
         <>
           <div className="absolute inset-0" data-native-stage-backdrop="true">
             <div
-              className="absolute inset-[-6%] scale-[1.06] bg-center bg-cover opacity-40 blur-2xl saturate-[0.85] brightness-[0.75]"
-              style={
-                nativeBackdropUrl
+              className="absolute inset-[-6%] scale-[1.06] bg-center bg-cover"
+              style={{
+                ...(nativeBackdropUrl
                   ? { backgroundImage: `url(${nativeBackdropUrl})` }
-                  : undefined
-              }
+                  : {}),
+                opacity: "var(--ambience-backdrop-opacity)",
+                filter: "var(--ambience-backdrop-filter)",
+              }}
             />
-            <div className="absolute inset-0 bg-[var(--color-scrim)]" />
+            <div className="absolute inset-0 bg-[var(--ambience-scrim)]" />
           </div>
           <div className="relative z-10 flex min-h-0 flex-1 overflow-hidden">
             <LyricsPanel presentation={presentation} />

--- a/src/lib/cover-art.hook.test.tsx
+++ b/src/lib/cover-art.hook.test.tsx
@@ -113,4 +113,21 @@ describe("useCoverArtUrl hook lifecycle", () => {
     expect(revokeObjectURL).toHaveBeenCalledTimes(1);
     expect(revokeObjectURL).toHaveBeenCalledWith(url1);
   });
+
+  test("returns null and skips retain/release when bytes are null", () => {
+    const { result, rerender, unmount } = renderHook(
+      (props: { bytes: CoverArtBytes }) =>
+        useCoverArtUrl("song-null", props.bytes, "preview"),
+      { bytes: null } as { bytes: CoverArtBytes },
+    );
+
+    expect(result.current).toBeNull();
+    expect(createObjectURL).not.toHaveBeenCalled();
+
+    // Non-null bytes arrive — now a URL is created.
+    rerender({ bytes: [0xff, 0xd8, 0x00] });
+    expect(result.current).toBeTruthy();
+
+    unmount();
+  });
 });

--- a/src/lib/cover-art.hook.test.tsx
+++ b/src/lib/cover-art.hook.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { CoverArtBytes } from "@/types/ipc";
+import { resetCoverArtCacheForTests, useCoverArtUrl } from "./cover-art";
+
+function renderHook<T, P>(
+  hook: (props: P) => T,
+  initialProps: P,
+): {
+  result: { current: T };
+  rerender: (props: P) => void;
+  unmount: () => void;
+} {
+  const result = { current: undefined as unknown as T };
+  let currentProps = initialProps;
+  function TestComponent() {
+    result.current = hook(currentProps);
+    return null;
+  }
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  act(() => {
+    root.render(<TestComponent />);
+  });
+  return {
+    result,
+    rerender: (props: P) => {
+      currentProps = props;
+      act(() => {
+        root.render(<TestComponent />);
+      });
+    },
+    unmount: () => {
+      act(() => root.unmount());
+    },
+  };
+}
+
+const createObjectURL = vi.fn(
+  (blob: Blob) => `blob:${blob.type}:${Math.random().toString(36).slice(2)}`,
+);
+const revokeObjectURL = vi.fn();
+
+describe("useCoverArtUrl hook lifecycle", () => {
+  beforeEach(() => {
+    vi.stubGlobal("URL", { createObjectURL, revokeObjectURL });
+  });
+
+  afterEach(() => {
+    resetCoverArtCacheForTests();
+    vi.unstubAllGlobals();
+    createObjectURL.mockClear();
+    revokeObjectURL.mockClear();
+  });
+
+  test("survives byte replacement across re-renders without prematurely revoking the new URL", () => {
+    // Regression: when bytes change under the same songHash+size, the old
+    // useEffect cleanup must not revoke the new URL. Before the fix, the
+    // cleanup decremented the new entry's refs to zero and revoked it,
+    // causing the ambience backdrop to silently disappear.
+    const jpeg: CoverArtBytes = [0xff, 0xd8, 0x00];
+    const png: CoverArtBytes = [0x89, 0x50, 0x4e, 0x47];
+
+    const { result, rerender, unmount } = renderHook(
+      (props: { bytes: CoverArtBytes }) =>
+        useCoverArtUrl("song-lifecycle", props.bytes, "preview"),
+      { bytes: jpeg },
+    );
+
+    const urlAfterJpeg = result.current;
+    expect(urlAfterJpeg).toBeTruthy();
+
+    // Replace bytes — simulates the async fetch delivering the real cover
+    // after the hook initially rendered with a stale or placeholder set.
+    rerender({ bytes: png });
+    const urlAfterPng = result.current;
+    expect(urlAfterPng).not.toBe(urlAfterJpeg);
+
+    // The old URL was revoked at replacement time.
+    expect(revokeObjectURL).toHaveBeenCalledWith(urlAfterJpeg);
+    // The new URL must NOT have been revoked by the stale cleanup.
+    expect(revokeObjectURL).not.toHaveBeenCalledWith(urlAfterPng);
+
+    unmount();
+    expect(revokeObjectURL).toHaveBeenCalledWith(urlAfterPng);
+  });
+
+  test("does not inflate ref count when bytes reference changes but content stays the same", () => {
+    // Store re-emits can produce a new array reference with identical bytes.
+    // The hook should not call retainCoverArtUrl again (which would increment
+    // refs without a matching release), so the URL is cleaned up correctly on
+    // unmount.
+    const jpeg: CoverArtBytes = [0xff, 0xd8, 0x00];
+    const jpegCopy: CoverArtBytes = [...jpeg];
+
+    const { result, rerender, unmount } = renderHook(
+      (props: { bytes: CoverArtBytes }) =>
+        useCoverArtUrl("song-stable", props.bytes, "preview"),
+      { bytes: jpeg },
+    );
+
+    const url1 = result.current;
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+
+    // New reference, same content — no new URL, no extra retain.
+    rerender({ bytes: jpegCopy });
+    expect(result.current).toBe(url1);
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+
+    unmount();
+    expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith(url1);
+  });
+});

--- a/src/lib/cover-art.test.ts
+++ b/src/lib/cover-art.test.ts
@@ -146,6 +146,27 @@ describe("cover-art", () => {
     expect(URL.revokeObjectURL).toHaveBeenCalledWith(second);
   });
 
+  test("releaseCoverArtUrl with url guard skips stale cleanups after byte replacement", () => {
+    // Simulates the useCoverArtUrl hook lifecycle: retain URL_A, then replace
+    // with URL_B (same key, different bytes), then the OLD useEffect cleanup
+    // fires. Without the url guard, the cleanup would decrement the new
+    // entry's refs and prematurely revoke URL_B.
+    const jpeg = [0xff, 0xd8, 0x00];
+    const png = [0x89, 0x50, 0x4e, 0x47];
+
+    const urlA = retainCoverArtUrl("song-guard", jpeg, "thumb");
+    const urlB = retainCoverArtUrl("song-guard", png, "thumb");
+    expect(urlA).not.toBe(urlB);
+
+    // Old cleanup fires with the stale url — must be a no-op.
+    releaseCoverArtUrl("song-guard", "thumb", urlA);
+    expect(URL.revokeObjectURL).not.toHaveBeenCalledWith(urlB);
+
+    // New cleanup fires with the current url — releases normally.
+    releaseCoverArtUrl("song-guard", "thumb", urlB);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith(urlB);
+  });
+
   test("same-key identical bytes reuse the cached URL without revoking", () => {
     const jpeg = [0xff, 0xd8, 0x00];
 

--- a/src/lib/cover-art.ts
+++ b/src/lib/cover-art.ts
@@ -7,7 +7,7 @@ interface CoverArtCacheEntry {
   // Identity of the bytes used to create this entry. When new bytes arrive
   // under the same `${songHash}:${size}` key, the replacement is detected by
   // comparing this digest against the incoming bytes and the old URL is
-  // revoked after its refs reach zero, so a stale entry is never returned.
+  // revoked immediately, so a stale entry is never returned.
   byteDigest: string;
 }
 
@@ -119,9 +119,12 @@ export function retainCoverArtUrl(
   const cached = coverArtUrlCache.get(key);
   if (cached) {
     // Byte identity in replacement: when new bytes arrive under the same key,
-    // revoke the old URL after its refs reach zero and create a new entry
-    // rather than returning stale content. Returning the cached URL here
-    // would silently serve the previous cover after a refresh.
+    // revoke the old URL immediately and create a new entry rather than
+    // returning stale content. The new entry starts with refs=1 (for this
+    // retain call); the old entry's refs are abandoned because the old URL is
+    // already revoked and its holders will clean up via releaseCoverArtUrl's
+    // url-match guard. Carrying over refs would let the old cleanup
+    // decrement the new URL below zero and prematurely revoke it.
     if (cached.byteDigest !== incomingDigest) {
       if (typeof URL.revokeObjectURL === "function") {
         URL.revokeObjectURL(cached.url);
@@ -132,7 +135,7 @@ export function retainCoverArtUrl(
         }),
       );
       coverArtUrlCache.set(key, {
-        refs: cached.refs,
+        refs: 1,
         url,
         byteDigest: incomingDigest,
       });
@@ -158,10 +161,20 @@ export function retainCoverArtUrl(
 export function releaseCoverArtUrl(
   songHash: string,
   size: CoverArtSize = "original",
+  url?: string | null,
 ): void {
   const key = cacheKey(songHash, size);
   const cached = coverArtUrlCache.get(key);
   if (!cached) {
+    return;
+  }
+
+  // When the caller provides the url that was retained, only release if the
+  // cached entry still holds that exact url. If the bytes were replaced
+  // between the retain and this release, the cached url is a newer one and
+  // decrementing its refs would prematurely revoke it. The old url was
+  // already revoked at replacement time, so this release is a safe no-op.
+  if (url != null && cached.url !== url) {
     return;
   }
 
@@ -205,14 +218,38 @@ export function resetCoverArtCacheForTests(): void {
   coverArtUrlCache.clear();
 }
 
+// Content-based identity for cover art bytes. Used as a useMemo dependency
+// instead of the raw bytes reference so that a new array with identical
+// content (e.g. from a store re-emit) does not trigger a redundant
+// retainCoverArtUrl call that would inflate the ref count without a matching
+// release.
+function coverArtDigest(bytes: CoverArtBytes): string | null {
+  const normalized = ensureCoverArtBytes(bytes);
+  if (!normalized || normalized.byteLength === 0) {
+    return null;
+  }
+  return byteDigest(normalized);
+}
+
 export function useCoverArtUrl(
   songHash: string,
   bytes: CoverArtBytes,
   size: CoverArtSize = "original",
 ): string | null {
+  // Stabilize on content identity (digest) rather than reference identity so
+  // store re-emits that produce a new array with the same bytes do not cause
+  // a redundant retain (which would leak a ref since the useEffect cleanup
+  // only fires when the url string changes).
+  const digest = useMemo(() => coverArtDigest(bytes), [bytes]);
+
+  // `bytes` is intentionally replaced by `digest` so that a new array
+  // reference with identical content does not trigger a redundant retain
+  // (ref-count leak). The lint rule cannot see that digest is derived from
+  // bytes, so suppress its missing-deps warning on the deps line below.
   const url = useMemo(
     () => retainCoverArtUrl(songHash, bytes, size),
-    [songHash, bytes, size],
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+    [songHash, digest, size],
   );
 
   useEffect(() => {
@@ -221,7 +258,10 @@ export function useCoverArtUrl(
     }
 
     return () => {
-      releaseCoverArtUrl(songHash, size);
+      // Pass the exact url so releaseCoverArtUrl can skip stale cleanups
+      // whose retained url was already replaced by a newer one under the
+      // same cache key.
+      releaseCoverArtUrl(songHash, size, url);
     };
   }, [songHash, size, url]);
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -80,6 +80,15 @@
     --color-on-accent: #ffffff;
     --color-on-media: #ffffff;
     --color-scrim: rgba(0, 0, 0, 0.5);
+    /*
+     * Ambience backdrop tokens for the blurred cover-art behind standard-mode
+     * lyrics. Kept separate from --color-scrim (which is shared with
+     * dialogs/popovers) so the ambience layer can be tuned independently to
+     * keep the cover visible while preserving lyric contrast.
+     */
+    --ambience-scrim: rgba(0, 0, 0, 0.5);
+    --ambience-backdrop-opacity: 0.4;
+    --ambience-backdrop-filter: blur(40px) saturate(0.85) brightness(0.75);
     --color-lyrics-active: #ffffff;
     --color-lyrics-past: rgba(255, 255, 255, 0.45);
     --color-lyrics-future: rgba(255, 255, 255, 0.5);
@@ -144,6 +153,15 @@
     --color-on-accent: #ffffff;
     --color-on-media: #ffffff;
     --color-scrim: rgba(255, 255, 255, 0.76);
+    /*
+     * Light ambience: lift the cover slightly so dark lyric text stays
+     * readable, and use a lighter scrim than the dark theme so the blurred
+     * cover art remains visible behind the lyrics. The dark theme darkens the
+     * cover; the light theme brightens it.
+     */
+    --ambience-scrim: rgba(255, 255, 255, 0.5);
+    --ambience-backdrop-opacity: 0.55;
+    --ambience-backdrop-filter: blur(40px) saturate(0.85) brightness(1.05);
     --color-lyrics-active: #16171a;
     --color-lyrics-past: rgba(29, 29, 31, 0.42);
     --color-lyrics-future: rgba(29, 29, 31, 0.48);


### PR DESCRIPTION
## Summary

The blurred cover-art backdrop behind standard-mode lyrics was unstable in both dark and light mode. Two root causes:

**1. Ref-count race in `useCoverArtUrl`** — When bytes change under the same `songHash+size` (async fetch delivering the real cover after a render with stale bytes), `retainCoverArtUrl` revoked the old URL and carried over `refs` to the new entry. The old `useEffect` cleanup then fired, decremented the new entry's refs to zero, and revoked the new URL — leaving the component holding a revoked URL that never reloads. This happened on every song change via the async fetch path.

- New entry starts at `refs=1` (old refs abandoned since old URL is already revoked)
- `releaseCoverArtUrl` gains an optional `url` guard so a stale cleanup carrying the old url is a no-op against the new cached entry
- The hook passes its retained url to release

**2. Ref-count leak on store re-emits** — A new array reference with identical bytes triggered a redundant retain (inflating refs) without a matching release. The hook now keys `useMemo` on a content digest instead of the raw bytes reference.

**3. Stale bytes on song change** — `PlaybackStage`'s fetch effect now clears `fetchedCoverArt` at the top of every dep change so the ambience layer never briefly paints the predecessor's cover.

**4. Light-mode scrim washout** — The ambience layer shared `--color-scrim` with dialogs/popovers, so light mode's 76% white scrim washed out the cover. Introduced dedicated `--ambience-scrim` / `--ambience-backdrop-opacity` / `--ambience-backdrop-filter` tokens tuned per theme.

#### Test plan
- [x] `pnpm lint` (0 warnings, 0 errors)
- [x] `pnpm build` (tsc + vite)
- [x] `pnpm test` (165 files, 1781 tests)
- [x] New regression test: byte replacement across re-renders does not prematurely revoke the new URL
- [x] New test: identical-content new reference does not inflate ref count
- [x] New test: `releaseCoverArtUrl` url guard skips stale cleanups after byte replacement
- [x] Patch coverage 88.8% (target 80%)