### PR TITLE
ci(release): append installation section to GitHub Release Notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,43 @@ jobs:
           INPUT_NOTES: ${{ github.event.inputs.notes }}
         run: |
           npx git-cliff --tag "${RELEASE_TAG}" --strip header -o RELEASE_NOTES.md
+
+          # Append installation section. Mirrors README "Install from Release"
+          # so users can install straight from the GitHub Release page.
+          cat >> RELEASE_NOTES.md <<'INSTALL_EOF'
+
+          ---
+
+          ## Installation
+
+          Download the latest build for your platform from the assets below:
+
+          | Platform              | Format                  |
+          | --------------------- | ----------------------- |
+          | macOS (Apple Silicon) | `.dmg`                  |
+          | macOS (Intel)         | `.dmg`                  |
+          | Windows               | `.exe` (NSIS installer) |
+          | Linux                 | `.AppImage` / `.deb`    |
+
+          **macOS (Homebrew):**
+
+          ```bash
+          brew install thedavidweng/tap/openkara
+          ```
+
+          **Windows (winget):**
+
+          ```bash
+          winget install thedavidweng.OpenKara
+          ```
+
+          **macOS Gatekeeper note:** If macOS says the app is damaged or can't be opened, run:
+
+          ```bash
+          xattr -rd com.apple.quarantine /Applications/OpenKara.app
+          ```
+          INSTALL_EOF
+
           {
             echo 'body<<GIT_CLIFF_EOF'
             cat RELEASE_NOTES.md


### PR DESCRIPTION
## Summary
- Append an `## Installation` section to the GitHub Release Notes body in the `prepare-release` job, mirroring README's "Install from Release" block (platform table, Homebrew, winget, macOS Gatekeeper note) so users can install straight from the Release page without jumping back to the README.

#### Test plan
- [x] pre-push hooks pass locally (lint, format-check, cargo-fmt-check, 1783 tests, patch-coverage)
- [ ] CI green on PR
- [ ] Next release's GitHub Release body includes the Installation section