### PR TITLE
ci: replace paths-filter with checked-in classifier and harden CI Gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,9 +522,9 @@ jobs:
             echo "git-cliff not installed, skipping parse check"
             exit 0
           fi
-          git cliff --help >/dev/null 2>&1 || true
           # Verify the config is parseable by generating an empty changelog.
-          git cliff --unreleased --tag 0.0.0-test --output /dev/null || true
+          # A parse failure must exit non-zero so release-validation fails.
+          git cliff --unreleased --tag 0.0.0-test --output /dev/null
 
   dependency-checks:
     name: Dependency surface checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,21 +20,21 @@ env:
 
 jobs:
   # ── Triage ───────────────────────────────────────────────────────────
-  # Runs on every PR/push. Does two things:
-  #   1. Auto-labels the PR by changed-file paths (actions/labeler).
-  #   2. Computes boolean path-filter outputs that downstream jobs use in
-  #      `if:` conditionals to skip entire job branches when nothing in
-  #      their scope changed. Skipped jobs report Success, so branch
-  #      protection required checks still pass.
+  # Runs the checked-in classifier (scripts/ci/classify-changes.mjs) to
+  # determine which jobs should run for this change set. The classifier is
+  # a pure function over filenames and event type — it is the single source
+  # of truth for path-based CI gating.
   #
-  # Path classification strategy:
-  #   - Known categories (frontend, rust, deps, workflows, e2e) list every
-  #     file path that can affect them.
-  #   - `unknown` matches any changed file NOT in a known category. This
-  #     is a safety net: new directories or config files added in the
-  #     future trigger full CI instead of silently skipping.
-  #   - Downstream jobs OR `unknown` into their conditions so unmapped
-  #     changes never bypass CI.
+  # Outputs:
+  #   expected-jobs       JSON array of job IDs that must run
+  #   run_<job>           "true"/"false" per job ID, consumed by `if:` conditions
+  #   unknown             "true" if any file is unmapped
+  #   unknown-files       JSON array of unmapped filenames
+  #   categories          JSON array of detected categories
+  #
+  # For push (to main) and workflow_dispatch, the classifier returns full CI
+  # as a deliberate safety path — the integration branch always gets full
+  # validation regardless of what changed.
   triage:
     name: Triage
     runs-on: ubuntu-24.04
@@ -43,17 +43,31 @@ jobs:
       contents: read
       pull-requests: write # labeler needs this to add/remove labels
     outputs:
-      frontend: ${{ steps.filter.outputs.frontend }}
-      rust: ${{ steps.filter.outputs.rust }}
-      deps: ${{ steps.filter.outputs.deps }}
-      workflows: ${{ steps.filter.outputs.workflows }}
-      e2e: ${{ steps.filter.outputs.e2e }}
-      unknown: ${{ steps.filter.outputs.unknown }}
+      expected-jobs: ${{ steps.classify.outputs.expected-jobs }}
+      expected-skipped-heavy: ${{ steps.classify.outputs.expected-skipped-heavy }}
+      unknown: ${{ steps.classify.outputs.unknown }}
+      unknown-files: ${{ steps.classify.outputs.unknown-files }}
+      categories: ${{ steps.classify.outputs.categories }}
+      run_triage: ${{ steps.classify.outputs.run_triage }}
+      run_conventional-commits: ${{ steps.classify.outputs.run_conventional-commits }}
+      run_ci-gate: ${{ steps.classify.outputs.run_ci-gate }}
+      run_js-quality: ${{ steps.classify.outputs.run_js-quality }}
+      run_app-frontend: ${{ steps.classify.outputs.run_app-frontend }}
+      run_website: ${{ steps.classify.outputs.run_website }}
+      run_playwright-ui-smoke: ${{ steps.classify.outputs.run_playwright-ui-smoke }}
+      run_workflow-lint: ${{ steps.classify.outputs.run_workflow-lint }}
+      run_release-validation: ${{ steps.classify.outputs.run_release-validation }}
+      run_cargo-deny: ${{ steps.classify.outputs.run_cargo-deny }}
+      run_dependency-checks: ${{ steps.classify.outputs.run_dependency-checks }}
+      run_prepare-model: ${{ steps.classify.outputs.run_prepare-model }}
+      run_rust-test: ${{ steps.classify.outputs.run_rust-test }}
+      run_rust-test-windows-compile: ${{ steps.classify.outputs.run_rust-test-windows-compile }}
+      run_tauri-build-smoke: ${{ steps.classify.outputs.run_tauri-build-smoke }}
+      run_tauri-build: ${{ steps.classify.outputs.run_tauri-build }}
     steps:
       # paths-filter uses the GitHub API for PR events (no checkout needed);
       # for push events it diffs via git, so checkout is required.
       - name: Checkout
-        if: github.event_name != 'pull_request'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
@@ -70,87 +84,103 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true
 
-      - name: Detect changed paths
-        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
-        id: filter
-        with:
-          filters: |
-            frontend:
-              - 'src/**'
-              - 'vite.config.ts'
-              - 'tsconfig.json'
-              - 'tsconfig.node.json'
-              - 'tsconfig.app.json'
-              - 'website/**'
-              - 'public/**'
-              - 'oxlintrc.json'
-              - '.oxfmtrc.json'
-              - 'knip.json'
-              - 'index.html'
-              - 'scripts/**'
-              - 'tests/**'
-              - 'playwright*.config.ts'
-            rust:
-              - 'src-tauri/**'
-              - 'rust-toolchain.toml'
-              - 'patches/**'
-              - 'scripts/prepare-onnx-runtime.mjs'
-            deps:
-              - 'pnpm-lock.yaml'
-              - 'package.json'
-              - 'src-tauri/Cargo.toml'
-              - 'src-tauri/Cargo.lock'
-            workflows:
-              - '.github/workflows/**'
-              - '.github/labeler.yml'
-            e2e:
-              - 'tests/e2e/**'
-              - 'playwright*.config.ts'
-            # Safety net: any changed file not in a known category triggers
-            # full CI. Negated patterns exclude known paths; if any file
-            # remains, `unknown` is true.
-            unknown:
-              - '**'
-              - '!src/**'
-              - '!src-tauri/**'
-              - '!scripts/**'
-              - '!tests/**'
-              - '!website/**'
-              - '!public/**'
-              - '!docs/**'
-              - '!**/*.md'
-              - '!pnpm-lock.yaml'
-              - '!package.json'
-              - '!vite.config.ts'
-              - '!tsconfig.json'
-              - '!tsconfig.node.json'
-              - '!tsconfig.app.json'
-              - '!knip.json'
-              - '!oxlintrc.json'
-              - '!.oxfmtrc.json'
-              - '!rust-toolchain.toml'
-              - '!patches/**'
-              - '!.github/workflows/**'
-              - '!.github/labeler.yml'
-              - '!playwright*.config.ts'
-              - '!index.html'
-              - '!cliff.toml'
-              - '!renovate.json'
-              - '!mise.toml'
-              - '!AGENTS.md'
-              - '!LICENSE'
-              - '!.gitignore'
-              - '!.gitattributes'
+      - name: Collect changed files
+        id: collect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            # Use the GitHub API with pagination to get the complete file list.
+            gh api --paginate --jq '.[].filename' \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+              > changed-files.txt
+          elif [ "$EVENT_NAME" = "push" ]; then
+            # Diff before/after. Handle the zero-SHA (new branch) edge case.
+            if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+              git diff --name-only HEAD~1..HEAD > changed-files.txt
+            else
+              git diff --name-only "$BEFORE".."$AFTER" > changed-files.txt
+            fi
+          else
+            # workflow_dispatch — no changed files; classifier returns full CI.
+            : > changed-files.txt
+          fi
+          echo "count=$(wc -l < changed-files.txt | tr -d ' ')" >> "$GITHUB_OUTPUT"
+
+      - name: Classify changes
+        id: classify
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          node scripts/ci/classify-changes.mjs \
+            --files "$(cat changed-files.txt)" \
+            --event "$EVENT_NAME" \
+            > classification.json
+
+          # Extract outputs for GITHUB_OUTPUT.
+          jq -r '
+            "expected-jobs=\(.expectedJobs | @json)",
+            "expected-skipped-heavy=\(.expectedSkippedHeavyJobs | @json)",
+            "unknown=\(if .unknownFiles | length > 0 then "true" else "false" end)",
+            "unknown-files=\(.unknownFiles | @json)",
+            "categories=\(.categories | @json)"
+          ' classification.json >> "$GITHUB_OUTPUT"
+
+          # Per-job run_ booleans.
+          jq -r '.run | to_entries[] | "run_\(.key)=\(.value)"' \
+            classification.json >> "$GITHUB_OUTPUT"
+
+          # Print classification to the step summary.
+          {
+            echo "## CI Triage"
+            echo ""
+            echo "**Event:** \`${EVENT_NAME}\`"
+            echo ""
+            echo "### Changed files"
+            echo ""
+            if [ -s changed-files.txt ]; then
+              while IFS= read -r file; do
+                cats=$(jq -r --arg f "$file" \
+                  '.categoriesByFile[$f] // ["unknown"] | join(", ")' \
+                  classification.json)
+                echo "- \`${file}\` → ${cats}"
+              done < changed-files.txt
+            else
+              echo "- _(none — full CI by event type)_"
+            fi
+            echo ""
+            echo "### Expected jobs"
+            echo ""
+            jq -r '.expectedJobs[] | "- \(.)"' classification.json
+            echo ""
+            echo "### Expected skipped heavy jobs"
+            echo ""
+            skipped=$(jq -r '.expectedSkippedHeavyJobs | length' classification.json)
+            if [ "$skipped" -gt 0 ]; then
+              jq -r '.expectedSkippedHeavyJobs[] | "- \(.)"' classification.json
+            else
+              echo "- _(none)_"
+            fi
+            if [ "$(jq '.unknownFiles | length' classification.json)" -gt 0 ]; then
+              echo ""
+              echo "### ⚠️ Unknown files (full CI safety fallback)"
+              echo ""
+              jq -r '.unknownFiles[] | "- `\(.)`"' classification.json
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
   prepare-model:
     name: Prepare separation model
     needs: triage
     if: |
-      success() &&
-      (needs.triage.outputs.rust == 'true' ||
-       needs.triage.outputs.deps == 'true' ||
-       needs.triage.outputs.workflows == 'true' ||
-       needs.triage.outputs.unknown == 'true')
+      !cancelled() &&
+      needs.triage.outputs.run_prepare-model == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
 
@@ -203,74 +233,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  cargo-deny:
-    name: Cargo deny
+  # ── JS quality ───────────────────────────────────────────────────────
+  # Format, lint, i18n, knip, schema drift, and dependency audit.
+  # Runs for any JS-touching category but does not build or run tests.
+  js-quality:
+    name: JS quality
     needs: triage
     if: |
-      success() &&
-      (needs.triage.outputs.rust == 'true' ||
-       needs.triage.outputs.deps == 'true' ||
-       needs.triage.outputs.workflows == 'true' ||
-       needs.triage.outputs.unknown == 'true')
+      !cancelled() &&
+      needs.triage.outputs.run_js-quality == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-
-      - name: Check Rust dependencies
-        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
-        with:
-          manifest-path: src-tauri/Cargo.toml
-
-  workflow-lint:
-    name: Workflow lint
-    needs: triage
-    if: |
-      success() &&
-      needs.triage.outputs.workflows == 'true'
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-
-    permissions:
-      contents: read
-      security-events: write # Needed by zizmor-action to upload SARIF results.
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-
-      - name: actionlint
-        uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
-        with:
-          actionlint_flags: ""
-
-      - name: zizmor
-        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
-        with:
-          persona: pedantic
-          min-severity: low
-
-  frontend:
-    name: Frontend quality / build / test
-    needs: triage
-    if: |
-      success() &&
-      (needs.triage.outputs.frontend == 'true' ||
-       needs.triage.outputs.deps == 'true' ||
-       needs.triage.outputs.workflows == 'true' ||
-       needs.triage.outputs.unknown == 'true')
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
-
-    permissions:
-      contents: read
-      pull-requests: write # Needed by vitest-coverage-report-action to comment coverage on PRs.
 
     steps:
       - name: Checkout
@@ -313,14 +286,44 @@ jobs:
       - name: knip (unused exports / dependencies)
         run: pnpm knip --no-progress
 
+  # ── App frontend ─────────────────────────────────────────────────────
+  # App typecheck, production build, and unit tests with coverage.
+  app-frontend:
+    name: App frontend build / test
+    needs: triage
+    if: |
+      !cancelled() &&
+      needs.triage.outputs.run_app-frontend == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    permissions:
+      contents: read
+      pull-requests: write # Needed by vitest-coverage-report-action to comment coverage on PRs.
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 11.13.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install JavaScript dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Build frontend
         run: node --run build
-
-      - name: Typecheck landing page
-        run: pnpm tsc --noEmit --project website/tsconfig.json
-
-      - name: Build landing page
-        run: node --run docs:build
 
       - name: Typecheck frontend
         run: pnpm tsc --noEmit --project tsconfig.json
@@ -384,15 +387,151 @@ jobs:
           flags: frontend
           fail_ci_if_error: false
 
+  # ── Website ──────────────────────────────────────────────────────────
+  # Website typecheck and docs build only. Does not run the full app
+  # test suite — website-only changes do not affect app behavior.
+  website:
+    name: Website build
+    needs: triage
+    if: |
+      !cancelled() &&
+      needs.triage.outputs.run_website == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 11.13.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install JavaScript dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck landing page
+        run: pnpm tsc --noEmit --project website/tsconfig.json
+
+      - name: Build landing page
+        run: node --run docs:build
+
+  cargo-deny:
+    name: Cargo deny
+    needs: triage
+    if: |
+      !cancelled() &&
+      needs.triage.outputs.run_cargo-deny == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Check Rust dependencies
+        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
+        with:
+          manifest-path: src-tauri/Cargo.toml
+
+  workflow-lint:
+    name: Workflow lint
+    needs: triage
+    if: |
+      !cancelled() &&
+      needs.triage.outputs.run_workflow-lint == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    permissions:
+      contents: read
+      security-events: write # Needed by zizmor-action to upload SARIF results.
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: actionlint
+        uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
+        with:
+          actionlint_flags: ""
+
+      - name: zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          persona: pedantic
+          min-severity: low
+
+  # ── Release validation ───────────────────────────────────────────────
+  # Focused validation for release-workflow and release-metadata changes.
+  # Runs the release-workflow and release-metadata contract tests and
+  # verifies cliff.toml parses. Does not run app/frontend/Rust CI.
+  release-validation:
+    name: Release validation
+    needs: triage
+    if: |
+      !cancelled() &&
+      needs.triage.outputs.run_release-validation == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 11.13.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install JavaScript dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run release contract tests
+        run: |
+          pnpm vitest run \
+            tests/release-workflow.test.ts \
+            tests/release-metadata.test.ts
+
+      - name: Verify cliff.toml parses
+        run: |
+          if ! command -v git-cliff &>/dev/null; then
+            echo "git-cliff not installed, skipping parse check"
+            exit 0
+          fi
+          git cliff --help >/dev/null 2>&1 || true
+          # Verify the config is parseable by generating an empty changelog.
+          git cliff --unreleased --tag 0.0.0-test --output /dev/null || true
+
   dependency-checks:
     name: Dependency surface checks
     needs: triage
     if: |
-      success() &&
-      (needs.triage.outputs.rust == 'true' ||
-       needs.triage.outputs.deps == 'true' ||
-       needs.triage.outputs.workflows == 'true' ||
-       needs.triage.outputs.unknown == 'true')
+      !cancelled() &&
+      needs.triage.outputs.run_dependency-checks == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
 
@@ -418,10 +557,7 @@ jobs:
     needs: [triage, prepare-model]
     if: |
       !cancelled() &&
-      (needs.triage.outputs.rust == 'true' ||
-       needs.triage.outputs.deps == 'true' ||
-       needs.triage.outputs.workflows == 'true' ||
-       needs.triage.outputs.unknown == 'true') &&
+      needs.triage.outputs.run_rust-test == 'true' &&
       needs.prepare-model.result == 'success'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -542,11 +678,8 @@ jobs:
     name: Rust tests (Windows compile)
     needs: triage
     if: |
-      success() &&
-      (needs.triage.outputs.rust == 'true' ||
-       needs.triage.outputs.deps == 'true' ||
-       needs.triage.outputs.workflows == 'true' ||
-       needs.triage.outputs.unknown == 'true')
+      !cancelled() &&
+      needs.triage.outputs.run_rust-test-windows-compile == 'true'
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
@@ -591,16 +724,14 @@ jobs:
   # Linux-only Tauri smoke build for frontend-only PRs. Verifies that the
   # frontend bundles into Tauri and the build entry point works, without
   # paying for the 3-platform matrix. Runs when frontend changed but rust
-  # did not (pure frontend, deps, workflows, or unknown).
+  # did not (pure frontend, deps_js, or frontend_tooling).
   tauri-build-smoke:
     name: Tauri build (Linux smoke)
-    needs: [triage, frontend]
+    needs: [triage, app-frontend]
     if: |
       !cancelled() &&
-      needs.triage.outputs.frontend == 'true' &&
-      needs.triage.outputs.rust != 'true' &&
-      needs.triage.outputs.unknown != 'true' &&
-      needs.frontend.result != 'failure'
+      needs.triage.outputs.run_tauri-build-smoke == 'true' &&
+      needs.app-frontend.result != 'failure'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
 
@@ -683,25 +814,22 @@ jobs:
     needs:
       [
         triage,
-        frontend,
+        app-frontend,
         rust-test,
         cargo-deny,
         dependency-checks,
         rust-test-windows-compile,
       ]
     # Use !cancelled() so the job can run even when some upstream jobs were
-    # skipped (e.g. a rust-only PR skips frontend, but tauri-build still
+    # skipped (e.g. a rust-only PR skips app-frontend, but tauri-build still
     # needs to verify the Rust side compiles into a Tauri bundle).
     # The result != 'failure' guards ensure we don't build on top of a
-    # failed dependency. Only runs for rust/deps/workflows/unknown —
+    # failed dependency. Only runs for rust/deps/unknown —
     # frontend-only PRs use tauri-build-smoke (Linux) instead.
     if: |
       !cancelled() &&
-      (needs.triage.outputs.rust == 'true' ||
-       needs.triage.outputs.deps == 'true' ||
-       needs.triage.outputs.workflows == 'true' ||
-       needs.triage.outputs.unknown == 'true') &&
-      needs.frontend.result != 'failure' &&
+      needs.triage.outputs.run_tauri-build == 'true' &&
+      needs.app-frontend.result != 'failure' &&
       needs.rust-test.result != 'failure' &&
       needs.cargo-deny.result != 'failure' &&
       needs.dependency-checks.result != 'failure' &&
@@ -878,12 +1006,8 @@ jobs:
     name: Playwright UI smoke
     needs: triage
     if: |
-      success() &&
-      (needs.triage.outputs.frontend == 'true' ||
-       needs.triage.outputs.e2e == 'true' ||
-       needs.triage.outputs.deps == 'true' ||
-       needs.triage.outputs.workflows == 'true' ||
-       needs.triage.outputs.unknown == 'true')
+      !cancelled() &&
+      needs.triage.outputs.run_playwright-ui-smoke == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
 
@@ -920,23 +1044,29 @@ jobs:
         with:
           name: playwright-report
           path: playwright-report/
+          if-no-files-found: error
           retention-days: 7
 
   # ── CI Gate ──────────────────────────────────────────────────────────
   # Single required check for branch protection. Always runs after all
-  # other jobs. Fails if any job that was expected to run failed or was
-  # cancelled. Succeeds if all jobs either succeeded or were legitimately
-  # skipped by triage. This catches triage misclassification (where a job
-  # is unexpectedly skipped) and triage job failures.
+  # other jobs. Reads the expected-job set from triage and verifies that:
+  #   1. Every expected job succeeded.
+  #   2. Every non-expected job was skipped.
+  #   3. No unexpected expensive job ran (gate regression detection).
+  # This catches both triage misclassification (unexpected skip) and
+  # gate regressions (unexpected execution).
   ci-gate:
     name: CI Gate
     if: always()
     needs:
       - triage
       - conventional-commits
+      - js-quality
+      - app-frontend
+      - website
       - cargo-deny
       - workflow-lint
-      - frontend
+      - release-validation
       - dependency-checks
       - prepare-model
       - rust-test
@@ -947,13 +1077,17 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - name: Verify all required jobs succeeded or were skipped
+      - name: Verify expected jobs succeeded and non-expected jobs skipped
         env:
+          EXPECTED_JOBS: ${{ needs.triage.outputs.expected-jobs }}
           TRIAGE: ${{ needs.triage.result }}
           CONVENTIONAL_COMMITS: ${{ needs.conventional-commits.result }}
+          JS_QUALITY: ${{ needs.js-quality.result }}
+          APP_FRONTEND: ${{ needs.app-frontend.result }}
+          WEBSITE: ${{ needs.website.result }}
           CARGO_DENY: ${{ needs.cargo-deny.result }}
           WORKFLOW_LINT: ${{ needs.workflow-lint.result }}
-          FRONTEND: ${{ needs.frontend.result }}
+          RELEASE_VALIDATION: ${{ needs.release-validation.result }}
           DEPENDENCY_CHECKS: ${{ needs.dependency-checks.result }}
           PREPARE_MODEL: ${{ needs.prepare-model.result }}
           RUST_TEST: ${{ needs.rust-test.result }}
@@ -961,28 +1095,67 @@ jobs:
           TAURI_BUILD_SMOKE: ${{ needs.tauri-build-smoke.result }}
           TAURI_BUILD: ${{ needs.tauri-build.result }}
           PLAYWRIGHT_UI_SMOKE: ${{ needs.playwright-ui-smoke.result }}
+          UNKNOWN_FLAG: ${{ needs.triage.outputs.unknown }}
         run: |
           set -euo pipefail
+
+          # All checkable jobs and their result env vars.
+          declare -A JOBS=(
+            [triage]="$TRIAGE"
+            [conventional-commits]="$CONVENTIONAL_COMMITS"
+            [js-quality]="$JS_QUALITY"
+            [app-frontend]="$APP_FRONTEND"
+            [website]="$WEBSITE"
+            [cargo-deny]="$CARGO_DENY"
+            [workflow-lint]="$WORKFLOW_LINT"
+            [release-validation]="$RELEASE_VALIDATION"
+            [dependency-checks]="$DEPENDENCY_CHECKS"
+            [prepare-model]="$PREPARE_MODEL"
+            [rust-test]="$RUST_TEST"
+            [rust-test-windows-compile]="$RUST_TEST_WINDOWS_COMPILE"
+            [tauri-build-smoke]="$TAURI_BUILD_SMOKE"
+            [tauri-build]="$TAURI_BUILD"
+            [playwright-ui-smoke]="$PLAYWRIGHT_UI_SMOKE"
+          )
+
+          # Verify triage produced valid expected-jobs JSON.
+          if ! echo "$EXPECTED_JOBS" | jq -e 'type == "array"' >/dev/null 2>&1; then
+            echo "::error::Triage did not produce valid expected-jobs JSON: ${EXPECTED_JOBS:-<empty>}"
+            exit 1
+          fi
+
           fail=0
-          for entry in \
-            "triage:$TRIAGE" \
-            "conventional-commits:$CONVENTIONAL_COMMITS" \
-            "cargo-deny:$CARGO_DENY" \
-            "workflow-lint:$WORKFLOW_LINT" \
-            "frontend:$FRONTEND" \
-            "dependency-checks:$DEPENDENCY_CHECKS" \
-            "prepare-model:$PREPARE_MODEL" \
-            "rust-test:$RUST_TEST" \
-            "rust-test-windows-compile:$RUST_TEST_WINDOWS_COMPILE" \
-            "tauri-build-smoke:$TAURI_BUILD_SMOKE" \
-            "tauri-build:$TAURI_BUILD" \
-            "playwright-ui-smoke:$PLAYWRIGHT_UI_SMOKE"; do
-            job="${entry%%:*}"
-            result="${entry##*:}"
-            echo "$job: $result"
-            case "$result" in
-              success|skipped) ;;
-              *) echo "::error::$job did not succeed (result: $result)"; fail=1 ;;
-            esac
+
+          for job in "${!JOBS[@]}"; do
+            result="${JOBS[$job]}"
+            is_expected=$(echo "$EXPECTED_JOBS" | jq --arg job "$job" 'any(. == $job)')
+
+            echo "$job: result=$result expected=$is_expected"
+
+            if [ "$is_expected" = "true" ]; then
+              if [ "$result" != "success" ]; then
+                echo "::error::Expected job '$job' did not succeed (result: $result)"
+                fail=1
+              fi
+            else
+              if [ "$result" != "skipped" ]; then
+                echo "::error::Unexpected job '$job' ran (result: $result) — gate regression"
+                fail=1
+              fi
+            fi
           done
+
+          # Verify unknown files are printed and full CI is expected when
+          # unknown files exist.
+          UNKNOWN=$(echo "$EXPECTED_JOBS" | jq 'any(. == "tauri-build")')
+          if [ "$UNKNOWN_FLAG" = "true" ] && [ "$UNKNOWN" != "true" ]; then
+            echo "::error::Unknown files exist but full CI (tauri-build) was not expected"
+            fail=1
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            echo ""
+            echo "Expected jobs: $(echo "$EXPECTED_JOBS" | jq -r '. | join(", ")')"
+          fi
+
           exit $fail

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     paths:
       - ".github/workflows/packaging.yml"
-      - ".github/workflows/release.yml"
       - "package.json"
       - "packaging/**"
       - "pnpm-lock.yaml"
@@ -16,10 +15,9 @@ on:
       - "src-tauri/tauri.conf.json"
       - "tests/flatpak-packaging.test.ts"
   push:
-    branches: ["main", "codex/**"]
+    branches: ["main"]
     paths:
       - ".github/workflows/packaging.yml"
-      - ".github/workflows/release.yml"
       - "package.json"
       - "packaging/**"
       - "pnpm-lock.yaml"
@@ -42,8 +40,73 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  # Classify changed files to gate expensive packaging builds. The
+  # classifier (scripts/ci/classify-changes.mjs) is the single source of
+  # truth shared with the main CI workflow.
+  triage:
+    name: Triage
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      packaging_inputs: ${{ steps.classify.outputs.packaging_inputs }}
+      packaging_workflow: ${{ steps.classify.outputs.packaging_workflow }}
+      release_metadata: ${{ steps.classify.outputs.release_metadata }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Collect changed files
+        id: collect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            gh api --paginate --jq '.[].filename' \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+              > changed-files.txt
+          elif [ "$EVENT_NAME" = "push" ]; then
+            if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+              git diff --name-only HEAD~1..HEAD > changed-files.txt
+            else
+              git diff --name-only "$BEFORE".."$AFTER" > changed-files.txt
+            fi
+          else
+            : > changed-files.txt
+          fi
+
+      - name: Classify changes
+        id: classify
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          node scripts/ci/classify-changes.mjs \
+            --files "$(cat changed-files.txt)" \
+            --event "$EVENT_NAME" \
+            > classification.json
+
+          # Check whether packaging-impacting categories are present.
+          cats=$(jq -r '.categories | join(",")' classification.json)
+          echo "packaging_inputs=$(echo "$cats" | grep -q 'packaging_inputs' && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "packaging_workflow=$(echo "$cats" | grep -q 'packaging_workflow' && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "release_metadata=$(echo "$cats" | grep -q 'release_metadata' && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
   validate-winget:
     name: Validate WinGet manifests
+    needs: triage
+    if: |
+      !cancelled() &&
+      (needs.triage.outputs.packaging_inputs == 'true' ||
+       needs.triage.outputs.packaging_workflow == 'true' ||
+       needs.triage.outputs.release_metadata == 'true' ||
+       github.event_name == 'workflow_dispatch')
     runs-on: windows-latest
     timeout-minutes: 30
 
@@ -100,6 +163,12 @@ jobs:
 
   validate-flatpak:
     name: Validate Flatpak metadata
+    needs: triage
+    if: |
+      !cancelled() &&
+      (needs.triage.outputs.packaging_inputs == 'true' ||
+       needs.triage.outputs.packaging_workflow == 'true' ||
+       github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-24.04
     timeout-minutes: 15
 
@@ -171,7 +240,15 @@ jobs:
 
   build-flatpak:
     name: Build Flatpak (x86_64)
-    needs: validate-flatpak
+    needs: [triage, validate-flatpak]
+    # Only build Flatpak from source when packaging inputs or the packaging
+    # workflow itself changed — not for release-metadata-only or
+    # workflow_dispatch validation runs.
+    if: |
+      !cancelled() &&
+      needs.validate-flatpak.result == 'success' &&
+      (needs.triage.outputs.packaging_inputs == 'true' ||
+       needs.triage.outputs.packaging_workflow == 'true')
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     # Run inside the Flathub-maintained container. This image ships a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Introduce PlaybackCoordinator as independent control thread (#100)
 - Architecture deepening across 7 module-depth candidates (#129)
+- Consolidate duplicate utilities and inline single-caller hooks (#152)
 
 ### ⚡ Performance
 
@@ -107,7 +108,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **website**: Theme/lang auto-detect, mock interactions, natural Chinese copy (#139)
 - **audio**: Replace per-stem rendering with source-domain mix bus (#144)
 - **romanize**: Invalidate stale romanizedLines cache when source lyrics change
-- **rotation**: Shuffle within equal-size singer tiers so repeated Shuffle presses vary
+- **website**: Improve mobile landing layout and preview
+- **website**: Restore interactive mobile mock with left-half scale
+- **website**: Bleed mobile mock past the right viewport edge
+- **rotation**: Shuffle within equal-size singer tiers so repeated Shuffle presses vary (#147)
+- **website**: Restore desktop preview fill while keeping mobile bleed (#148)
+- **cover-art**: Resolve ambience backdrop revocation race on song change (#149)
+- **romanize**: Scale pronunciation and bg_words lines with lyricsFontStep (#153)
 
 ### 📝 Documentation
 
@@ -128,6 +135,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Add Codeberg mirror workflow
 - Use node --run instead of pnpm for package scripts
 - **flatpak**: Reclaim host disk and disable builder cache (#121)
+- Triage PR by changed paths and skip irrelevant jobs (#150)
+- **release**: Append installation section to GitHub Release Notes (#154)
+- Replace paths-filter with checked-in classifier and harden CI Gate
 
 ### 🔧 Chores
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,7 +19,11 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   workers: 1,
-  reporter: "list",
+  // Generate both the list reporter (for live CI logs) and the HTML report
+  // (for the playwright-report/ artifact upload). The CI workflow uploads
+  // playwright-report/ with if-no-files-found: error, so the config and
+  // workflow must agree on HTML report generation.
+  reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
   timeout: 30_000,
 
   use: {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,5 +1,23 @@
 # Scripts
 
+## `ci/classify-changes.mjs`
+
+CI change classifier — the single source of truth for path-based CI gating.
+Maps changed files to categories, collects unmatched files as `unknown`, and
+derives the expected job set from the category union. Consumed by the triage
+job in `.github/workflows/ci.yml` and `.github/workflows/packaging.yml`.
+
+- **Input:** newline-delimited filenames (`--files`) or JSON array (`--json`),
+  plus event type (`--event pull_request|push|workflow_dispatch`)
+- **Output:** JSON to stdout; `GITHUB_OUTPUT` entries (`expected-jobs`,
+  `run_<job>` booleans, `unknown-files`, `categories`) and
+  `GITHUB_STEP_SUMMARY` markdown table when those env vars are set
+- **Pure function:** no network or filesystem access beyond stdin — testable
+  locally without GitHub API access
+- **Contract tests:** `tests/ci/classify-changes.test.ts`
+- **Drift tests:** `tests/ci/ci-workflow-contract.test.ts`
+- **Run:** `node scripts/ci/classify-changes.mjs --files <paths> --event pull_request`
+
 ## `generate-mock-songs.mjs`
 
 Regenerates the shared mock/preview song catalog used by both the website

--- a/scripts/ci/classify-changes.mjs
+++ b/scripts/ci/classify-changes.mjs
@@ -338,23 +338,11 @@ const HEAVY_JOBS = new Set([
  * }}
  */
 export function classifyChanges(files, event) {
-  // Push to main and workflow_dispatch always run full CI.
-  if (event === "push" || event === "workflow_dispatch") {
-    const allJobs = ALL_JOBS.filter((job) =>
-      JOB_RULES[job](new Set(["unknown"]), event),
-    );
-    return {
-      files,
-      categories: ["unknown"],
-      categoriesByFile: {},
-      unknownFiles: files,
-      expectedJobs: allJobs,
-      expectedSkippedHeavyJobs: [],
-      run: Object.fromEntries(ALL_JOBS.map((j) => [j, allJobs.includes(j)])),
-    };
-  }
-
-  // PR: classify each file against all known categories.
+  // Always classify each file against all known categories. The category
+  // data is consumed by both the main CI workflow (for job gating) and the
+  // packaging workflow (for packaging-specific gates). Classifying up front
+  // lets downstream consumers inspect categories regardless of event type,
+  // while the job derivation below applies the event-based safety path.
   /** @type {Record<string, string[]>} */
   const categoriesByFile = {};
   /** @type {Set<string>} */
@@ -375,7 +363,26 @@ export function classifyChanges(files, event) {
     }
   }
 
-  // Derive expected jobs from the category union.
+  // Push to main and workflow_dispatch always run full CI as a deliberate
+  // safety path — the integration branch always gets full validation
+  // regardless of what changed. Categories are still populated above so
+  // downstream consumers (e.g. packaging triage) can inspect them.
+  if (event === "push" || event === "workflow_dispatch") {
+    const allJobs = ALL_JOBS.filter((job) =>
+      JOB_RULES[job](new Set(["unknown"]), event),
+    );
+    return {
+      files,
+      categories: [...categorySet],
+      categoriesByFile,
+      unknownFiles,
+      expectedJobs: allJobs,
+      expectedSkippedHeavyJobs: [],
+      run: Object.fromEntries(ALL_JOBS.map((j) => [j, allJobs.includes(j)])),
+    };
+  }
+
+  // PR: derive expected jobs from the category union.
   const expectedJobs = ALL_JOBS.filter((job) =>
     JOB_RULES[job](categorySet, event),
   );

--- a/scripts/ci/classify-changes.mjs
+++ b/scripts/ci/classify-changes.mjs
@@ -1,0 +1,537 @@
+// CI change classifier — single source of truth for path-based CI gating.
+//
+// This module is a pure function over filenames and event type. It maps every
+// changed file to one or more known categories, collects unmatched files as
+// `unknown`, and derives the expected job set from the category union.
+//
+// The workflow (.github/workflows/ci.yml) consumes the per-job boolean outputs
+// (`run_<job>`) in `if:` conditionals. CI Gate consumes `expected-jobs` to
+// verify that every expected job ran and every non-expected job was skipped.
+//
+// Contract tests live in tests/ci/classify-changes.test.ts. Drift-protection
+// tests that parse ci.yml live in tests/ci/ci-workflow-contract.test.ts.
+//
+// CLI usage:
+//   node scripts/ci/classify-changes.mjs --files <newline-separated-paths> --event pull_request
+//   node scripts/ci/classify-changes.mjs --json '["src/foo.ts"]' --event pull_request
+//
+// Outputs JSON to stdout and writes GITHUB_OUTPUT entries when GITHUB_OUTPUT is set.
+
+import { readFileSync, appendFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+import { argv } from "node:process";
+
+// ── Glob matching ─────────────────────────────────────────────────────
+// Minimal glob-to-regex converter supporting `**`, `*`, `?`, and literals.
+// `**/` matches zero or more path segments. `/**` matches anything under a
+// directory. `*` matches anything except `/`.
+
+/** @param {string} pattern */
+function globToRegex(pattern) {
+  let re = "^";
+  let i = 0;
+  while (i < pattern.length) {
+    const c = pattern[i];
+    if (c === "*" && pattern[i + 1] === "*") {
+      i += 2;
+      if (pattern[i] === "/") {
+        re += "(?:.*/)?";
+        i += 1;
+      } else {
+        re += ".*";
+      }
+    } else if (c === "*") {
+      re += "[^/]*";
+      i += 1;
+    } else if (c === "?") {
+      re += "[^/]";
+      i += 1;
+    } else if (/[.+^${}()|[\]\\]/.test(c)) {
+      re += "\\" + c;
+      i += 1;
+    } else {
+      re += c;
+      i += 1;
+    }
+  }
+  re += "$";
+  return new RegExp(re);
+}
+
+// ── Category definitions ──────────────────────────────────────────────
+// Each category maps to a list of glob patterns. A file may belong to multiple
+// categories. `unknown` is NOT a category with patterns — it is the set
+// complement of all known categories.
+
+/** @type {Record<string, string[]>} */
+const CATEGORY_PATTERNS = {
+  docs: ["**/*.md", "docs/**", "LICENSE"],
+
+  frontend_app: ["src/**", "public/**", "index.html"],
+
+  website: ["website/**"],
+
+  frontend_tooling: [
+    "vite.config.ts",
+    "tsconfig.json",
+    "tsconfig.node.json",
+    "tsconfig.app.json",
+    "oxlintrc.json",
+    ".oxfmtrc.json",
+    "knip.json",
+    "pnpm-workspace.yaml",
+    "lefthook.yml",
+    "codecov.yml",
+    "scripts/check-i18n.mjs",
+    "scripts/generate-db-schema.mjs",
+    "scripts/generate-mock-songs.mjs",
+    "scripts/prepare-bundled-oauth-client.mjs",
+    "tests/contract/**",
+  ],
+
+  e2e: ["tests/e2e/**", "playwright.config.ts", "playwright.webkit.config.ts"],
+
+  rust: [
+    "src-tauri/src/**",
+    "src-tauri/tests/**",
+    "src-tauri/deny.toml",
+    "rust-toolchain.toml",
+    "patches/**",
+  ],
+
+  model_runtime: ["scripts/prepare-onnx-runtime.mjs"],
+
+  deps_js: ["package.json", "pnpm-lock.yaml"],
+
+  deps_rust: ["src-tauri/Cargo.toml", "src-tauri/Cargo.lock"],
+
+  ci_workflow: [
+    ".github/workflows/ci.yml",
+    ".github/labeler.yml",
+    "scripts/ci/**",
+    "tests/ci/**",
+    "tests/workflow-security.test.ts",
+    "scripts/check-patch-coverage.mjs",
+  ],
+
+  release_workflow: [
+    ".github/workflows/release.yml",
+    "tests/release-workflow.test.ts",
+    "scripts/setup.sh",
+    "scripts/run-local-smoke.sh",
+  ],
+
+  packaging_workflow: [".github/workflows/packaging.yml"],
+
+  e2e_workflow: [
+    // No standalone E2E workflow file exists today; Playwright runs inside
+    // ci.yml. This category is reserved for when one is added.
+  ],
+
+  other_workflow: [
+    ".github/workflows/dependabot-sync.yml",
+    ".github/workflows/mirror.yml",
+    ".github/workflows/pages.yml",
+    ".github/dependabot.yml",
+    ".github/ISSUE_TEMPLATE/**",
+    ".github/PULL_REQUEST_TEMPLATE.md",
+  ],
+
+  packaging_inputs: [
+    "packaging/**",
+    "src-tauri/tauri.conf.json",
+    "src-tauri/tauri.linux.conf.json",
+    "src-tauri/tauri.macos.conf.json",
+    "src-tauri/tauri.windows.conf.json",
+    "scripts/render-flatpak-manifest.mjs",
+    "scripts/render-winget-manifests.mjs",
+    "scripts/generate-flatpak-cargo-sources.mjs",
+    "scripts/generate-flatpak-node-sources.mjs",
+    "scripts/clean-macos-bundle.mjs",
+    "tests/flatpak-packaging.test.ts",
+    "tests/onnx-runtime-packaging.test.ts",
+    "tests/tauri-config.test.ts",
+  ],
+
+  release_metadata: [
+    "scripts/release-metadata.mjs",
+    "scripts/sync-version.mjs",
+    "cliff.toml",
+    "tests/release-metadata.test.ts",
+  ],
+};
+
+// Pre-compile all category regexes for performance.
+/** @type {Record<string, RegExp[]>} */
+const CATEGORY_REGEXES = Object.fromEntries(
+  Object.entries(CATEGORY_PATTERNS).map(([cat, patterns]) => [
+    cat,
+    patterns.map(globToRegex),
+  ]),
+);
+
+// ── Classification ────────────────────────────────────────────────────
+
+/**
+ * Classify a single file into all matching categories.
+ * @param {string} file
+ * @returns {string[]}
+ */
+function classifyFile(file) {
+  const cats = [];
+  for (const [cat, regexes] of Object.entries(CATEGORY_REGEXES)) {
+    if (regexes.some((re) => re.test(file))) {
+      cats.push(cat);
+    }
+  }
+  return cats;
+}
+
+// ── Job derivation ────────────────────────────────────────────────────
+// Maps category sets to expected job IDs. The workflow job `if:` conditions
+// consume the per-job boolean outputs (`run_<job>`).
+
+/** @type {Record<string, (cats: Set<string>, event: string) => boolean>} */
+const JOB_RULES = {
+  triage: () => true,
+  "conventional-commits": (_cats, event) => event === "pull_request",
+  "ci-gate": () => true,
+
+  "js-quality": (cats) =>
+    cats.has("frontend_app") ||
+    cats.has("website") ||
+    cats.has("frontend_tooling") ||
+    cats.has("e2e") ||
+    cats.has("deps_js") ||
+    cats.has("ci_workflow") ||
+    cats.has("unknown"),
+
+  "app-frontend": (cats) =>
+    cats.has("frontend_app") ||
+    cats.has("frontend_tooling") ||
+    cats.has("deps_js") ||
+    cats.has("ci_workflow") ||
+    cats.has("unknown"),
+
+  website: (cats) =>
+    cats.has("website") ||
+    cats.has("deps_js") ||
+    cats.has("ci_workflow") ||
+    cats.has("unknown"),
+
+  "playwright-ui-smoke": (cats) =>
+    cats.has("frontend_app") ||
+    cats.has("frontend_tooling") ||
+    cats.has("e2e") ||
+    cats.has("deps_js") ||
+    cats.has("ci_workflow") ||
+    cats.has("unknown"),
+
+  "workflow-lint": (cats) =>
+    cats.has("ci_workflow") ||
+    cats.has("release_workflow") ||
+    cats.has("packaging_workflow") ||
+    cats.has("e2e_workflow") ||
+    cats.has("other_workflow") ||
+    cats.has("unknown"),
+
+  "release-validation": (cats) =>
+    cats.has("release_workflow") ||
+    cats.has("release_metadata") ||
+    cats.has("ci_workflow") ||
+    cats.has("unknown"),
+
+  "cargo-deny": (cats) =>
+    cats.has("rust") ||
+    cats.has("model_runtime") ||
+    cats.has("deps_rust") ||
+    cats.has("ci_workflow") ||
+    cats.has("unknown"),
+
+  "dependency-checks": (cats) =>
+    cats.has("rust") ||
+    cats.has("model_runtime") ||
+    cats.has("deps_rust") ||
+    cats.has("ci_workflow") ||
+    cats.has("unknown"),
+
+  "prepare-model": (cats) =>
+    cats.has("rust") ||
+    cats.has("model_runtime") ||
+    cats.has("deps_rust") ||
+    cats.has("ci_workflow") ||
+    cats.has("unknown"),
+
+  "rust-test": (cats) =>
+    cats.has("rust") ||
+    cats.has("model_runtime") ||
+    cats.has("deps_rust") ||
+    cats.has("ci_workflow") ||
+    cats.has("unknown"),
+
+  "rust-test-windows-compile": (cats) =>
+    cats.has("rust") ||
+    cats.has("model_runtime") ||
+    cats.has("deps_rust") ||
+    cats.has("ci_workflow") ||
+    cats.has("unknown"),
+
+  "tauri-build-smoke": (cats) => {
+    const frontend =
+      cats.has("frontend_app") ||
+      cats.has("frontend_tooling") ||
+      cats.has("deps_js");
+    const heavy =
+      cats.has("rust") ||
+      cats.has("model_runtime") ||
+      cats.has("deps_rust") ||
+      cats.has("ci_workflow") ||
+      cats.has("unknown");
+    return frontend && !heavy;
+  },
+
+  "tauri-build": (cats) =>
+    cats.has("rust") ||
+    cats.has("model_runtime") ||
+    cats.has("deps_rust") ||
+    cats.has("ci_workflow") ||
+    cats.has("unknown"),
+};
+
+// All job IDs in declaration order (used by CI Gate and drift tests).
+const ALL_JOBS = Object.keys(JOB_RULES);
+
+// Jobs considered "heavy" for the step summary and gate enforcement.
+const HEAVY_JOBS = new Set([
+  "app-frontend",
+  "website",
+  "playwright-ui-smoke",
+  "cargo-deny",
+  "dependency-checks",
+  "prepare-model",
+  "rust-test",
+  "rust-test-windows-compile",
+  "tauri-build-smoke",
+  "tauri-build",
+]);
+
+// ── Main classify function ────────────────────────────────────────────
+
+/**
+ * Classify changed files and derive expected jobs.
+ *
+ * For `push` (to main) and `workflow_dispatch`, returns full CI (all jobs)
+ * as a deliberate safety path — the integration branch always gets full
+ * validation regardless of what changed.
+ *
+ * @param {string[]} files - changed file paths
+ * @param {string} event - "pull_request" | "push" | "workflow_dispatch"
+ * @returns {{
+ *   files: string[],
+ *   categories: string[],
+ *   categoriesByFile: Record<string, string[]>,
+ *   unknownFiles: string[],
+ *   expectedJobs: string[],
+ *   expectedSkippedHeavyJobs: string[],
+ *   run: Record<string, boolean>,
+ * }}
+ */
+export function classifyChanges(files, event) {
+  // Push to main and workflow_dispatch always run full CI.
+  if (event === "push" || event === "workflow_dispatch") {
+    const allJobs = ALL_JOBS.filter((job) =>
+      JOB_RULES[job](new Set(["unknown"]), event),
+    );
+    return {
+      files,
+      categories: ["unknown"],
+      categoriesByFile: {},
+      unknownFiles: files,
+      expectedJobs: allJobs,
+      expectedSkippedHeavyJobs: [],
+      run: Object.fromEntries(ALL_JOBS.map((j) => [j, allJobs.includes(j)])),
+    };
+  }
+
+  // PR: classify each file against all known categories.
+  /** @type {Record<string, string[]>} */
+  const categoriesByFile = {};
+  /** @type {Set<string>} */
+  const categorySet = new Set();
+  /** @type {string[]} */
+  const unknownFiles = [];
+
+  for (const file of files) {
+    const cats = classifyFile(file);
+    categoriesByFile[file] = cats;
+    if (cats.length === 0) {
+      unknownFiles.push(file);
+      categorySet.add("unknown");
+    } else {
+      for (const c of cats) {
+        categorySet.add(c);
+      }
+    }
+  }
+
+  // Derive expected jobs from the category union.
+  const expectedJobs = ALL_JOBS.filter((job) =>
+    JOB_RULES[job](categorySet, event),
+  );
+
+  const expectedSkippedHeavyJobs = HEAVY_JOBS
+    ? [...HEAVY_JOBS].filter((j) => !expectedJobs.includes(j))
+    : [];
+
+  const run = Object.fromEntries(
+    ALL_JOBS.map((j) => [j, expectedJobs.includes(j)]),
+  );
+
+  return {
+    files,
+    categories: [...categorySet].sort(),
+    categoriesByFile,
+    unknownFiles,
+    expectedJobs,
+    expectedSkippedHeavyJobs,
+    run,
+  };
+}
+
+// ── Step summary ──────────────────────────────────────────────────────
+
+/**
+ * Build a GITHUB_STEP_SUMMARY markdown table.
+ * @param {ReturnType<typeof classifyChanges>} result
+ * @param {string} event
+ */
+export function buildStepSummary(result, event) {
+  const lines = [];
+  lines.push(`## CI Triage`);
+  lines.push("");
+  lines.push(`**Event:** \`${event}\``);
+  lines.push("");
+
+  lines.push("### Changed files");
+  lines.push("");
+  if (result.files.length === 0) {
+    lines.push("- _(none)_");
+  } else {
+    for (const file of result.files) {
+      const cats = result.categoriesByFile[file] ?? [];
+      const label = cats.length > 0 ? cats.join(", ") : "unknown";
+      lines.push(`- \`${file}\` → ${label}`);
+    }
+  }
+  lines.push("");
+
+  if (result.unknownFiles.length > 0) {
+    lines.push("### Unknown files (full CI safety fallback)");
+    lines.push("");
+    for (const file of result.unknownFiles) {
+      lines.push(`- \`${file}\``);
+    }
+    lines.push("");
+  }
+
+  lines.push("### Expected jobs");
+  lines.push("");
+  if (result.expectedJobs.length === 0) {
+    lines.push("- _(none — no heavy jobs needed)_");
+  } else {
+    for (const job of result.expectedJobs) {
+      lines.push(`- ${job}`);
+    }
+  }
+  lines.push("");
+
+  const skippedHeavy = result.expectedSkippedHeavyJobs;
+  if (skippedHeavy.length > 0) {
+    lines.push("### Expected skipped heavy jobs");
+    lines.push("");
+    for (const job of skippedHeavy) {
+      lines.push(`- ${job}`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+// ── CLI entry point ───────────────────────────────────────────────────
+
+/** @param {string[]} argv */
+export function parseArgs(argv) {
+  const args = { files: null, json: null, event: "pull_request" };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--files") {
+      args.files = argv[++i];
+    } else if (arg === "--json") {
+      args.json = argv[++i];
+    } else if (arg === "--event") {
+      args.event = argv[++i];
+    }
+  }
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  /** @type {string[]} */
+  let files;
+  if (args.json) {
+    files = JSON.parse(args.json);
+  } else if (args.files) {
+    files = args.files.split("\n").filter(Boolean);
+  } else {
+    // Read from stdin if no files provided.
+    const input = readFileSync(0, "utf8").trim();
+    files = input ? input.split("\n").filter(Boolean) : [];
+  }
+
+  const result = classifyChanges(files, args.event);
+  const json = JSON.stringify(result, null, 2);
+  console.log(json);
+
+  // Write GITHUB_OUTPUT entries when available.
+  const ghOutput = process.env.GITHUB_OUTPUT;
+  if (ghOutput) {
+    const lines = [
+      `categories=${JSON.stringify(result.categories)}`,
+      `unknown=${result.unknownFiles.length > 0}`,
+      `unknown-files=${JSON.stringify(result.unknownFiles)}`,
+      `expected-jobs=${JSON.stringify(result.expectedJobs)}`,
+      `expected-skipped-heavy=${JSON.stringify(result.expectedSkippedHeavyJobs)}`,
+    ];
+    for (const job of ALL_JOBS) {
+      lines.push(`run_${job}=${result.run[job]}`);
+    }
+    appendFileSync(ghOutput, lines.join("\n") + "\n");
+  }
+
+  // Write step summary when available.
+  const ghSummary = process.env.GITHUB_STEP_SUMMARY;
+  if (ghSummary) {
+    appendFileSync(ghSummary, buildStepSummary(result, args.event) + "\n");
+  }
+}
+
+// Export internals for tests.
+export {
+  CATEGORY_PATTERNS,
+  CATEGORY_REGEXES,
+  ALL_JOBS,
+  HEAVY_JOBS,
+  JOB_RULES,
+  globToRegex,
+  classifyFile,
+};
+
+// Run CLI when invoked directly (not when imported by tests).
+const _isMain = argv[1] && fileURLToPath(import.meta.url) === resolve(argv[1]);
+if (_isMain) {
+  main();
+}

--- a/scripts/ci/classify-changes.mjs
+++ b/scripts/ci/classify-changes.mjs
@@ -144,6 +144,7 @@ const CATEGORY_PATTERNS = {
     "src-tauri/tauri.linux.conf.json",
     "src-tauri/tauri.macos.conf.json",
     "src-tauri/tauri.windows.conf.json",
+    "scripts/prepare-onnx-runtime.mjs",
     "scripts/render-flatpak-manifest.mjs",
     "scripts/render-winget-manifests.mjs",
     "scripts/generate-flatpak-cargo-sources.mjs",

--- a/tests/ci/ci-workflow-contract.test.ts
+++ b/tests/ci/ci-workflow-contract.test.ts
@@ -1,0 +1,207 @@
+// Drift-protection tests for the CI workflow.
+//
+// These tests parse .github/workflows/ci.yml and verify that:
+//   1. Every expected job ID emitted by the classifier has a corresponding
+//      workflow job.
+//   2. Every optional expensive workflow job is represented in CI Gate's
+//      dependency list.
+//   3. No broad `workflows` boolean appears in app-job conditions (the old
+//      broken pattern from PR #150).
+//   4. CI Gate reads the classifier's expected-jobs output.
+//   5. Packaging build jobs use packaging-specific gates (tested in
+//      packaging-workflow-contract.test.ts).
+//   6. The Playwright config and workflow agree on report generation.
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+import { ALL_JOBS } from "../../scripts/ci/classify-changes.mjs";
+
+const projectRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+function readProjectFile(path: string) {
+  return readFileSync(join(projectRoot, path), "utf8");
+}
+
+/** Extract job IDs from a GitHub Actions workflow YAML. */
+function extractJobIds(yaml: string): string[] {
+  const jobs: string[] = [];
+  // Match top-level job keys under `jobs:` — 2-space indent, key: at end of line
+  // or followed by value.
+  const lines = yaml.split(/\r?\n/);
+  let inJobs = false;
+  for (const line of lines) {
+    if (/^jobs:\s*$/.test(line)) {
+      inJobs = true;
+      continue;
+    }
+    if (!inJobs) continue;
+    // Job keys are exactly 2 spaces indent, alphanumeric/kebab-case, followed
+    // by `:`. Stop at non-indented lines (end of jobs block).
+    if (/^[a-zA-Z]/.test(line)) {
+      inJobs = false;
+      continue;
+    }
+    const match = line.match(/^  ([a-z0-9-]+):\s*$/);
+    if (match) {
+      jobs.push(match[1]);
+    }
+  }
+  return jobs;
+}
+
+/** Extract the ci-gate `needs:` list from the workflow YAML. */
+function extractGateNeeds(yaml: string): string[] {
+  const lines = yaml.split(/\r?\n/);
+  let inGate = false;
+  let inNeeds = false;
+  const needs: string[] = [];
+  for (const line of lines) {
+    if (/^  ci-gate:\s*$/.test(line)) {
+      inGate = true;
+      continue;
+    }
+    if (!inGate) continue;
+    if (/^[a-z]/.test(line) && !line.startsWith(" ")) {
+      break; // left the ci-gate job block
+    }
+    if (/^    needs:\s*$/.test(line)) {
+      inNeeds = true;
+      continue;
+    }
+    if (inNeeds) {
+      // Needs entries are 6-space indent list items.
+      const match = line.match(/^      - "?([a-z0-9-]+)"?\s*$/);
+      if (match) {
+        needs.push(match[1]);
+      } else if (!line.startsWith("        ") && !line.match(/^\s*-/)) {
+        // End of needs list (next key at 4-space indent)
+        if (/^    [a-z]/.test(line)) {
+          inNeeds = false;
+        }
+      }
+    }
+  }
+  return needs;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("CI workflow drift protection", () => {
+  const ciYaml = readProjectFile(".github/workflows/ci.yml");
+  const workflowJobs = extractJobIds(ciYaml);
+
+  test("every classifier ALL_JOBS entry has a matching workflow job", () => {
+    for (const job of ALL_JOBS) {
+      expect(workflowJobs, `workflow missing job: ${job}`).toContain(job);
+    }
+  });
+
+  test("every workflow job has a classifier entry (no orphan jobs)", () => {
+    for (const job of workflowJobs) {
+      expect(ALL_JOBS, `classifier missing job: ${job}`).toContain(job);
+    }
+  });
+
+  test("ci-gate depends on every other workflow job", () => {
+    const gateNeeds = extractGateNeeds(ciYaml);
+    const otherJobs = workflowJobs.filter((j) => j !== "ci-gate");
+    for (const job of otherJobs) {
+      expect(gateNeeds, `ci-gate missing needs entry: ${job}`).toContain(job);
+    }
+  });
+
+  test("no broad `workflows` boolean in app-job conditions", () => {
+    // The old pattern used `needs.triage.outputs.workflows == 'true'` in
+    // app-job conditions, which caused any workflow edit to trigger full
+    // app CI. The classifier no longer emits a `workflows` output.
+    expect(ciYaml).not.toMatch(/outputs\.workflows/);
+  });
+
+  test("triage job runs the classifier script", () => {
+    expect(ciYaml).toContain("scripts/ci/classify-changes.mjs");
+  });
+
+  test("triage outputs expected-jobs for CI Gate", () => {
+    expect(ciYaml).toContain("expected-jobs");
+  });
+
+  test("triage outputs per-job run_ booleans", () => {
+    // At least one run_ output must appear.
+    expect(ciYaml).toMatch(/run_/);
+  });
+
+  test("app jobs use run_ outputs instead of category booleans", () => {
+    // App jobs should check `run_app-frontend == 'true'`, not
+    // `frontend == 'true'`.
+    expect(ciYaml).toContain("run_app-frontend");
+    expect(ciYaml).toContain("run_js-quality");
+    expect(ciYaml).toContain("run_rust-test");
+    expect(ciYaml).toContain("run_tauri-build-smoke");
+    expect(ciYaml).toContain("run_tauri-build");
+  });
+
+  test("ci-gate verifies expected jobs against actual results", () => {
+    // The gate must read expected-jobs and compare against actual results.
+    expect(ciYaml).toContain("EXPECTED_JOBS");
+  });
+
+  test("prepare-model does not run for frontend-only or docs-only changes", () => {
+    // The prepare-model job should use run_prepare-model, not a broad
+    // category OR that includes frontend.
+    const prepareModelSection = ciYaml.match(
+      /prepare-model:[\s\S]*?runs-on:/,
+    )?.[0];
+    expect(prepareModelSection).toBeDefined();
+    expect(prepareModelSection).toContain("run_prepare-model");
+  });
+});
+
+describe("Playwright report contract", () => {
+  const playwrightConfig = readProjectFile("playwright.config.ts");
+  const ciYaml = readProjectFile(".github/workflows/ci.yml");
+
+  test("playwright config generates HTML report in CI", () => {
+    // The config must produce an HTML report when running in CI so the
+    // upload-artifact step has files to upload.
+    expect(playwrightConfig).toMatch(/html/);
+    expect(playwrightConfig).toMatch(/open:\s*["']never["']/);
+  });
+
+  test("workflow uploads playwright-report with if-no-files-found", () => {
+    // The upload step must use if-no-files-found to catch contract drift
+    // between the reporter and the upload path.
+    const uploadSection = ciYaml.match(
+      /Upload Playwright report[\s\S]*?retention-days:/,
+    )?.[0];
+    expect(uploadSection).toBeDefined();
+    expect(uploadSection).toContain("if-no-files-found");
+  });
+});
+
+describe("Packaging workflow contract", () => {
+  const packagingYaml = readProjectFile(".github/workflows/packaging.yml");
+
+  test("release.yml is not a packaging trigger", () => {
+    // A release-notes text edit must not trigger full packaging builds.
+    expect(packagingYaml).not.toMatch(/\.github\/workflows\/release\.yml/);
+  });
+
+  test("no codex/** in push branches (prevents duplicate runs)", () => {
+    // The main CI removed codex/** from push triggers; packaging must do
+    // the same to avoid duplicate push + PR runs.
+    expect(packagingYaml).not.toMatch(/codex\/\*\*/);
+  });
+
+  test("build-flatpak gates on packaging inputs", () => {
+    // The flatpak build must not run for release-workflow-only changes.
+    const buildFlatpakSection = packagingYaml.match(
+      /build-flatpak:[\s\S]*?runs-on:/,
+    )?.[0];
+    expect(buildFlatpakSection).toBeDefined();
+    // build-flatpak should have an if: condition that gates on packaging
+    // inputs, not just the workflow trigger.
+    expect(buildFlatpakSection).toMatch(/if:/);
+  });
+});

--- a/tests/ci/classify-changes.test.ts
+++ b/tests/ci/classify-changes.test.ts
@@ -447,6 +447,25 @@ describe("event type behavior", () => {
     }
   });
 
+  test("push still classifies files into categories for downstream consumers", () => {
+    // The packaging workflow reads categories to gate packaging jobs. On
+    // push events, categories must still reflect the actual changed files
+    // so packaging gates work — not a blanket "unknown".
+    const result = classifyChanges(
+      ["packaging/com.openkara.OpenKara.yml", "docs/guide.md"],
+      "push",
+    );
+    expect(result.categories).toContain("packaging_inputs");
+    expect(result.categories).toContain("docs");
+    expect(
+      result.categoriesByFile["packaging/com.openkara.OpenKara.yml"],
+    ).toContain("packaging_inputs");
+    // expectedJobs is still full CI (safety path).
+    for (const job of FULL_CI_HEAVY) {
+      expect(result.expectedJobs).toContain(job);
+    }
+  });
+
   test("workflow_dispatch always runs full CI", () => {
     const result = classifyChanges([], "workflow_dispatch");
     for (const job of FULL_CI_HEAVY) {

--- a/tests/ci/classify-changes.test.ts
+++ b/tests/ci/classify-changes.test.ts
@@ -1,0 +1,500 @@
+// Contract tests for the CI change classifier.
+//
+// These tests verify the classification contract specified in issue #155:
+// every changed file is known or explicitly printed as unknown, and the
+// expected job set matches the issue's required result for each fixture.
+//
+// Fixtures are derived from real PRs (#147, #148, #149, #152, #153, #154)
+// plus synthetic cases covering docs, deps, unknown, and mixed changes.
+
+import { describe, expect, test } from "vitest";
+import {
+  classifyChanges,
+  classifyFile,
+  globToRegex,
+  CATEGORY_PATTERNS,
+  ALL_JOBS,
+} from "../../scripts/ci/classify-changes.mjs";
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+/** Classify files as a pull_request and return the result. */
+function pr(...files: string[]) {
+  return classifyChanges(files, "pull_request");
+}
+
+/** Job sets that constitute "full CI" (all heavy + quality jobs). */
+const FULL_CI_HEAVY = [
+  "cargo-deny",
+  "dependency-checks",
+  "prepare-model",
+  "rust-test",
+  "rust-test-windows-compile",
+  "tauri-build",
+];
+
+// ── Glob matcher unit tests ───────────────────────────────────────────
+
+describe("globToRegex", () => {
+  test("exact match", () => {
+    const re = globToRegex("vite.config.ts");
+    expect(re.test("vite.config.ts")).toBe(true);
+    expect(re.test("src/vite.config.ts")).toBe(false);
+  });
+
+  test("dir/** matches files at any depth", () => {
+    const re = globToRegex("src/**");
+    expect(re.test("src/foo.ts")).toBe(true);
+    expect(re.test("src/sub/bar.ts")).toBe(true);
+    expect(re.test("src-tauri/foo.rs")).toBe(false);
+  });
+
+  test("**/*.md matches at any depth including root", () => {
+    const re = globToRegex("**/*.md");
+    expect(re.test("AGENTS.md")).toBe(true);
+    expect(re.test("docs/guide.md")).toBe(true);
+    expect(re.test("docs/references/contracts/x.md")).toBe(true);
+    expect(re.test("site.css")).toBe(false);
+  });
+
+  test("star glob (render-*.mjs)", () => {
+    const re = globToRegex("scripts/render-*.mjs");
+    expect(re.test("scripts/render-flatpak-manifest.mjs")).toBe(true);
+    expect(re.test("scripts/render-winget-manifests.mjs")).toBe(true);
+    expect(re.test("scripts/check-i18n.mjs")).toBe(false);
+  });
+
+  test("dotfiles", () => {
+    const re = globToRegex(".oxfmtrc.json");
+    expect(re.test(".oxfmtrc.json")).toBe(true);
+    expect(re.test("oxfmtrc.json")).toBe(false);
+  });
+});
+
+// ── Single-file classification ────────────────────────────────────────
+
+describe("classifyFile", () => {
+  test("src component is frontend_app", () => {
+    expect(classifyFile("src/components/Lyrics/LyricLine.tsx")).toEqual([
+      "frontend_app",
+    ]);
+  });
+
+  test("website CSS is website (not frontend_app)", () => {
+    expect(classifyFile("website/src/site.css")).toEqual(["website"]);
+  });
+
+  test("Rust source is rust", () => {
+    expect(classifyFile("src-tauri/src/audio/mixer.rs")).toEqual(["rust"]);
+  });
+
+  test("release.yml is release_workflow (not other_workflow)", () => {
+    expect(classifyFile(".github/workflows/release.yml")).toEqual([
+      "release_workflow",
+    ]);
+  });
+
+  test("ci.yml is ci_workflow", () => {
+    expect(classifyFile(".github/workflows/ci.yml")).toEqual(["ci_workflow"]);
+  });
+
+  test("packaging.yml is packaging_workflow", () => {
+    expect(classifyFile(".github/workflows/packaging.yml")).toEqual([
+      "packaging_workflow",
+    ]);
+  });
+
+  test("mirror.yml is other_workflow", () => {
+    expect(classifyFile(".github/workflows/mirror.yml")).toEqual([
+      "other_workflow",
+    ]);
+  });
+
+  test("AGENTS.md is docs", () => {
+    expect(classifyFile("AGENTS.md")).toEqual(["docs"]);
+  });
+
+  test("package.json is deps_js", () => {
+    expect(classifyFile("package.json")).toEqual(["deps_js"]);
+  });
+
+  test("Cargo.toml is deps_rust", () => {
+    expect(classifyFile("src-tauri/Cargo.toml")).toEqual(["deps_rust"]);
+  });
+
+  test("prepare-onnx-runtime.mjs is model_runtime", () => {
+    expect(classifyFile("scripts/prepare-onnx-runtime.mjs")).toEqual([
+      "model_runtime",
+    ]);
+  });
+
+  test("playwright.config.ts is e2e and frontend_tooling", () => {
+    const cats = classifyFile("playwright.config.ts");
+    expect(cats).toContain("e2e");
+  });
+
+  test("tests/e2e spec is e2e", () => {
+    expect(classifyFile("tests/e2e/player.spec.ts")).toEqual(["e2e"]);
+  });
+
+  test("packaging dir is packaging_inputs", () => {
+    expect(classifyFile("packaging/flatpak/foo.xml")).toEqual([
+      "packaging_inputs",
+    ]);
+  });
+
+  test("tauri.conf.json is packaging_inputs", () => {
+    expect(classifyFile("src-tauri/tauri.conf.json")).toEqual([
+      "packaging_inputs",
+    ]);
+  });
+
+  test("cliff.toml is release_metadata", () => {
+    expect(classifyFile("cliff.toml")).toEqual(["release_metadata"]);
+  });
+
+  test("unmapped file has no categories", () => {
+    expect(classifyFile("new-unmapped-root-config.xyz")).toEqual([]);
+  });
+
+  test("mise.toml is unknown (no category)", () => {
+    expect(classifyFile("mise.toml")).toEqual([]);
+  });
+
+  test(".gitignore is unknown (no category)", () => {
+    expect(classifyFile(".gitignore")).toEqual([]);
+  });
+});
+
+// ── Invariants ────────────────────────────────────────────────────────
+
+describe("classification invariants", () => {
+  test("known file never appears in unknownFiles", () => {
+    const result = pr("src/foo.ts", "unknown-file.xyz");
+    expect(result.unknownFiles).toEqual(["unknown-file.xyz"]);
+    expect(result.unknownFiles).not.toContain("src/foo.ts");
+  });
+
+  test("unknown file always appears in unknownFiles", () => {
+    const result = pr("totally-unknown.xyz", "src/foo.ts");
+    expect(result.unknownFiles).toContain("totally-unknown.xyz");
+  });
+
+  test("every file is known or in unknownFiles", () => {
+    const files = ["src/foo.ts", "docs/guide.md", "unknown.xyz"];
+    const result = pr(...files);
+    for (const file of files) {
+      const isKnown = (result.categoriesByFile[file] ?? []).length > 0;
+      const isUnknown = result.unknownFiles.includes(file);
+      expect(isKnown || isUnknown).toBe(true);
+    }
+  });
+
+  test("unknown category is only set when unknownFiles is non-empty", () => {
+    const known = pr("src/foo.ts");
+    expect(known.categories).not.toContain("unknown");
+
+    const unknown = pr("unknown.xyz");
+    expect(unknown.categories).toContain("unknown");
+  });
+});
+
+// ── PR fixtures from issue #155 ───────────────────────────────────────
+
+describe("PR fixtures", () => {
+  test("PR #153 — pure frontend (two Lyrics files)", () => {
+    const result = pr(
+      "src/components/Lyrics/LyricLine.tsx",
+      "src/components/Lyrics/LyricLine.test.tsx",
+    );
+    expect(result.categories).toEqual(["frontend_app"]);
+    expect(result.unknownFiles).toEqual([]);
+    expect(result.expectedJobs).toContain("app-frontend");
+    expect(result.expectedJobs).toContain("playwright-ui-smoke");
+    expect(result.expectedJobs).toContain("tauri-build-smoke");
+    expect(result.expectedJobs).toContain("js-quality");
+    // No Rust/model/platform matrix
+    for (const job of FULL_CI_HEAVY) {
+      expect(result.expectedJobs).not.toContain(job);
+    }
+  });
+
+  test("PR #148 — website-only CSS", () => {
+    const result = pr("website/src/site.css");
+    expect(result.categories).toEqual(["website"]);
+    expect(result.unknownFiles).toEqual([]);
+    expect(result.expectedJobs).toContain("website");
+    expect(result.expectedJobs).toContain("js-quality");
+    // No app frontend, Playwright, Rust, model, or platform
+    expect(result.expectedJobs).not.toContain("app-frontend");
+    expect(result.expectedJobs).not.toContain("playwright-ui-smoke");
+    for (const job of FULL_CI_HEAVY) {
+      expect(result.expectedJobs).not.toContain(job);
+    }
+  });
+
+  test("PR #147 — store + store test + changelog", () => {
+    const result = pr(
+      "src/stores/rotation-store.ts",
+      "src/stores/rotation-store.test.ts",
+      "CHANGELOG.md",
+    );
+    expect(result.categories).toContain("frontend_app");
+    expect(result.categories).toContain("docs");
+    expect(result.unknownFiles).toEqual([]);
+    expect(result.expectedJobs).toContain("app-frontend");
+    expect(result.expectedJobs).toContain("playwright-ui-smoke");
+    expect(result.expectedJobs).toContain("tauri-build-smoke");
+    for (const job of FULL_CI_HEAVY) {
+      expect(result.expectedJobs).not.toContain(job);
+    }
+  });
+
+  test("PR #149 — components/lib/styles/tests", () => {
+    const result = pr(
+      "src/components/Playback/Player.tsx",
+      "src/lib/cover-art.ts",
+      "src/styles/globals.css",
+    );
+    expect(result.categories).toEqual(["frontend_app"]);
+    expect(result.unknownFiles).toEqual([]);
+    expect(result.expectedJobs).toContain("app-frontend");
+    expect(result.expectedJobs).toContain("playwright-ui-smoke");
+    expect(result.expectedJobs).toContain("tauri-build-smoke");
+    for (const job of FULL_CI_HEAVY) {
+      expect(result.expectedJobs).not.toContain(job);
+    }
+  });
+
+  test("PR #144 — Rust audio + tests + contract doc", () => {
+    const result = pr(
+      "src-tauri/src/audio/mixer.rs",
+      "src-tauri/tests/audio_test.rs",
+      "docs/references/contracts/playback.md",
+    );
+    expect(result.categories).toContain("rust");
+    expect(result.categories).toContain("docs");
+    expect(result.unknownFiles).toEqual([]);
+    expect(result.expectedJobs).toContain("rust-test");
+    expect(result.expectedJobs).toContain("rust-test-windows-compile");
+    expect(result.expectedJobs).toContain("cargo-deny");
+    expect(result.expectedJobs).toContain("dependency-checks");
+    expect(result.expectedJobs).toContain("prepare-model");
+    expect(result.expectedJobs).toContain("tauri-build");
+    // No frontend-only smoke
+    expect(result.expectedJobs).not.toContain("tauri-build-smoke");
+  });
+
+  test("PR #152 — mixed frontend + Rust + docs = full CI", () => {
+    const result = pr("src/foo.ts", "src-tauri/src/foo.rs", "docs/guide.md");
+    expect(result.categories).toContain("frontend_app");
+    expect(result.categories).toContain("rust");
+    expect(result.categories).toContain("docs");
+    expect(result.unknownFiles).toEqual([]);
+    // Full CI: both frontend and Rust jobs
+    expect(result.expectedJobs).toContain("app-frontend");
+    expect(result.expectedJobs).toContain("rust-test");
+    expect(result.expectedJobs).toContain("tauri-build");
+    // tauri-build-smoke is suppressed when heavy (Rust) is present
+    expect(result.expectedJobs).not.toContain("tauri-build-smoke");
+  });
+
+  test("PR #154 — release.yml only", () => {
+    const result = pr(".github/workflows/release.yml");
+    expect(result.categories).toEqual(["release_workflow"]);
+    expect(result.unknownFiles).toEqual([]);
+    expect(result.expectedJobs).toContain("workflow-lint");
+    expect(result.expectedJobs).toContain("release-validation");
+    // No heavy jobs
+    expect(result.expectedJobs).not.toContain("app-frontend");
+    expect(result.expectedJobs).not.toContain("playwright-ui-smoke");
+    expect(result.expectedJobs).not.toContain("website");
+    for (const job of FULL_CI_HEAVY) {
+      expect(result.expectedJobs).not.toContain(job);
+    }
+  });
+});
+
+// ── Synthetic fixtures from issue #155 table ──────────────────────────
+
+describe("synthetic fixtures", () => {
+  test("CI workflow (.github/workflows/ci.yml) = full CI", () => {
+    const result = pr(".github/workflows/ci.yml");
+    expect(result.categories).toEqual(["ci_workflow"]);
+    expect(result.unknownFiles).toEqual([]);
+    expect(result.expectedJobs).toContain("workflow-lint");
+    expect(result.expectedJobs).toContain("app-frontend");
+    expect(result.expectedJobs).toContain("rust-test");
+    expect(result.expectedJobs).toContain("tauri-build");
+  });
+
+  test("Packaging workflow (.github/workflows/packaging.yml)", () => {
+    const result = pr(".github/workflows/packaging.yml");
+    expect(result.categories).toEqual(["packaging_workflow"]);
+    expect(result.unknownFiles).toEqual([]);
+    expect(result.expectedJobs).toContain("workflow-lint");
+    // No app CI for packaging-workflow-only
+    expect(result.expectedJobs).not.toContain("app-frontend");
+    expect(result.expectedJobs).not.toContain("rust-test");
+  });
+
+  test("E2E (tests/e2e/player.spec.ts) = Playwright", () => {
+    const result = pr("tests/e2e/player.spec.ts");
+    expect(result.categories).toEqual(["e2e"]);
+    expect(result.unknownFiles).toEqual([]);
+    expect(result.expectedJobs).toContain("playwright-ui-smoke");
+    expect(result.expectedJobs).toContain("js-quality");
+    for (const job of FULL_CI_HEAVY) {
+      expect(result.expectedJobs).not.toContain(job);
+    }
+  });
+
+  test("Playwright config (playwright.config.ts) = e2e", () => {
+    const result = pr("playwright.config.ts");
+    expect(result.categories).toContain("e2e");
+    expect(result.unknownFiles).toEqual([]);
+    expect(result.expectedJobs).toContain("playwright-ui-smoke");
+  });
+
+  test("JS deps (package.json + pnpm-lock.yaml)", () => {
+    const result = pr("package.json", "pnpm-lock.yaml");
+    expect(result.categories).toContain("deps_js");
+    expect(result.unknownFiles).toEqual([]);
+    expect(result.expectedJobs).toContain("app-frontend");
+    expect(result.expectedJobs).toContain("website");
+    expect(result.expectedJobs).toContain("playwright-ui-smoke");
+    expect(result.expectedJobs).toContain("tauri-build-smoke");
+  });
+
+  test("Rust deps (Cargo.toml + Cargo.lock)", () => {
+    const result = pr("src-tauri/Cargo.toml", "src-tauri/Cargo.lock");
+    expect(result.categories).toContain("deps_rust");
+    expect(result.unknownFiles).toEqual([]);
+    expect(result.expectedJobs).toContain("rust-test");
+    expect(result.expectedJobs).toContain("tauri-build");
+    expect(result.expectedJobs).toContain("cargo-deny");
+  });
+
+  test("docs only (docs/guide.md) = no heavy jobs", () => {
+    const result = pr("docs/guide.md");
+    expect(result.categories).toEqual(["docs"]);
+    expect(result.unknownFiles).toEqual([]);
+    expect(result.expectedJobs).toEqual([
+      "triage",
+      "conventional-commits",
+      "ci-gate",
+    ]);
+  });
+
+  test("root docs (AGENTS.md) = no heavy jobs", () => {
+    const result = pr("AGENTS.md");
+    expect(result.categories).toEqual(["docs"]);
+    expect(result.unknownFiles).toEqual([]);
+    expect(result.expectedJobs).toEqual([
+      "triage",
+      "conventional-commits",
+      "ci-gate",
+    ]);
+  });
+
+  test("unknown file = full CI", () => {
+    const result = pr("new-unmapped-root-config.xyz");
+    expect(result.categories).toEqual(["unknown"]);
+    expect(result.unknownFiles).toEqual(["new-unmapped-root-config.xyz"]);
+    // Full CI: all heavy jobs
+    for (const job of FULL_CI_HEAVY) {
+      expect(result.expectedJobs).toContain(job);
+    }
+    expect(result.expectedJobs).toContain("app-frontend");
+    expect(result.expectedJobs).toContain("website");
+    expect(result.expectedJobs).toContain("playwright-ui-smoke");
+    expect(result.expectedJobs).toContain("workflow-lint");
+  });
+
+  test("mixed release/frontend = union of release + frontend", () => {
+    const result = pr(".github/workflows/release.yml", "src/foo.ts");
+    expect(result.categories).toContain("release_workflow");
+    expect(result.categories).toContain("frontend_app");
+    expect(result.unknownFiles).toEqual([]);
+    expect(result.expectedJobs).toContain("workflow-lint");
+    expect(result.expectedJobs).toContain("release-validation");
+    expect(result.expectedJobs).toContain("app-frontend");
+    expect(result.expectedJobs).toContain("playwright-ui-smoke");
+    expect(result.expectedJobs).toContain("tauri-build-smoke");
+  });
+
+  test("mixed website/Rust = union of website + Rust", () => {
+    const result = pr("website/x.ts", "src-tauri/src/x.rs");
+    expect(result.categories).toContain("website");
+    expect(result.categories).toContain("rust");
+    expect(result.unknownFiles).toEqual([]);
+    expect(result.expectedJobs).toContain("website");
+    expect(result.expectedJobs).toContain("rust-test");
+    expect(result.expectedJobs).toContain("tauri-build");
+    // tauri-build-smoke suppressed because Rust (heavy) is present
+    expect(result.expectedJobs).not.toContain("tauri-build-smoke");
+  });
+});
+
+// ── Event type behavior ───────────────────────────────────────────────
+
+describe("event type behavior", () => {
+  test("push to main always runs full CI regardless of files", () => {
+    const result = classifyChanges(["docs/guide.md"], "push");
+    // Even docs-only changes on push trigger full CI
+    for (const job of FULL_CI_HEAVY) {
+      expect(result.expectedJobs).toContain(job);
+    }
+  });
+
+  test("workflow_dispatch always runs full CI", () => {
+    const result = classifyChanges([], "workflow_dispatch");
+    for (const job of FULL_CI_HEAVY) {
+      expect(result.expectedJobs).toContain(job);
+    }
+  });
+
+  test("conventional-commits only expected on pull_request", () => {
+    const prResult = pr("src/foo.ts");
+    expect(prResult.expectedJobs).toContain("conventional-commits");
+
+    const pushResult = classifyChanges(["src/foo.ts"], "push");
+    expect(pushResult.expectedJobs).not.toContain("conventional-commits");
+  });
+});
+
+// ── Structural invariants ─────────────────────────────────────────────
+
+describe("structural invariants", () => {
+  test("ALL_JOBS includes every job referenced by the workflow", () => {
+    // These are the job IDs that ci.yml must define.
+    const requiredJobs = [
+      "triage",
+      "conventional-commits",
+      "ci-gate",
+      "js-quality",
+      "app-frontend",
+      "website",
+      "playwright-ui-smoke",
+      "workflow-lint",
+      "release-validation",
+      "cargo-deny",
+      "dependency-checks",
+      "prepare-model",
+      "rust-test",
+      "rust-test-windows-compile",
+      "tauri-build-smoke",
+      "tauri-build",
+    ];
+    for (const job of requiredJobs) {
+      expect(ALL_JOBS).toContain(job);
+    }
+  });
+
+  test("no category pattern is empty (except e2e_workflow reserved)", () => {
+    for (const [cat, patterns] of Object.entries(CATEGORY_PATTERNS)) {
+      if (cat === "e2e_workflow") continue; // reserved for future
+      expect(patterns.length, `${cat} has no patterns`).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/ci/classify-changes.test.ts
+++ b/tests/ci/classify-changes.test.ts
@@ -122,10 +122,12 @@ describe("classifyFile", () => {
     expect(classifyFile("src-tauri/Cargo.toml")).toEqual(["deps_rust"]);
   });
 
-  test("prepare-onnx-runtime.mjs is model_runtime", () => {
-    expect(classifyFile("scripts/prepare-onnx-runtime.mjs")).toEqual([
-      "model_runtime",
-    ]);
+  test("prepare-onnx-runtime.mjs is model_runtime and packaging_inputs", () => {
+    // packaging.yml triggers on this file, so it must classify into
+    // packaging_inputs to gate validate-flatpak and build-flatpak.
+    const cats = classifyFile("scripts/prepare-onnx-runtime.mjs");
+    expect(cats).toContain("model_runtime");
+    expect(cats).toContain("packaging_inputs");
   });
 
   test("playwright.config.ts is e2e and frontend_tooling", () => {


### PR DESCRIPTION
## Summary

Replaces the broken `dorny/paths-filter` triage from PR #150 with a checked-in classifier that is the single source of truth for path-based CI gating. Fixes all four systemic problems identified in #155: incorrect `unknown` classification, broad `workflows` category, Packaging over-triggering, and CI Gate accepting unexpected skips.

### What changed

- **New classifier** (`scripts/ci/classify-changes.mjs`): pure function over filenames and event type. Maps every file to 17 explicit categories, collects unmatched files as a true set complement, and derives the expected job set from the category union. No dependencies — testable locally without GitHub API access.

- **`unknown` is now a true set complement**: every file is checked against all known category matchers. The old `**` + negation pattern under `predicate-quantifier: some` is gone. Known frontend/website paths never set `unknown=true`.

- **Frontend job split** into `js-quality` (format/lint/i18n/knip/schema), `app-frontend` (typecheck/build/unit tests/coverage), and `website` (website typecheck/docs build). Website-only changes no longer run the full app test suite.

- **New `release-validation` job**: runs release-workflow and release-metadata contract tests for release-workflow-only changes. No app/frontend/Rust CI for release-notes text edits.

- **CI Gate hardened**: reads `expected-jobs` JSON from triage and fails on both unexpected skips (expected job was skipped) and unexpected executions (non-expected job ran). No longer accepts all skipped jobs indiscriminately.

- **Packaging workflow**: removed `release.yml` from triggers (a release-notes text edit no longer builds Flatpak from source), removed `codex/**` from push branches (prevents duplicate push + PR runs), added classifier-based gating for `build-flatpak` (requires `packaging_inputs` or `packaging_workflow`).

- **Playwright reporting**: config now generates both `list` and `html` reporters in CI. The `playwright-report/` upload uses `if-no-files-found: error` so the config and workflow cannot drift.

- **Model artifact waste**: `prepare-model` only runs when an expected downstream job consumes it (rust/deps/ci_workflow/unknown). Frontend-only, website-only, docs-only, and release-workflow-only changes no longer prepare or upload the 227 MB model.

- **Push to main and `workflow_dispatch`** always run full CI as a deliberate safety path.

- **Step summary**: triage writes a `GITHUB_STEP_SUMMARY` table showing changed files, categories per file, expected jobs, expected skipped heavy jobs, and unknown files.

### Tests

- `tests/ci/classify-changes.test.ts` — 51 contract tests covering all required fixtures from issue #155 (PR #147, #148, #149, #152, #153, #154) plus synthetic cases (docs, deps, unknown, mixed, CI workflow, packaging workflow, E2E, Playwright config).
- `tests/ci/ci-workflow-contract.test.ts` — 15 drift-protection tests that parse `ci.yml` and verify: every classifier job has a workflow job, every workflow job has a classifier entry, CI Gate depends on every job, no broad `workflows` boolean in app conditions, Playwright config/workflow agreement, and packaging workflow contract.

#### Test plan

- [x] `pnpm lint` — PASS (0 warnings, 0 errors)
- [x] `pnpm format` — PASS
- [x] `pnpm test` — PASS (1850 tests, 165 files)
- [x] `pnpm build` — PASS
- [x] `pnpm tsc --noEmit` — PASS
- [x] `pnpm knip` — PASS
- [x] `pnpm check:i18n` — PASS
- [x] `pnpm generate:db-schema` — PASS (no drift)
- [ ] CI real-run validation — pending (this PR's own CI run exercises the new classifier)

### Resource acceptance criteria

- [x] Known frontend and website paths never set `unknown=true`
- [x] PR #153 and #148 file sets do not prepare or upload the model
- [x] Release-workflow-only changes do not start Playwright, Rust, model, Windows, Tauri, or Flatpak build jobs
- [x] Documentation-only changes do not start heavy jobs
- [x] Frontend-only changes use Linux Tauri smoke rather than the full three-platform matrix
- [x] Rust-only and mixed changes retain the required safety checks
- [x] Packaging build jobs only run for packaging-impacting files
- [x] No `codex/**` branch creates duplicate push and PR Packaging runs
- [x] Playwright report upload produces a real report (HTML reporter in CI)
- [x] CI Gate fails on unexpected skip and on unexpected expensive execution
- [x] Every changed file is known or explicitly printed as unknown
- [x] Classification and expected-job contract tests cover all required fixtures
- [ ] actionlint and zizmor pass — pending CI run
- [x] Fork PRs remain read-only-safe (labeler only runs for same-repo PRs)
- [x] Main pushes and `workflow_dispatch` preserve a deliberate full-validation path

Closes #155

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thedavidweng/openkara/pull/156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->