### PR TITLE
fix(romanize): scale pronunciation and bg_words lines with lyricsFontStep

### DIFF
--- a/src/components/Lyrics/LyricLine.test.tsx
+++ b/src/components/Lyrics/LyricLine.test.tsx
@@ -630,4 +630,80 @@ describe("LyricLine", () => {
     expect(markup).toContain("text-[var(--color-lyrics-active)]");
     expect(markup).toContain("var(--shadow-lyrics-glow-strong)");
   });
+
+  test("scales romanized pronunciation line with lyricsFontStep in standard mode", () => {
+    const line = {
+      time_ms: 1000,
+      text: "你好世界",
+      words: [
+        { text: "你好", time_ms: 1000, end_ms: 1500 },
+        { text: "世界", time_ms: 1500, end_ms: 2000 },
+      ],
+      bg_words: null,
+      section: null,
+    };
+
+    const smallStep = renderToStaticMarkup(
+      <LyricLine
+        lineIndex={0}
+        line={line}
+        state="active"
+        lyricsFontStep={-2}
+        romanizedText="ni hao shi jie"
+      />,
+    );
+    const largeStep = renderToStaticMarkup(
+      <LyricLine
+        lineIndex={0}
+        line={line}
+        state="active"
+        lyricsFontStep={2}
+        romanizedText="ni hao shi jie"
+      />,
+    );
+
+    // Smallest step clamps the secondary track at text-xs (the primary lyric
+    // at step -2 is still text-lg, so the secondary must be smaller).
+    expect(smallStep).toContain("text-xs");
+    expect(smallStep).not.toContain("md:text-base");
+    // Largest step grows the secondary track past the old fixed text-sm/md:text-base.
+    expect(largeStep).toContain("text-lg");
+    expect(largeStep).toContain("xl:text-3xl");
+  });
+
+  test("scales bg_words line with lyricsFontStep in standard mode", () => {
+    const line = {
+      time_ms: 1000,
+      text: "main line",
+      words: [
+        { text: "main", time_ms: 1000, end_ms: 1500 },
+        { text: "line", time_ms: 1500, end_ms: 2000 },
+      ],
+      bg_words: [{ text: "bg", time_ms: 1200, end_ms: 1800 }],
+      section: null,
+    };
+
+    const smallStep = renderToStaticMarkup(
+      <LyricLine
+        lineIndex={0}
+        line={line}
+        state="active"
+        activeWordIndex={1}
+        lyricsFontStep={-2}
+      />,
+    );
+    const largeStep = renderToStaticMarkup(
+      <LyricLine
+        lineIndex={0}
+        line={line}
+        state="active"
+        activeWordIndex={1}
+        lyricsFontStep={2}
+      />,
+    );
+
+    expect(smallStep).toContain("text-xs");
+    expect(largeStep).toContain("text-lg");
+    expect(largeStep).toContain("xl:text-3xl");
+  });
 });

--- a/src/components/Lyrics/LyricLine.tsx
+++ b/src/components/Lyrics/LyricLine.tsx
@@ -40,6 +40,21 @@ const AUDIENCE_TEXT_SIZE_CLASSES = {
   [2]: "text-6xl font-bold tracking-tight md:text-8xl xl:text-8xl",
 } as const;
 
+// RATIONALE: Secondary lines (romanized pronunciation, background vocals) sit
+// visually below the primary lyric. The audience renderer scales them to 0.55×
+// the primary fontSizePx; standard mode mirrors that ratio by stepping the
+// Tailwind size down so the secondary track grows and shrinks with the same
+// lyricsFontStep control instead of staying pinned at text-sm/md:text-base.
+// The smallest step clamps at text-xs to stay readable when the primary is
+// already at its minimum.
+const STANDARD_SECONDARY_TEXT_SIZE_CLASSES = {
+  [-2]: "text-xs",
+  [-1]: "text-xs md:text-sm",
+  [0]: "text-sm md:text-base",
+  [1]: "text-base md:text-lg xl:text-2xl",
+  [2]: "text-lg md:text-2xl xl:text-3xl",
+} as const;
+
 function getLyricsTextSizeClass(
   presentation: "standard" | "audience",
   lyricsFontStep: number,
@@ -54,6 +69,16 @@ function getLyricsTextSizeClass(
   return presentation === "audience"
     ? AUDIENCE_TEXT_SIZE_CLASSES[clampedStep]
     : STANDARD_TEXT_SIZE_CLASSES[clampedStep];
+}
+
+function getLyricsSecondaryTextSizeClass(lyricsFontStep: number): string {
+  const clampedStep = Math.max(-2, Math.min(2, lyricsFontStep)) as
+    | -2
+    | -1
+    | 0
+    | 1
+    | 2;
+  return STANDARD_SECONDARY_TEXT_SIZE_CLASSES[clampedStep];
 }
 
 function shouldEmphasize(word: {
@@ -112,6 +137,8 @@ export const LyricLine = memo(function LyricLine({
   const seek = usePlayerStore((s) => s.seek);
   const isSeekable = state !== "plain";
   const textSizeClass = getLyricsTextSizeClass(presentation, lyricsFontStep);
+  const secondaryTextSizeClass =
+    getLyricsSecondaryTextSizeClass(lyricsFontStep);
   const audiencePresentationSpec =
     buildAudiencePresentationSpec(lyricsFontStep);
 
@@ -351,7 +378,7 @@ export const LyricLine = memo(function LyricLine({
           className={
             presentation === "audience"
               ? "motion-surface font-medium tracking-tight"
-              : `motion-surface text-sm font-medium md:text-base ${
+              : `motion-surface ${secondaryTextSizeClass} font-medium ${
                   state === "plain" || state === "active"
                     ? "text-[var(--color-text-dim)]"
                     : state === "past"
@@ -391,7 +418,7 @@ export const LyricLine = memo(function LyricLine({
           className={
             presentation === "audience"
               ? "motion-surface font-medium tracking-tight opacity-50"
-              : `motion-surface text-sm font-medium md:text-base ${
+              : `motion-surface ${secondaryTextSizeClass} font-medium ${
                   state === "plain" || state === "active"
                     ? "text-[var(--color-text-dim)]"
                     : state === "past"


### PR DESCRIPTION
## Summary
- Standard-mode romanized pronunciation lines and background-vocal (`bg_words`) lines were pinned to `text-sm md:text-base` and ignored the lyrics font-size control, while the audience renderer already scaled them to 0.55× of the primary `fontSizePx`.
- Mirror the audience ratio in standard mode via a new `STANDARD_SECONDARY_TEXT_SIZE_CLASSES` table keyed by `lyricsFontStep`. Step 0 keeps the old `text-sm md:text-base` so the default visual is unchanged; only non-default font sizes now flow through to the secondary track. Minimum step clamps at `text-xs` to stay readable.
- Applies the same scaling to `bg_words`, which had the identical fixed-size problem and shares the secondary visual tier.

#### Test plan
- [x] `pnpm vitest run src/components/Lyrics/LyricLine.test.tsx` — 21/21 (incl. 2 new tests covering romanized + bg_words scaling at step -2 / +2)
- [x] `pnpm vitest run src/components/Lyrics/LyricsPanel.test.tsx` — 18/18
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `tsc --noEmit` — clean
- [x] pre-push hook: full suite 1785/1785, patch coverage 100% (4/4)