### PR TITLE
feat(remote): durable remote-state.db control plane with operation state machine and startup recovery (#151)

### DIFF
--- a/src-tauri/migrations/remote_state/001_init.sql
+++ b/src-tauri/migrations/remote_state/001_init.sql
@@ -1,0 +1,82 @@
+-- Local-only control-plane database for remote repository state.
+--
+-- This database lives at <app-data>/remote-state.db and is NEVER uploaded to
+-- any cloud provider. It is the authoritative local record of:
+--   * repository cleanliness and expected remote generation
+--   * durable operation/outbox state
+--   * resumable upload sessions and offsets
+--   * verified cache catalog and LRU metadata
+--   * recovery after process termination
+--   * deferred remote cleanup
+--
+-- All schema objects use CREATE TABLE IF NOT EXISTS so that re-running the
+-- migration on an already-migrated database is a no-op (idempotent).
+
+CREATE TABLE IF NOT EXISTS remote_repository_state (
+  library_id TEXT PRIMARY KEY,
+  committed_generation INTEGER NOT NULL,
+  committed_manifest_revision TEXT,
+  local_base_generation INTEGER NOT NULL,
+  local_db_digest TEXT,
+  local_state TEXT NOT NULL CHECK (
+    local_state IN ('clean', 'dirty', 'publishing', 'conflicted', 'reauth_required')
+  ),
+  active_operation_id TEXT,
+  last_success_at_ms INTEGER,
+  last_error_code TEXT,
+  updated_at_ms INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS remote_operations (
+  operation_id TEXT PRIMARY KEY,
+  library_id TEXT NOT NULL,
+  operation_kind TEXT NOT NULL CHECK (
+    operation_kind IN ('publish', 'pull', 'download_asset', 'delete_asset', 'gc')
+  ),
+  state TEXT NOT NULL CHECK (
+    state IN (
+      'prepared', 'pending', 'running', 'retry_wait', 'committing',
+      'verifying', 'completed', 'failed', 'conflicted', 'cancelled'
+    )
+  ),
+  expected_generation INTEGER,
+  target_generation INTEGER,
+  source_db_digest TEXT,
+  candidate_db_digest TEXT,
+  payload_json TEXT NOT NULL,
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  next_attempt_at_ms INTEGER,
+  error_code TEXT,
+  error_detail TEXT,
+  created_at_ms INTEGER NOT NULL,
+  updated_at_ms INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS remote_transfer_parts (
+  operation_id TEXT NOT NULL,
+  relative_path TEXT NOT NULL,
+  direction TEXT NOT NULL CHECK (direction IN ('upload', 'download')),
+  expected_size INTEGER,
+  expected_digest TEXT,
+  provider_revision TEXT,
+  provider_session_id TEXT,
+  transferred_bytes INTEGER NOT NULL DEFAULT 0,
+  state TEXT NOT NULL,
+  updated_at_ms INTEGER NOT NULL,
+  PRIMARY KEY (operation_id, relative_path, direction)
+);
+
+CREATE TABLE IF NOT EXISTS remote_cache_entries (
+  cache_key TEXT PRIMARY KEY,
+  library_id TEXT NOT NULL,
+  relative_path TEXT NOT NULL,
+  provider_revision TEXT,
+  content_digest TEXT,
+  expected_size INTEGER NOT NULL,
+  downloaded_ranges_json TEXT NOT NULL,
+  complete INTEGER NOT NULL,
+  pinned_count INTEGER NOT NULL DEFAULT 0,
+  last_access_at_ms INTEGER NOT NULL,
+  verified_at_ms INTEGER,
+  data_path TEXT NOT NULL
+);

--- a/src-tauri/src/app_runtime.rs
+++ b/src-tauri/src/app_runtime.rs
@@ -174,6 +174,13 @@ pub fn setup_app<R: Runtime>(app: &mut tauri::App<R>) -> Result<(), Box<dyn std:
         .as_ref()
         .and_then(|config| config.remote_cache_bytes_limit);
     let remote_state = RemoteState::new_with_limit(&app_data_dir, remote_cache_bytes_limit);
+
+    // Run startup recovery for the durable remote control plane. This
+    // transitions interrupted operations to safe states but does NOT
+    // re-execute them (PR#4/#5 drive re-execution). The recovery pass must
+    // not block library startup — it runs after the control DB is open.
+    run_remote_recovery(&remote_state, &app_data_dir);
+
     let shell_state = AppShell::new(
         Arc::clone(&library),
         app_data_dir.clone(),
@@ -520,6 +527,52 @@ pub(crate) fn spawn_model_bootstrap_worker<R: Runtime>(
         };
         let _ = app_handle.emit(event, snapshot);
     });
+}
+
+/// Run the startup recovery pass for the durable remote control plane.
+///
+/// This transitions interrupted operations (running/committing/verifying →
+/// retry_wait, prepared → cancelled/pending/conflicted) but does NOT
+/// re-execute them. PR#4/#5 will drive re-execution once credentials and the
+/// active library are available.
+///
+/// The recovery pass runs after the control DB is open and must not block
+/// library startup. Errors are logged but do not abort app startup — a
+/// failed recovery leaves operations in their pre-recovery states, which is
+/// safe because the next startup will retry recovery.
+fn run_remote_recovery(remote_state: &RemoteState, app_data_dir: &std::path::Path) {
+    use crate::remote::recovery::{run_recovery, Clock, FileDigestResolver};
+
+    let recovery_result = {
+        let conn = match remote_state.control_db.lock() {
+            Ok(conn) => conn,
+            Err(_) => {
+                eprintln!("warning: remote control DB lock was poisoned during recovery");
+                return;
+            }
+        };
+
+        // Resolve the working DB path for a library via the config. This is
+        // used to compute the current digest for `prepared` operations.
+        let app_data_dir_owned = app_data_dir.to_path_buf();
+        let resolver = FileDigestResolver::new(move |library_id: &str| {
+            let config = crate::config::load_config(&app_data_dir_owned)
+                .ok()
+                .flatten()?;
+            let library = config.libraries.iter().find(|l| l.id() == library_id)?;
+            let root_path = library.working_copy_root()?;
+            let root = crate::library_root::LibraryRoot::open(&root_path).ok()?;
+            Some(root.database_path())
+        });
+
+        let clock: Clock = Box::new(crate::remote::types::current_unix_time_ms);
+
+        run_recovery(&conn, &resolver, &clock)
+    };
+
+    if let Err(error) = recovery_result {
+        eprintln!("warning: remote control DB recovery failed: {:?}", error);
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/remote/control_db.rs
+++ b/src-tauri/src/remote/control_db.rs
@@ -1,0 +1,1035 @@
+//! Durable local control-plane database for remote repository state.
+//!
+//! This database (`<app-data>/remote-state.db`) is the authoritative local
+//! record of remote operation/outbox state, repository cleanliness, resumable
+//! transfer offsets, and the verified cache catalog. It stays outside every
+//! portable library and is NEVER uploaded to a cloud provider.
+//!
+//! ## Why a separate database
+//!
+//! Library SQLite databases are portable: they travel inside the remote
+//! repository working copy and are synced to cloud storage. Persisting
+//! operation state, retry schedules, or cache metadata there would leak
+//! machine-local concerns into the portable set and risk clobbering another
+//! device's control state on sync. A dedicated local-only database keeps the
+//! control plane private to this machine while the library DB remains the
+//! shared content address.
+//!
+//! ## Storage safety
+//!
+//! Only sanitized machine-readable error codes are persisted. OAuth access
+//! tokens, passwords, request URLs containing credentials, and raw provider
+//! responses are never written here.
+//!
+//! ## Concurrency
+//!
+//! The control DB is opened with WAL journal mode so concurrent readers (e.g.
+//! `get_all_upload_statuses`) do not block the single writer that transitions
+//! operation state. All state transitions are committed transactionally.
+
+use crate::commands::error::{database_error, internal_error, CommandError, CommandResult};
+use crate::hash;
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+
+/// SQL migrations for the remote control database, kept in a subdirectory so
+/// they stay separate from portable library DB migrations.
+const REMOTE_STATE_MIGRATIONS: [&str; 1] =
+    [include_str!("../../migrations/remote_state/001_init.sql")];
+
+/// Filename of the control database inside the app data directory.
+pub const CONTROL_DB_FILENAME: &str = "remote-state.db";
+
+// ---------------------------------------------------------------------------
+// Typed enums mirroring the CHECK constraints
+// ---------------------------------------------------------------------------
+
+/// Repository cleanliness state for a remote library.
+///
+/// Mirrors the `local_state` CHECK constraint on `remote_repository_state`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LocalState {
+    Clean,
+    Dirty,
+    Publishing,
+    Conflicted,
+    ReauthRequired,
+}
+
+impl LocalState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            LocalState::Clean => "clean",
+            LocalState::Dirty => "dirty",
+            LocalState::Publishing => "publishing",
+            LocalState::Conflicted => "conflicted",
+            LocalState::ReauthRequired => "reauth_required",
+        }
+    }
+
+    fn from_db(value: &str) -> Result<Self, CommandError> {
+        match value {
+            "clean" => Ok(LocalState::Clean),
+            "dirty" => Ok(LocalState::Dirty),
+            "publishing" => Ok(LocalState::Publishing),
+            "conflicted" => Ok(LocalState::Conflicted),
+            "reauth_required" => Ok(LocalState::ReauthRequired),
+            other => Err(internal_error(format!(
+                "unknown local_state value in control DB: {other}"
+            ))),
+        }
+    }
+}
+
+/// Kind of remote operation recorded in `remote_operations`.
+///
+/// Mirrors the `operation_kind` CHECK constraint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OperationKind {
+    Publish,
+    Pull,
+    DownloadAsset,
+    DeleteAsset,
+    Gc,
+}
+
+impl OperationKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            OperationKind::Publish => "publish",
+            OperationKind::Pull => "pull",
+            OperationKind::DownloadAsset => "download_asset",
+            OperationKind::DeleteAsset => "delete_asset",
+            OperationKind::Gc => "gc",
+        }
+    }
+
+    fn from_db(value: &str) -> Result<Self, CommandError> {
+        match value {
+            "publish" => Ok(OperationKind::Publish),
+            "pull" => Ok(OperationKind::Pull),
+            "download_asset" => Ok(OperationKind::DownloadAsset),
+            "delete_asset" => Ok(OperationKind::DeleteAsset),
+            "gc" => Ok(OperationKind::Gc),
+            other => Err(internal_error(format!(
+                "unknown operation_kind value in control DB: {other}"
+            ))),
+        }
+    }
+}
+
+/// Lifecycle state of a remote operation.
+///
+/// Mirrors the `state` CHECK constraint on `remote_operations`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OperationState {
+    Prepared,
+    Pending,
+    Running,
+    RetryWait,
+    Committing,
+    Verifying,
+    Completed,
+    Failed,
+    Conflicted,
+    Cancelled,
+}
+
+impl OperationState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            OperationState::Prepared => "prepared",
+            OperationState::Pending => "pending",
+            OperationState::Running => "running",
+            OperationState::RetryWait => "retry_wait",
+            OperationState::Committing => "committing",
+            OperationState::Verifying => "verifying",
+            OperationState::Completed => "completed",
+            OperationState::Failed => "failed",
+            OperationState::Conflicted => "conflicted",
+            OperationState::Cancelled => "cancelled",
+        }
+    }
+
+    fn from_db(value: &str) -> Result<Self, CommandError> {
+        match value {
+            "prepared" => Ok(OperationState::Prepared),
+            "pending" => Ok(OperationState::Pending),
+            "running" => Ok(OperationState::Running),
+            "retry_wait" => Ok(OperationState::RetryWait),
+            "committing" => Ok(OperationState::Committing),
+            "verifying" => Ok(OperationState::Verifying),
+            "completed" => Ok(OperationState::Completed),
+            "failed" => Ok(OperationState::Failed),
+            "conflicted" => Ok(OperationState::Conflicted),
+            "cancelled" => Ok(OperationState::Cancelled),
+            other => Err(internal_error(format!(
+                "unknown operation state value in control DB: {other}"
+            ))),
+        }
+    }
+}
+
+/// Transfer direction for a `remote_transfer_parts` row.
+///
+/// Mirrors the `direction` CHECK constraint.
+// used by PR#5: resumable uploads/downloads
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransferDirection {
+    Upload,
+    Download,
+}
+
+impl TransferDirection {
+    // used by PR#5: resumable uploads/downloads
+    #[allow(dead_code)]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TransferDirection::Upload => "upload",
+            TransferDirection::Download => "download",
+        }
+    }
+
+    // used by PR#5: resumable uploads/downloads
+    #[allow(dead_code)]
+    fn from_db(value: &str) -> Result<Self, CommandError> {
+        match value {
+            "upload" => Ok(TransferDirection::Upload),
+            "download" => Ok(TransferDirection::Download),
+            other => Err(internal_error(format!(
+                "unknown transfer direction value in control DB: {other}"
+            ))),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// payload_json contract
+// ---------------------------------------------------------------------------
+
+/// Stable JSON shape stored in `remote_operations.payload_json` for publish
+/// operations. Later PRs (PR#4/#5) extend this with additional fields but must
+/// keep `song_ids`, `percent`, and `detail` backward-compatible so recovery
+/// and `get_all_upload_statuses` can read rows written by older versions.
+///
+/// ```json
+/// {"song_ids": ["hash-a", "hash-b"], "percent": 42, "detail": "Uploading stems"}
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperationPayload {
+    /// Song hashes affected by this operation. For publish operations this is
+    /// the set of songs whose assets are uploaded.
+    pub song_ids: Vec<String>,
+    /// Completion percentage (0-100) for progress projection.
+    pub percent: u8,
+    /// Human-readable detail string for the upload status snapshot.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+impl OperationPayload {
+    pub fn to_json(&self) -> CommandResult<String> {
+        serde_json::to_string(self)
+            .map_err(|e| internal_error(format!("failed to serialize operation payload: {e}")))
+    }
+
+    pub fn from_json(json: &str) -> CommandResult<Self> {
+        serde_json::from_str(json)
+            .map_err(|e| internal_error(format!("failed to deserialize operation payload: {e}")))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Row types
+// ---------------------------------------------------------------------------
+
+/// Row of `remote_repository_state`.
+#[derive(Debug, Clone)]
+pub struct RepositoryStateRow {
+    pub library_id: String,
+    pub committed_generation: i64,
+    pub committed_manifest_revision: Option<String>,
+    pub local_base_generation: i64,
+    pub local_db_digest: Option<String>,
+    pub local_state: LocalState,
+    pub active_operation_id: Option<String>,
+    pub last_success_at_ms: Option<i64>,
+    pub last_error_code: Option<String>,
+    pub updated_at_ms: i64,
+}
+
+/// Row of `remote_operations`.
+#[derive(Debug, Clone)]
+pub struct OperationRow {
+    pub operation_id: String,
+    pub library_id: String,
+    pub operation_kind: OperationKind,
+    pub state: OperationState,
+    pub expected_generation: Option<i64>,
+    pub target_generation: Option<i64>,
+    pub source_db_digest: Option<String>,
+    pub candidate_db_digest: Option<String>,
+    pub payload_json: String,
+    pub attempt_count: i64,
+    pub next_attempt_at_ms: Option<i64>,
+    pub error_code: Option<String>,
+    pub error_detail: Option<String>,
+    pub created_at_ms: i64,
+    pub updated_at_ms: i64,
+}
+
+/// Row of `remote_transfer_parts`.
+// used by PR#5: resumable uploads/downloads
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct TransferPartRow {
+    pub operation_id: String,
+    pub relative_path: String,
+    pub direction: TransferDirection,
+    pub expected_size: Option<i64>,
+    pub expected_digest: Option<String>,
+    pub provider_revision: Option<String>,
+    pub provider_session_id: Option<String>,
+    pub transferred_bytes: i64,
+    pub state: String,
+    pub updated_at_ms: i64,
+}
+
+/// Row of `remote_cache_entries`.
+// used by PR#6: persistent cache catalog
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct CacheEntryRow {
+    pub cache_key: String,
+    pub library_id: String,
+    pub relative_path: String,
+    pub provider_revision: Option<String>,
+    pub content_digest: Option<String>,
+    pub expected_size: i64,
+    pub downloaded_ranges_json: String,
+    pub complete: bool,
+    pub pinned_count: i64,
+    pub last_access_at_ms: i64,
+    pub verified_at_ms: Option<i64>,
+    pub data_path: String,
+}
+
+// ---------------------------------------------------------------------------
+// Connection management + migrations
+// ---------------------------------------------------------------------------
+
+/// Path of the control database inside the app data directory.
+pub fn control_db_path(app_data_dir: &Path) -> PathBuf {
+    app_data_dir.join(CONTROL_DB_FILENAME)
+}
+
+/// Open the control database, enable WAL journal mode, and apply migrations.
+///
+/// WAL mode lets concurrent readers (upload-status queries) proceed without
+/// blocking the single writer that transitions operation state.
+pub fn open_control_db(path: &Path) -> CommandResult<Connection> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            internal_error(format!(
+                "failed to create control DB parent directory {}: {e}",
+                path.display()
+            ))
+        })?;
+    }
+    let conn = Connection::open(path).map_err(|e| {
+        database_error(format!(
+            "failed to open control DB at {}: {e}",
+            path.display()
+        ))
+    })?;
+
+    // Enable WAL so readers never block the writer. This is a persistent
+    // property of the database file, but setting it on every open is cheap
+    // and makes the behavior explicit.
+    conn.execute_batch("PRAGMA journal_mode=WAL;")
+        .map_err(|e| database_error(format!("failed to enable WAL on control DB: {e}")))?;
+
+    apply_migrations(&conn)?;
+    Ok(conn)
+}
+
+/// Apply all remote-state migrations. Idempotent: every statement uses
+/// `CREATE TABLE IF NOT EXISTS`, so running this on an already-migrated
+/// database is a no-op.
+pub fn apply_migrations(connection: &Connection) -> CommandResult<()> {
+    for migration in REMOTE_STATE_MIGRATIONS {
+        connection
+            .execute_batch(migration)
+            .map_err(|e| database_error(format!("failed to apply control DB migration: {e}")))?;
+    }
+    Ok(())
+}
+
+/// Query the current journal mode. Used by tests to assert WAL is enabled.
+// also used by PR#5 for transfer diagnostics
+#[allow(dead_code)]
+pub fn journal_mode(connection: &Connection) -> CommandResult<String> {
+    connection
+        .query_row("PRAGMA journal_mode;", [], |row| row.get::<_, String>(0))
+        .map_err(|e| database_error(format!("failed to query journal mode: {e}")))
+}
+
+// ---------------------------------------------------------------------------
+// remote_repository_state CRUD
+// ---------------------------------------------------------------------------
+
+/// Insert or replace a repository state row.
+pub fn upsert_repository_state(
+    connection: &Connection,
+    row: &RepositoryStateRow,
+) -> CommandResult<()> {
+    connection
+        .execute(
+            "INSERT INTO remote_repository_state (
+                library_id, committed_generation, committed_manifest_revision,
+                local_base_generation, local_db_digest, local_state,
+                active_operation_id, last_success_at_ms, last_error_code, updated_at_ms
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+            ON CONFLICT(library_id) DO UPDATE SET
+                committed_generation = excluded.committed_generation,
+                committed_manifest_revision = excluded.committed_manifest_revision,
+                local_base_generation = excluded.local_base_generation,
+                local_db_digest = excluded.local_db_digest,
+                local_state = excluded.local_state,
+                active_operation_id = excluded.active_operation_id,
+                last_success_at_ms = excluded.last_success_at_ms,
+                last_error_code = excluded.last_error_code,
+                updated_at_ms = excluded.updated_at_ms",
+            params![
+                row.library_id,
+                row.committed_generation,
+                row.committed_manifest_revision,
+                row.local_base_generation,
+                row.local_db_digest,
+                row.local_state.as_str(),
+                row.active_operation_id,
+                row.last_success_at_ms,
+                row.last_error_code,
+                row.updated_at_ms,
+            ],
+        )
+        .map_err(|e| database_error(format!("failed to upsert repository state: {e}")))?;
+    Ok(())
+}
+
+/// Load a repository state row by library_id.
+pub fn get_repository_state(
+    connection: &Connection,
+    library_id: &str,
+) -> CommandResult<Option<RepositoryStateRow>> {
+    let mut stmt = connection
+        .prepare(
+            "SELECT library_id, committed_generation, committed_manifest_revision,
+                    local_base_generation, local_db_digest, local_state,
+                    active_operation_id, last_success_at_ms, last_error_code, updated_at_ms
+             FROM remote_repository_state WHERE library_id = ?1",
+        )
+        .map_err(|e| database_error(format!("failed to prepare repository state query: {e}")))?;
+    let row = stmt
+        .query_row([library_id], map_repository_state_row)
+        .optional()
+        .map_err(|e| database_error(format!("failed to query repository state: {e}")))?;
+    Ok(row)
+}
+
+/// Load all repository state rows.
+// used by PR#4: recovery coordinator
+#[allow(dead_code)]
+pub fn list_repository_states(connection: &Connection) -> CommandResult<Vec<RepositoryStateRow>> {
+    let mut stmt = connection
+        .prepare(
+            "SELECT library_id, committed_generation, committed_manifest_revision,
+                    local_base_generation, local_db_digest, local_state,
+                    active_operation_id, last_success_at_ms, last_error_code, updated_at_ms
+             FROM remote_repository_state",
+        )
+        .map_err(|e| database_error(format!("failed to prepare repository state list: {e}")))?;
+    let rows = stmt
+        .query_map([], map_repository_state_row)
+        .map_err(|e| database_error(format!("failed to list repository states: {e}")))?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|e| database_error(format!("failed to collect repository states: {e}")))?;
+    Ok(rows)
+}
+
+fn map_repository_state_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RepositoryStateRow> {
+    let local_state_str: String = row.get(5)?;
+    let local_state = LocalState::from_db(&local_state_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            5,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                e.message,
+            )),
+        )
+    })?;
+    Ok(RepositoryStateRow {
+        library_id: row.get(0)?,
+        committed_generation: row.get(1)?,
+        committed_manifest_revision: row.get(2)?,
+        local_base_generation: row.get(3)?,
+        local_db_digest: row.get(4)?,
+        local_state,
+        active_operation_id: row.get(6)?,
+        last_success_at_ms: row.get(7)?,
+        last_error_code: row.get(8)?,
+        updated_at_ms: row.get(9)?,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// remote_operations CRUD
+// ---------------------------------------------------------------------------
+
+/// Insert or replace an operation row.
+pub fn upsert_operation(connection: &Connection, row: &OperationRow) -> CommandResult<()> {
+    connection
+        .execute(
+            "INSERT INTO remote_operations (
+                operation_id, library_id, operation_kind, state,
+                expected_generation, target_generation, source_db_digest, candidate_db_digest,
+                payload_json, attempt_count, next_attempt_at_ms,
+                error_code, error_detail, created_at_ms, updated_at_ms
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+            ON CONFLICT(operation_id) DO UPDATE SET
+                library_id = excluded.library_id,
+                operation_kind = excluded.operation_kind,
+                state = excluded.state,
+                expected_generation = excluded.expected_generation,
+                target_generation = excluded.target_generation,
+                source_db_digest = excluded.source_db_digest,
+                candidate_db_digest = excluded.candidate_db_digest,
+                payload_json = excluded.payload_json,
+                attempt_count = excluded.attempt_count,
+                next_attempt_at_ms = excluded.next_attempt_at_ms,
+                error_code = excluded.error_code,
+                error_detail = excluded.error_detail,
+                updated_at_ms = excluded.updated_at_ms",
+            params![
+                row.operation_id,
+                row.library_id,
+                row.operation_kind.as_str(),
+                row.state.as_str(),
+                row.expected_generation,
+                row.target_generation,
+                row.source_db_digest,
+                row.candidate_db_digest,
+                row.payload_json,
+                row.attempt_count,
+                row.next_attempt_at_ms,
+                row.error_code,
+                row.error_detail,
+                row.created_at_ms,
+                row.updated_at_ms,
+            ],
+        )
+        .map_err(|e| database_error(format!("failed to upsert operation: {e}")))?;
+    Ok(())
+}
+
+/// Load an operation row by operation_id.
+pub fn get_operation(
+    connection: &Connection,
+    operation_id: &str,
+) -> CommandResult<Option<OperationRow>> {
+    let mut stmt = connection
+        .prepare(
+            "SELECT operation_id, library_id, operation_kind, state,
+                    expected_generation, target_generation, source_db_digest, candidate_db_digest,
+                    payload_json, attempt_count, next_attempt_at_ms,
+                    error_code, error_detail, created_at_ms, updated_at_ms
+             FROM remote_operations WHERE operation_id = ?1",
+        )
+        .map_err(|e| database_error(format!("failed to prepare operation query: {e}")))?;
+    let row = stmt
+        .query_row([operation_id], map_operation_row)
+        .optional()
+        .map_err(|e| database_error(format!("failed to query operation: {e}")))?;
+    Ok(row)
+}
+
+/// Load all operation rows.
+pub fn list_operations(connection: &Connection) -> CommandResult<Vec<OperationRow>> {
+    let mut stmt = connection
+        .prepare(
+            "SELECT operation_id, library_id, operation_kind, state,
+                    expected_generation, target_generation, source_db_digest, candidate_db_digest,
+                    payload_json, attempt_count, next_attempt_at_ms,
+                    error_code, error_detail, created_at_ms, updated_at_ms
+             FROM remote_operations",
+        )
+        .map_err(|e| database_error(format!("failed to prepare operation list: {e}")))?;
+    let rows = stmt
+        .query_map([], map_operation_row)
+        .map_err(|e| database_error(format!("failed to list operations: {e}")))?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|e| database_error(format!("failed to collect operations: {e}")))?;
+    Ok(rows)
+}
+
+/// Load all operation rows for a given library.
+// used by PR#4: operation executor
+#[allow(dead_code)]
+pub fn list_operations_for_library(
+    connection: &Connection,
+    library_id: &str,
+) -> CommandResult<Vec<OperationRow>> {
+    let mut stmt = connection
+        .prepare(
+            "SELECT operation_id, library_id, operation_kind, state,
+                    expected_generation, target_generation, source_db_digest, candidate_db_digest,
+                    payload_json, attempt_count, next_attempt_at_ms,
+                    error_code, error_detail, created_at_ms, updated_at_ms
+             FROM remote_operations WHERE library_id = ?1",
+        )
+        .map_err(|e| database_error(format!("failed to prepare operation list: {e}")))?;
+    let rows = stmt
+        .query_map([library_id], map_operation_row)
+        .map_err(|e| database_error(format!("failed to list operations: {e}")))?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|e| database_error(format!("failed to collect operations: {e}")))?;
+    Ok(rows)
+}
+
+/// Load all operation rows matching one of the given states.
+pub fn list_operations_in_states(
+    connection: &Connection,
+    states: &[OperationState],
+) -> CommandResult<Vec<OperationRow>> {
+    if states.is_empty() {
+        return Ok(Vec::new());
+    }
+    let placeholders: Vec<String> = (0..states.len()).map(|i| format!("?{}", i + 1)).collect();
+    let sql = format!(
+        "SELECT operation_id, library_id, operation_kind, state,
+                expected_generation, target_generation, source_db_digest, candidate_db_digest,
+                payload_json, attempt_count, next_attempt_at_ms,
+                error_code, error_detail, created_at_ms, updated_at_ms
+         FROM remote_operations WHERE state IN ({})",
+        placeholders.join(", ")
+    );
+    let mut stmt = connection
+        .prepare(&sql)
+        .map_err(|e| database_error(format!("failed to prepare operation state query: {e}")))?;
+    let state_strs: Vec<&str> = states.iter().map(|s| s.as_str()).collect();
+    let params_iter = state_strs
+        .iter()
+        .map(|s| s as &dyn rusqlite::ToSql)
+        .collect::<Vec<_>>();
+    let rows = stmt
+        .query_map(params_iter.as_slice(), map_operation_row)
+        .map_err(|e| database_error(format!("failed to query operations by state: {e}")))?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|e| database_error(format!("failed to collect operations by state: {e}")))?;
+    Ok(rows)
+}
+
+fn map_operation_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<OperationRow> {
+    let kind_str: String = row.get(2)?;
+    let state_str: String = row.get(3)?;
+    let operation_kind = OperationKind::from_db(&kind_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            2,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                e.message,
+            )),
+        )
+    })?;
+    let state = OperationState::from_db(&state_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            3,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                e.message,
+            )),
+        )
+    })?;
+    Ok(OperationRow {
+        operation_id: row.get(0)?,
+        library_id: row.get(1)?,
+        operation_kind,
+        state,
+        expected_generation: row.get(4)?,
+        target_generation: row.get(5)?,
+        source_db_digest: row.get(6)?,
+        candidate_db_digest: row.get(7)?,
+        payload_json: row.get(8)?,
+        attempt_count: row.get(9)?,
+        next_attempt_at_ms: row.get(10)?,
+        error_code: row.get(11)?,
+        error_detail: row.get(12)?,
+        created_at_ms: row.get(13)?,
+        updated_at_ms: row.get(14)?,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// remote_transfer_parts CRUD
+// ---------------------------------------------------------------------------
+
+/// Insert or replace a transfer part row.
+// used by PR#5: resumable uploads/downloads
+#[allow(dead_code)]
+pub fn upsert_transfer_part(connection: &Connection, row: &TransferPartRow) -> CommandResult<()> {
+    connection
+        .execute(
+            "INSERT INTO remote_transfer_parts (
+                operation_id, relative_path, direction,
+                expected_size, expected_digest, provider_revision, provider_session_id,
+                transferred_bytes, state, updated_at_ms
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+            ON CONFLICT(operation_id, relative_path, direction) DO UPDATE SET
+                expected_size = excluded.expected_size,
+                expected_digest = excluded.expected_digest,
+                provider_revision = excluded.provider_revision,
+                provider_session_id = excluded.provider_session_id,
+                transferred_bytes = excluded.transferred_bytes,
+                state = excluded.state,
+                updated_at_ms = excluded.updated_at_ms",
+            params![
+                row.operation_id,
+                row.relative_path,
+                row.direction.as_str(),
+                row.expected_size,
+                row.expected_digest,
+                row.provider_revision,
+                row.provider_session_id,
+                row.transferred_bytes,
+                row.state,
+                row.updated_at_ms,
+            ],
+        )
+        .map_err(|e| database_error(format!("failed to upsert transfer part: {e}")))?;
+    Ok(())
+}
+
+/// Load all transfer parts for an operation.
+// used by PR#5: resumable uploads/downloads
+#[allow(dead_code)]
+pub fn list_transfer_parts(
+    connection: &Connection,
+    operation_id: &str,
+) -> CommandResult<Vec<TransferPartRow>> {
+    let mut stmt = connection
+        .prepare(
+            "SELECT operation_id, relative_path, direction,
+                    expected_size, expected_digest, provider_revision, provider_session_id,
+                    transferred_bytes, state, updated_at_ms
+             FROM remote_transfer_parts WHERE operation_id = ?1",
+        )
+        .map_err(|e| database_error(format!("failed to prepare transfer part query: {e}")))?;
+    let rows = stmt
+        .query_map([operation_id], map_transfer_part_row)
+        .map_err(|e| database_error(format!("failed to list transfer parts: {e}")))?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|e| database_error(format!("failed to collect transfer parts: {e}")))?;
+    Ok(rows)
+}
+
+// used by PR#5: resumable uploads/downloads
+#[allow(dead_code)]
+fn map_transfer_part_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TransferPartRow> {
+    let direction_str: String = row.get(2)?;
+    let direction = TransferDirection::from_db(&direction_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            2,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                e.message,
+            )),
+        )
+    })?;
+    Ok(TransferPartRow {
+        operation_id: row.get(0)?,
+        relative_path: row.get(1)?,
+        direction,
+        expected_size: row.get(3)?,
+        expected_digest: row.get(4)?,
+        provider_revision: row.get(5)?,
+        provider_session_id: row.get(6)?,
+        transferred_bytes: row.get(7)?,
+        state: row.get(8)?,
+        updated_at_ms: row.get(9)?,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// remote_cache_entries CRUD
+// ---------------------------------------------------------------------------
+
+/// Insert or replace a cache entry row.
+///
+/// PR#6 will populate this table; PR#2 only provides the accessor so the
+/// schema is in place.
+// used by PR#6: persistent cache catalog
+#[allow(dead_code)]
+pub fn upsert_cache_entry(connection: &Connection, row: &CacheEntryRow) -> CommandResult<()> {
+    connection
+        .execute(
+            "INSERT INTO remote_cache_entries (
+                cache_key, library_id, relative_path, provider_revision, content_digest,
+                expected_size, downloaded_ranges_json, complete, pinned_count,
+                last_access_at_ms, verified_at_ms, data_path
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+            ON CONFLICT(cache_key) DO UPDATE SET
+                library_id = excluded.library_id,
+                relative_path = excluded.relative_path,
+                provider_revision = excluded.provider_revision,
+                content_digest = excluded.content_digest,
+                expected_size = excluded.expected_size,
+                downloaded_ranges_json = excluded.downloaded_ranges_json,
+                complete = excluded.complete,
+                pinned_count = excluded.pinned_count,
+                last_access_at_ms = excluded.last_access_at_ms,
+                verified_at_ms = excluded.verified_at_ms,
+                data_path = excluded.data_path",
+            params![
+                row.cache_key,
+                row.library_id,
+                row.relative_path,
+                row.provider_revision,
+                row.content_digest,
+                row.expected_size,
+                row.downloaded_ranges_json,
+                row.complete,
+                row.pinned_count,
+                row.last_access_at_ms,
+                row.verified_at_ms,
+                row.data_path,
+            ],
+        )
+        .map_err(|e| database_error(format!("failed to upsert cache entry: {e}")))?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Digest helper
+// ---------------------------------------------------------------------------
+
+/// Compute the SHA-256 hex digest of a file's contents.
+///
+/// Used to record the working DB digest before and after a local mutation so
+/// recovery can detect whether a `prepared` operation's local edit committed.
+pub fn sha256_file(path: &Path) -> CommandResult<String> {
+    let bytes = std::fs::read(path).map_err(|e| {
+        internal_error(format!("failed to read {} for digest: {e}", path.display()))
+    })?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    Ok(hash::hex_lower(hasher.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn fresh_db() -> (TempDir, Connection) {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("remote-state.db");
+        let conn = open_control_db(&path).expect("open control DB");
+        (dir, conn)
+    }
+
+    fn now_ms() -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64
+    }
+
+    #[test]
+    fn wal_mode_is_enabled_on_open() {
+        let (_dir, conn) = fresh_db();
+        let mode = journal_mode(&conn).expect("journal mode");
+        assert_eq!(mode.to_lowercase(), "wal");
+    }
+
+    #[test]
+    fn migration_is_idempotent() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("remote-state.db");
+        let conn = open_control_db(&path).expect("first open");
+        // Re-running migrations on an already-migrated DB must not error.
+        apply_migrations(&conn).expect("second migration is a no-op");
+        // Re-opening also re-runs migrations and must succeed.
+        drop(conn);
+        let conn2 = open_control_db(&path).expect("reopen");
+        // Tables still exist and are usable.
+        let row = RepositoryStateRow {
+            library_id: "lib-1".to_owned(),
+            committed_generation: 0,
+            committed_manifest_revision: None,
+            local_base_generation: 0,
+            local_db_digest: None,
+            local_state: LocalState::Clean,
+            active_operation_id: None,
+            last_success_at_ms: None,
+            last_error_code: None,
+            updated_at_ms: now_ms(),
+        };
+        upsert_repository_state(&conn2, &row).expect("upsert after re-migration");
+    }
+
+    #[test]
+    fn repository_state_round_trips() {
+        let (_dir, conn) = fresh_db();
+        let row = RepositoryStateRow {
+            library_id: "lib-1".to_owned(),
+            committed_generation: 3,
+            committed_manifest_revision: Some("rev-abc".to_owned()),
+            local_base_generation: 2,
+            local_db_digest: Some("deadbeef".to_owned()),
+            local_state: LocalState::Dirty,
+            active_operation_id: Some("op-1".to_owned()),
+            last_success_at_ms: Some(1000),
+            last_error_code: None,
+            updated_at_ms: now_ms(),
+        };
+        upsert_repository_state(&conn, &row).expect("upsert");
+        let loaded = get_repository_state(&conn, "lib-1").expect("get").unwrap();
+        assert_eq!(loaded.library_id, "lib-1");
+        assert_eq!(loaded.committed_generation, 3);
+        assert_eq!(loaded.local_state, LocalState::Dirty);
+        assert_eq!(loaded.local_db_digest.as_deref(), Some("deadbeef"));
+    }
+
+    #[test]
+    fn operation_round_trips() {
+        let (_dir, conn) = fresh_db();
+        let payload = OperationPayload {
+            song_ids: vec!["song-a".to_owned()],
+            percent: 42,
+            detail: Some("Uploading".to_owned()),
+        };
+        let row = OperationRow {
+            operation_id: "op-1".to_owned(),
+            library_id: "lib-1".to_owned(),
+            operation_kind: OperationKind::Publish,
+            state: OperationState::Pending,
+            expected_generation: Some(3),
+            target_generation: Some(4),
+            source_db_digest: Some("abc".to_owned()),
+            candidate_db_digest: None,
+            payload_json: payload.to_json().unwrap(),
+            attempt_count: 0,
+            next_attempt_at_ms: None,
+            error_code: None,
+            error_detail: None,
+            created_at_ms: now_ms(),
+            updated_at_ms: now_ms(),
+        };
+        upsert_operation(&conn, &row).expect("upsert");
+        let loaded = get_operation(&conn, "op-1").expect("get").unwrap();
+        assert_eq!(loaded.operation_kind, OperationKind::Publish);
+        assert_eq!(loaded.state, OperationState::Pending);
+        let p = OperationPayload::from_json(&loaded.payload_json).unwrap();
+        assert_eq!(p.song_ids, vec!["song-a".to_owned()]);
+        assert_eq!(p.percent, 42);
+    }
+
+    #[test]
+    fn list_operations_in_states_filters() {
+        let (_dir, conn) = fresh_db();
+        let now = now_ms();
+        for (id, state) in [
+            ("op-1", OperationState::Running),
+            ("op-2", OperationState::Completed),
+            ("op-3", OperationState::Committing),
+        ] {
+            upsert_operation(
+                &conn,
+                &OperationRow {
+                    operation_id: id.to_owned(),
+                    library_id: "lib-1".to_owned(),
+                    operation_kind: OperationKind::Publish,
+                    state,
+                    expected_generation: None,
+                    target_generation: None,
+                    source_db_digest: None,
+                    candidate_db_digest: None,
+                    payload_json: r#"{"song_ids":[],"percent":0}"#.to_owned(),
+                    attempt_count: 0,
+                    next_attempt_at_ms: None,
+                    error_code: None,
+                    error_detail: None,
+                    created_at_ms: now,
+                    updated_at_ms: now,
+                },
+            )
+            .expect("upsert");
+        }
+        let active = list_operations_in_states(
+            &conn,
+            &[OperationState::Running, OperationState::Committing],
+        )
+        .expect("list");
+        assert_eq!(active.len(), 2);
+        assert!(active.iter().all(|r| r.operation_id != "op-2"));
+    }
+
+    #[test]
+    fn transfer_part_round_trips() {
+        let (_dir, conn) = fresh_db();
+        let row = TransferPartRow {
+            operation_id: "op-1".to_owned(),
+            relative_path: "media/song.mp3".to_owned(),
+            direction: TransferDirection::Upload,
+            expected_size: Some(1024),
+            expected_digest: Some("hash".to_owned()),
+            provider_revision: None,
+            provider_session_id: None,
+            transferred_bytes: 512,
+            state: "in_progress".to_owned(),
+            updated_at_ms: now_ms(),
+        };
+        upsert_transfer_part(&conn, &row).expect("upsert");
+        let parts = list_transfer_parts(&conn, "op-1").expect("list");
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0].direction, TransferDirection::Upload);
+        assert_eq!(parts[0].transferred_bytes, 512);
+    }
+
+    #[test]
+    fn sha256_file_matches_known_value() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("test.bin");
+        std::fs::write(&path, b"hello").expect("write");
+        let digest = sha256_file(&path).expect("digest");
+        // SHA-256 of "hello"
+        assert_eq!(
+            digest,
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+    }
+
+    #[test]
+    fn payload_json_round_trips_without_detail() {
+        let payload = OperationPayload {
+            song_ids: vec!["x".to_owned()],
+            percent: 0,
+            detail: None,
+        };
+        let json = payload.to_json().unwrap();
+        let back = OperationPayload::from_json(&json).unwrap();
+        assert_eq!(back.song_ids, vec!["x".to_owned()]);
+        assert_eq!(back.percent, 0);
+    }
+}

--- a/src-tauri/src/remote/mod.rs
+++ b/src-tauri/src/remote/mod.rs
@@ -6,13 +6,15 @@
 mod auth;
 mod auth_binding;
 mod bootstrap;
+pub(crate) mod control_db;
 mod dropbox;
 mod google_drive;
 mod mutation;
 pub(crate) mod provider;
+pub(crate) mod recovery;
 mod registry;
 mod sync;
-mod types;
+pub(crate) mod types;
 mod webdav;
 
 use crate::{

--- a/src-tauri/src/remote/mutation.rs
+++ b/src-tauri/src/remote/mutation.rs
@@ -2,6 +2,24 @@
 //! Pre-Mutation Refresh / Pre-Publish Conflict / Publish Changes protocol
 //! defined in `docs/references/contracts/library.md` and `CONTEXT.md`.
 //!
+//! # Durable outbox contract (PR#2)
+//!
+//! Every local mutation that publishes to a remote follows this sequence:
+//! 1. Read the local repository state row and current expected generation.
+//! 2. Write a durable `prepared` operation row (operation_id, expected_generation,
+//!    source_db_digest = current working DB SHA-256, payload_json with affected
+//!    song IDs + kind).
+//! 3. Execute and commit the library SQLite mutation (the mutation closure).
+//! 4. Compute the post-mutation DB digest.
+//! 5. Mark the repository `dirty` and the operation `pending` in the control DB.
+//! 6. Return the local mutation result to the caller.
+//! 7. Publication runs asynchronously (PR#4 drives it; PR#2 leaves the
+//!    operation `pending`).
+//!
+//! A network failure after step 6 leaves the local edit visible and durable
+//! with a retrying/outbox status. Recovery on the next startup inspects the
+//! `prepared`/`pending` rows and transitions them safely.
+//!
 //! # Why six entry points, not one
 //!
 //! Collapsing these into a single `run_mutation(closure, manifest)` that
@@ -36,10 +54,25 @@ use tauri::AppHandle;
 // sync_backend: production delegates to sync::, test uses thread-local mock
 // ---------------------------------------------------------------------------
 
+/// Handle returned by `record_prepared_operation` so the caller can transition
+/// the durable row to `pending` after the local mutation commits.
+// used by PR#4: operation executor will read these to drive retry
+#[allow(dead_code)]
+pub struct PreparedOperation {
+    pub operation_id: String,
+    pub library_id: String,
+}
+
 #[cfg(not(test))]
 mod sync_backend {
     use super::super::sync;
-    use crate::commands::error::CommandResult;
+    use super::PreparedOperation;
+    use crate::commands::error::{internal_error, CommandResult};
+    use crate::remote::control_db::{
+        self, get_repository_state, upsert_operation, upsert_repository_state, LocalState,
+        OperationKind, OperationPayload, OperationRow, OperationState, RepositoryStateRow,
+    };
+    use crate::remote::sync::active_remote_library;
     use crate::AppState;
     use std::path::Path;
     use tauri::AppHandle;
@@ -73,6 +106,135 @@ mod sync_backend {
         app_handle: &AppHandle<R>,
     ) -> CommandResult<()> {
         sync::sync_bound_remote_for_active_local_library(state, app_handle)
+    }
+
+    // --- Durable outbox state recording (PR#2) ---
+
+    /// Record a `prepared` operation row before the local mutation commits.
+    /// Returns the operation_id and source_db_digest so the caller can
+    /// transition the row to `pending` after the mutation.
+    ///
+    /// If no active remote library is bound, this is a no-op (local-only
+    /// library — nothing to publish).
+    pub fn record_prepared_operation(
+        state: &AppState,
+        song_ids: &[String],
+    ) -> CommandResult<Option<PreparedOperation>> {
+        let Some(library) = active_remote_library(&state.shell.app_data_dir)? else {
+            return Ok(None);
+        };
+        let library_id = library.id().to_owned();
+
+        // Resolve the working DB path to compute the pre-mutation digest.
+        let db_path = library
+            .working_copy_root()
+            .and_then(|root| crate::library_root::LibraryRoot::open(&root).ok())
+            .map(|root| root.database_path());
+
+        let source_db_digest = db_path
+            .as_ref()
+            .and_then(|p| control_db::sha256_file(p).ok());
+
+        // Read the current expected generation from the repository state row.
+        // PR#4 will wire committed_generation to the manifest generation; for
+        // now it defaults to 0.
+        let expected_generation = {
+            let conn = state.remote.control_db.lock().map_err(|_| {
+                crate::commands::error::state_lock_error("control DB lock was poisoned")
+            })?;
+            get_repository_state(&conn, &library_id)?
+                .map(|r| r.committed_generation)
+                .unwrap_or(0)
+        };
+
+        let operation_id = format!(
+            "publish-{}",
+            song_ids
+                .first()
+                .cloned()
+                .unwrap_or_else(|| "batch".to_owned())
+        );
+        let now = crate::remote::types::current_unix_time_ms();
+
+        let payload = OperationPayload {
+            song_ids: song_ids.to_vec(),
+            percent: 0,
+            detail: None,
+        };
+
+        let row = OperationRow {
+            operation_id: operation_id.clone(),
+            library_id: library_id.clone(),
+            operation_kind: OperationKind::Publish,
+            state: OperationState::Prepared,
+            expected_generation: Some(expected_generation),
+            target_generation: None,
+            source_db_digest: source_db_digest.clone(),
+            candidate_db_digest: None,
+            payload_json: payload.to_json()?,
+            attempt_count: 0,
+            next_attempt_at_ms: None,
+            error_code: None,
+            error_detail: None,
+            created_at_ms: now,
+            updated_at_ms: now,
+        };
+
+        {
+            let conn = state.remote.control_db.lock().map_err(|_| {
+                crate::commands::error::state_lock_error("control DB lock was poisoned")
+            })?;
+            upsert_operation(&conn, &row)?;
+        }
+
+        Ok(Some(PreparedOperation {
+            operation_id,
+            library_id,
+        }))
+    }
+
+    /// Transition a `prepared` operation to `pending` and mark the repository
+    /// `dirty` after the local mutation has committed.
+    pub fn mark_operation_pending_and_dirty(
+        state: &AppState,
+        prepared: &PreparedOperation,
+    ) -> CommandResult<()> {
+        let now = crate::remote::types::current_unix_time_ms();
+
+        let conn = state.remote.control_db.lock().map_err(|_| {
+            crate::commands::error::state_lock_error("control DB lock was poisoned")
+        })?;
+
+        // Transition the operation to pending.
+        let mut op = control_db::get_operation(&conn, &prepared.operation_id)?
+            .ok_or_else(|| internal_error("prepared operation row was not found"))?;
+        op.state = OperationState::Pending;
+        op.updated_at_ms = now;
+        upsert_operation(&conn, &op)?;
+
+        // Mark the repository dirty.
+        let repo_row = match get_repository_state(&conn, &prepared.library_id)? {
+            Some(mut row) => {
+                row.local_state = LocalState::Dirty;
+                row.updated_at_ms = now;
+                row
+            }
+            None => RepositoryStateRow {
+                library_id: prepared.library_id.clone(),
+                committed_generation: 0,
+                committed_manifest_revision: None,
+                local_base_generation: 0,
+                local_db_digest: None,
+                local_state: LocalState::Dirty,
+                active_operation_id: Some(prepared.operation_id.clone()),
+                last_success_at_ms: None,
+                last_error_code: None,
+                updated_at_ms: now,
+            },
+        };
+        upsert_repository_state(&conn, &repo_row)?;
+
+        Ok(())
     }
 }
 
@@ -172,6 +334,26 @@ mod sync_backend {
         CALLS.with(|c| c.borrow_mut().push(SyncCall::Mirror));
         MIRROR_RESULT.with(|r| r.borrow().clone())
     }
+
+    // --- Durable outbox state recording (PR#2) ---
+    //
+    // In tests, the test fixture has no active remote library, so these are
+    // no-ops. The existing call-sequence assertions remain intact because the
+    // durable recording does not add any SyncCall entries.
+
+    pub fn record_prepared_operation(
+        _state: &AppState,
+        _song_ids: &[String],
+    ) -> CommandResult<Option<super::PreparedOperation>> {
+        Ok(None)
+    }
+
+    pub fn mark_operation_pending_and_dirty(
+        _state: &AppState,
+        _prepared: &super::PreparedOperation,
+    ) -> CommandResult<()> {
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -181,12 +363,25 @@ mod sync_backend {
 /// Shared prefix for every mutation that starts with a Pre-Mutation Refresh:
 /// `prepare → mutation`. Centralizes the `app_data_dir` extraction so a
 /// future change to how the active remote is resolved touches one place.
+///
+/// Also records the durable outbox contract: a `prepared` operation row is
+/// written before the mutation, and the row is transitioned to `pending` +
+/// the repository marked `dirty` after the mutation commits. When no active
+/// remote library is bound, the durable recording is a no-op.
 fn prepare_and_mutate<T, F>(state: &AppState, mutation: F) -> CommandResult<T>
 where
     F: FnOnce() -> CommandResult<T>,
 {
     sync_backend::prepare(&state.shell.app_data_dir)?;
-    mutation()
+    // The song_ids are not known at this point for all callers; record with an
+    // empty list. Callers that know the song_ids use the explicit wrappers
+    // below which call record_prepared_operation with the real ids.
+    let prepared = sync_backend::record_prepared_operation(state, &[])?;
+    let result = mutation()?;
+    if let Some(ref prepared) = prepared {
+        sync_backend::mark_operation_pending_and_dirty(state, prepared)?;
+    }
+    Ok(result)
 }
 
 pub(crate) fn run_imported_songs_mutation<R, F>(
@@ -200,7 +395,14 @@ where
 {
     // ImportSongsResult is not a CommandResult, so call prepare directly.
     sync_backend::prepare(&state.shell.app_data_dir)?;
+    // The imported song_ids are only known after the mutation, so record the
+    // prepared operation with an empty list. The payload is updated when
+    // mark_upload_status is called during publish.
+    let prepared = sync_backend::record_prepared_operation(state, &[])?;
     let result = mutation();
+    if let Some(ref prepared) = prepared {
+        sync_backend::mark_operation_pending_and_dirty(state, prepared)?;
+    }
     let imported_song_ids: Vec<String> = result
         .imported
         .iter()

--- a/src-tauri/src/remote/mutation.rs
+++ b/src-tauri/src/remote/mutation.rs
@@ -147,13 +147,18 @@ mod sync_backend {
                 .unwrap_or(0)
         };
 
-        let operation_id = format!(
-            "publish-{}",
-            song_ids
-                .first()
-                .cloned()
-                .unwrap_or_else(|| "batch".to_owned())
-        );
+        let operation_id = if let Some(first) = song_ids.first() {
+            format!("publish-{first}")
+        } else {
+            // Batch mutations don't know song_ids yet. Use a unique
+            // timestamp-based id so concurrent or sequential batch mutations
+            // don't collide on the same primary key. These rows are internal
+            // outbook entries for recovery; get_all_upload_statuses filters
+            // them out (empty song_ids payload) so they never surface as
+            // phantom user-visible uploads.
+            let now = crate::remote::types::current_unix_time_ms();
+            format!("publish-batch-{now}")
+        };
         let now = crate::remote::types::current_unix_time_ms();
 
         let payload = OperationPayload {

--- a/src-tauri/src/remote/recovery.rs
+++ b/src-tauri/src/remote/recovery.rs
@@ -1,0 +1,620 @@
+//! Startup recovery for the durable remote control plane.
+//!
+//! On app startup, after the control DB is migrated and BEFORE remote
+//! libraries are loaded for use, a recovery pass transitions interrupted
+//! operations to safe states. Actual re-execution of operations is deferred to
+//! PR#4/#5 — this module only performs state transitions and scheduling.
+//!
+//! ## Recovery rules
+//!
+//! - `running`, `committing`, `verifying`: these were interrupted mid-flight
+//!   and must not be assumed complete. Transition to `retry_wait` (or
+//!   `pending` if no attempt backoff is needed) with `next_attempt_at_ms` set
+//!   to a near-future time.
+//! - `prepared` mutation intents: inspect the working DB digest vs
+//!   `source_db_digest`:
+//!   - unchanged → the mutation never committed locally; mark `cancelled`.
+//!   - changed → the local mutation committed but publication didn't finish;
+//!     promote to `pending` and mark `remote_repository_state.local_state =
+//!     'dirty'`.
+//!   - If `expected_generation` differs from the currently-known
+//!     `committed_generation`, mark `conflicted`.
+//! - `completed` operations stay `completed` and are not re-queued.
+//!
+//! ## Shutdown safety
+//!
+//! Because operations are durable, app shutdown does NOT delete rows or
+//! pretend to finish active operations. The next startup's recovery pass
+//! transitions any interrupted operations to safe retry states. No atexit
+//! hooks are needed.
+
+use crate::commands::error::CommandResult;
+use crate::remote::control_db::{
+    self, get_repository_state, list_operations_in_states, upsert_operation,
+    upsert_repository_state, LocalState, OperationRow, OperationState, RepositoryStateRow,
+};
+use rusqlite::Connection;
+
+/// Near-future offset (ms) applied to `next_attempt_at_ms` for operations
+/// transitioned to `retry_wait` during recovery. PR#4's executor will pick
+/// these up once credentials and the active library are available.
+const RECOVERY_RETRY_OFFSET_MS: i64 = 5_000;
+
+/// Clock abstraction so tests can use deterministic timestamps.
+pub type Clock = Box<dyn Fn() -> i64 + Send + Sync>;
+
+/// Trait for resolving the current working DB digest for a library during
+/// recovery. Production resolves the active library's DB path; tests inject a
+/// fixed digest.
+pub trait DigestResolver {
+    /// Return the SHA-256 hex digest of the working DB for `library_id`, or
+    /// `None` if the library is not available locally.
+    fn working_db_digest(&self, library_id: &str) -> Option<String>;
+}
+
+/// Result of running the recovery pass, for inspection in tests and logging.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RecoveryReport {
+    pub transitioned_to_retry_wait: Vec<String>,
+    pub transitioned_to_pending: Vec<String>,
+    pub cancelled: Vec<String>,
+    pub conflicted: Vec<String>,
+    pub already_completed: usize,
+}
+
+/// Run the startup recovery pass.
+///
+/// This transitions interrupted operations to safe states but does NOT
+/// re-execute them. PR#4 will drive retry via the operation executor.
+///
+/// `digest_resolver` provides the current working DB digest for `prepared`
+/// operations. `clock` provides the current time in milliseconds.
+pub fn run_recovery(
+    connection: &Connection,
+    digest_resolver: &dyn DigestResolver,
+    clock: &Clock,
+) -> CommandResult<RecoveryReport> {
+    let mut report = RecoveryReport::default();
+
+    // 1. running / committing / verifying → retry_wait (interrupted mid-flight)
+    let in_flight = list_operations_in_states(
+        connection,
+        &[
+            OperationState::Running,
+            OperationState::Committing,
+            OperationState::Verifying,
+        ],
+    )?;
+    for op in in_flight {
+        transition_in_flight_to_retry_wait(connection, &op, clock)?;
+        report.transitioned_to_retry_wait.push(op.operation_id);
+    }
+
+    // 2. prepared mutation intents → cancelled / pending / conflicted
+    let prepared = list_operations_in_states(connection, &[OperationState::Prepared])?;
+    for op in prepared {
+        let outcome = resolve_prepared_operation(connection, &op, digest_resolver, clock)?;
+        match outcome {
+            PreparedOutcome::Cancelled => report.cancelled.push(op.operation_id),
+            PreparedOutcome::PromotedToPending => {
+                report.transitioned_to_pending.push(op.operation_id)
+            }
+            PreparedOutcome::Conflicted => report.conflicted.push(op.operation_id),
+        }
+    }
+
+    // 3. completed operations stay completed — count for observability
+    let completed = list_operations_in_states(connection, &[OperationState::Completed])?;
+    report.already_completed = completed.len();
+
+    // TODO(PR#4): drive retry via operation executor. After credentials and
+    // the active library are available, the executor should pick up operations
+    // in `pending` / `retry_wait` and re-execute them.
+    Ok(report)
+}
+
+/// Transition an interrupted in-flight operation to `retry_wait`.
+fn transition_in_flight_to_retry_wait(
+    connection: &Connection,
+    op: &OperationRow,
+    clock: &Clock,
+) -> CommandResult<()> {
+    let now = (clock)();
+    let mut updated = op.clone();
+    updated.state = OperationState::RetryWait;
+    updated.next_attempt_at_ms = Some(now + RECOVERY_RETRY_OFFSET_MS);
+    updated.updated_at_ms = now;
+    upsert_operation(connection, &updated)
+}
+
+/// Outcome of resolving a `prepared` operation during recovery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PreparedOutcome {
+    /// Working DB unchanged → mutation never committed; operation cancelled.
+    Cancelled,
+    /// Working DB changed → mutation committed; promoted to `pending` + dirty.
+    PromotedToPending,
+    /// Expected generation differs from committed generation → conflicted.
+    Conflicted,
+}
+
+/// Resolve a `prepared` operation by comparing digests and generations.
+fn resolve_prepared_operation(
+    connection: &Connection,
+    op: &OperationRow,
+    digest_resolver: &dyn DigestResolver,
+    clock: &Clock,
+) -> CommandResult<PreparedOutcome> {
+    let now = (clock)();
+
+    // Conflict check: if expected_generation differs from the currently-known
+    // committed_generation, the remote advanced independently.
+    // TODO(PR#4): replace revision-based conflict check with manifest
+    // generation CAS.
+    if let Some(expected_gen) = op.expected_generation {
+        if let Some(repo_state) = get_repository_state(connection, &op.library_id)? {
+            if repo_state.committed_generation != expected_gen {
+                let mut updated = op.clone();
+                updated.state = OperationState::Conflicted;
+                updated.updated_at_ms = now;
+                upsert_operation(connection, &updated)?;
+                return Ok(PreparedOutcome::Conflicted);
+            }
+        }
+    }
+
+    let working_digest = digest_resolver.working_db_digest(&op.library_id);
+    let source_digest = op.source_db_digest.as_deref();
+
+    let working_unchanged = working_digest.as_deref() == source_digest;
+
+    if working_unchanged {
+        // The mutation never committed locally — discard the intent.
+        let mut updated = op.clone();
+        updated.state = OperationState::Cancelled;
+        updated.updated_at_ms = now;
+        upsert_operation(connection, &updated)?;
+        Ok(PreparedOutcome::Cancelled)
+    } else {
+        // The local mutation committed but publication didn't finish.
+        // Promote to pending and mark the repository dirty.
+        let mut updated = op.clone();
+        updated.state = OperationState::Pending;
+        updated.updated_at_ms = now;
+        upsert_operation(connection, &updated)?;
+
+        mark_repository_dirty(connection, &op.library_id, now)?;
+        Ok(PreparedOutcome::PromotedToPending)
+    }
+}
+
+/// Mark a repository's `local_state` as `dirty`. Inserts a row if none exists
+/// (e.g. the library was never recorded before the mutation).
+fn mark_repository_dirty(
+    connection: &Connection,
+    library_id: &str,
+    now_ms: i64,
+) -> CommandResult<()> {
+    let existing = get_repository_state(connection, library_id)?;
+    let row = match existing {
+        Some(mut row) => {
+            row.local_state = LocalState::Dirty;
+            row.updated_at_ms = now_ms;
+            row
+        }
+        None => RepositoryStateRow {
+            library_id: library_id.to_owned(),
+            committed_generation: 0,
+            committed_manifest_revision: None,
+            local_base_generation: 0,
+            local_db_digest: None,
+            local_state: LocalState::Dirty,
+            active_operation_id: None,
+            last_success_at_ms: None,
+            last_error_code: None,
+            updated_at_ms: now_ms,
+        },
+    };
+    upsert_repository_state(connection, &row)
+}
+
+/// A `DigestResolver` that always returns `None`. Used when no active library
+/// is available (e.g. the control DB is open but libraries are not loaded yet
+/// in a minimal test).
+// used by recovery tests
+#[allow(dead_code)]
+pub struct NullDigestResolver;
+
+impl DigestResolver for NullDigestResolver {
+    fn working_db_digest(&self, _library_id: &str) -> Option<String> {
+        None
+    }
+}
+
+/// A `DigestResolver` backed by a map of library_id → digest. Used in tests to
+/// simulate working DB state without real files.
+// used by recovery tests
+#[allow(dead_code)]
+pub struct MapDigestResolver {
+    digests: std::collections::HashMap<String, String>,
+}
+
+impl MapDigestResolver {
+    // used by recovery tests
+    #[allow(dead_code)]
+    pub fn new(digests: std::collections::HashMap<String, String>) -> Self {
+        Self { digests }
+    }
+}
+
+impl DigestResolver for MapDigestResolver {
+    fn working_db_digest(&self, library_id: &str) -> Option<String> {
+        self.digests.get(library_id).cloned()
+    }
+}
+
+/// A `DigestResolver` that computes the real SHA-256 of the working DB file
+/// for a library. The closure maps `library_id` → DB path.
+pub struct FileDigestResolver<F>
+where
+    F: Fn(&str) -> Option<std::path::PathBuf> + Send + Sync,
+{
+    resolve_path: F,
+}
+
+impl<F> FileDigestResolver<F>
+where
+    F: Fn(&str) -> Option<std::path::PathBuf> + Send + Sync,
+{
+    pub fn new(resolve_path: F) -> Self {
+        Self { resolve_path }
+    }
+}
+
+impl<F> DigestResolver for FileDigestResolver<F>
+where
+    F: Fn(&str) -> Option<std::path::PathBuf> + Send + Sync,
+{
+    fn working_db_digest(&self, library_id: &str) -> Option<String> {
+        let path = (self.resolve_path)(library_id)?;
+        if !path.exists() {
+            return None;
+        }
+        control_db::sha256_file(&path).ok()
+    }
+}
+
+/// Helper: acquire the per-library commit lock. Returns a guard that serializes
+/// concurrent commit attempts for the same library. Different libraries proceed
+/// concurrently.
+///
+/// This is a no-op placeholder seam for PR#2 — the actual lock map lives in
+/// `RemoteState`. This function is provided so PR#4/#5 can call it with a
+/// resolved lock without reaching into `RemoteState` internals.
+// used by PR#4/#5: operation executor
+#[allow(dead_code)]
+pub fn acquire_commit_lock<'a>(
+    locks: &'a std::collections::HashMap<String, std::sync::Arc<std::sync::Mutex<()>>>,
+    library_id: &str,
+) -> Option<std::sync::MutexGuard<'a, ()>> {
+    locks
+        .get(library_id)
+        .map(|lock| lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::remote::control_db::{get_operation, open_control_db, OperationKind, OperationRow};
+    use tempfile::TempDir;
+
+    fn fresh_db() -> (TempDir, Connection) {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("remote-state.db");
+        let conn = open_control_db(&path).expect("open control DB");
+        (dir, conn)
+    }
+
+    fn fixed_clock(ms: i64) -> Clock {
+        Box::new(move || ms)
+    }
+
+    fn make_operation(
+        id: &str,
+        library_id: &str,
+        state: OperationState,
+        source_db_digest: Option<&str>,
+        expected_generation: Option<i64>,
+    ) -> OperationRow {
+        OperationRow {
+            operation_id: id.to_owned(),
+            library_id: library_id.to_owned(),
+            operation_kind: OperationKind::Publish,
+            state,
+            expected_generation,
+            target_generation: None,
+            source_db_digest: source_db_digest.map(|s| s.to_owned()),
+            candidate_db_digest: None,
+            payload_json: r#"{"song_ids":[],"percent":0}"#.to_owned(),
+            attempt_count: 0,
+            next_attempt_at_ms: None,
+            error_code: None,
+            error_detail: None,
+            created_at_ms: 1000,
+            updated_at_ms: 1000,
+        }
+    }
+
+    fn make_repo_state(library_id: &str, committed_generation: i64) -> RepositoryStateRow {
+        RepositoryStateRow {
+            library_id: library_id.to_owned(),
+            committed_generation,
+            committed_manifest_revision: None,
+            local_base_generation: 0,
+            local_db_digest: None,
+            local_state: LocalState::Clean,
+            active_operation_id: None,
+            last_success_at_ms: None,
+            last_error_code: None,
+            updated_at_ms: 1000,
+        }
+    }
+
+    // --- Crash/restart at every transition ---
+
+    #[test]
+    fn recovery_transitions_running_to_retry_wait() {
+        let (_dir, conn) = fresh_db();
+        let op = make_operation("op-1", "lib-1", OperationState::Running, None, None);
+        upsert_operation(&conn, &op).unwrap();
+
+        let report = run_recovery(&conn, &NullDigestResolver, &fixed_clock(5000)).unwrap();
+
+        assert_eq!(report.transitioned_to_retry_wait, vec!["op-1".to_owned()]);
+        let loaded = get_operation(&conn, "op-1").unwrap().unwrap();
+        assert_eq!(loaded.state, OperationState::RetryWait);
+        assert_eq!(
+            loaded.next_attempt_at_ms,
+            Some(5000 + RECOVERY_RETRY_OFFSET_MS)
+        );
+    }
+
+    #[test]
+    fn recovery_transitions_committing_to_retry_wait() {
+        let (_dir, conn) = fresh_db();
+        let op = make_operation("op-1", "lib-1", OperationState::Committing, None, None);
+        upsert_operation(&conn, &op).unwrap();
+
+        let report = run_recovery(&conn, &NullDigestResolver, &fixed_clock(5000)).unwrap();
+
+        assert_eq!(report.transitioned_to_retry_wait, vec!["op-1".to_owned()]);
+        let loaded = get_operation(&conn, "op-1").unwrap().unwrap();
+        assert_eq!(loaded.state, OperationState::RetryWait);
+    }
+
+    #[test]
+    fn recovery_transitions_verifying_to_retry_wait() {
+        let (_dir, conn) = fresh_db();
+        let op = make_operation("op-1", "lib-1", OperationState::Verifying, None, None);
+        upsert_operation(&conn, &op).unwrap();
+
+        let report = run_recovery(&conn, &NullDigestResolver, &fixed_clock(5000)).unwrap();
+
+        assert_eq!(report.transitioned_to_retry_wait, vec!["op-1".to_owned()]);
+        let loaded = get_operation(&conn, "op-1").unwrap().unwrap();
+        assert_eq!(loaded.state, OperationState::RetryWait);
+    }
+
+    #[test]
+    fn recovery_transitions_pending_stays_pending() {
+        let (_dir, conn) = fresh_db();
+        let op = make_operation("op-1", "lib-1", OperationState::Pending, None, None);
+        upsert_operation(&conn, &op).unwrap();
+
+        let report = run_recovery(&conn, &NullDigestResolver, &fixed_clock(5000)).unwrap();
+
+        // pending is not in the in-flight set — it should not be transitioned.
+        assert!(report.transitioned_to_retry_wait.is_empty());
+        assert!(report.transitioned_to_pending.is_empty());
+        let loaded = get_operation(&conn, "op-1").unwrap().unwrap();
+        assert_eq!(loaded.state, OperationState::Pending);
+    }
+
+    #[test]
+    fn recovery_transitions_retry_wait_stays_retry_wait() {
+        let (_dir, conn) = fresh_db();
+        let op = make_operation("op-1", "lib-1", OperationState::RetryWait, None, None);
+        upsert_operation(&conn, &op).unwrap();
+
+        let report = run_recovery(&conn, &NullDigestResolver, &fixed_clock(5000)).unwrap();
+
+        assert!(report.transitioned_to_retry_wait.is_empty());
+        let loaded = get_operation(&conn, "op-1").unwrap().unwrap();
+        assert_eq!(loaded.state, OperationState::RetryWait);
+    }
+
+    // --- Completed work does not repeat ---
+
+    #[test]
+    fn recovery_completed_stays_completed_and_not_requeued() {
+        let (_dir, conn) = fresh_db();
+        let op = make_operation("op-1", "lib-1", OperationState::Completed, None, None);
+        upsert_operation(&conn, &op).unwrap();
+
+        let report = run_recovery(&conn, &NullDigestResolver, &fixed_clock(5000)).unwrap();
+
+        assert_eq!(report.already_completed, 1);
+        assert!(report.transitioned_to_retry_wait.is_empty());
+        assert!(report.transitioned_to_pending.is_empty());
+        let loaded = get_operation(&conn, "op-1").unwrap().unwrap();
+        assert_eq!(loaded.state, OperationState::Completed);
+    }
+
+    // --- Prepared local mutation reconstruction from DB digests ---
+
+    #[test]
+    fn recovery_prepared_unchanged_db_is_cancelled() {
+        let (_dir, conn) = fresh_db();
+        let op = make_operation(
+            "op-1",
+            "lib-1",
+            OperationState::Prepared,
+            Some("digest-aaa"),
+            Some(0),
+        );
+        upsert_operation(&conn, &op).unwrap();
+        upsert_repository_state(&conn, &make_repo_state("lib-1", 0)).unwrap();
+
+        let resolver = MapDigestResolver::new(
+            [("lib-1".to_owned(), "digest-aaa".to_owned())]
+                .into_iter()
+                .collect(),
+        );
+        let report = run_recovery(&conn, &resolver, &fixed_clock(5000)).unwrap();
+
+        assert_eq!(report.cancelled, vec!["op-1".to_owned()]);
+        let loaded = get_operation(&conn, "op-1").unwrap().unwrap();
+        assert_eq!(loaded.state, OperationState::Cancelled);
+    }
+
+    #[test]
+    fn recovery_prepared_changed_db_is_pending_and_dirty() {
+        let (_dir, conn) = fresh_db();
+        let op = make_operation(
+            "op-1",
+            "lib-1",
+            OperationState::Prepared,
+            Some("digest-aaa"),
+            Some(0),
+        );
+        upsert_operation(&conn, &op).unwrap();
+        upsert_repository_state(&conn, &make_repo_state("lib-1", 0)).unwrap();
+
+        let resolver = MapDigestResolver::new(
+            [("lib-1".to_owned(), "digest-bbb".to_owned())]
+                .into_iter()
+                .collect(),
+        );
+        let report = run_recovery(&conn, &resolver, &fixed_clock(5000)).unwrap();
+
+        assert_eq!(report.transitioned_to_pending, vec!["op-1".to_owned()]);
+        let loaded = get_operation(&conn, "op-1").unwrap().unwrap();
+        assert_eq!(loaded.state, OperationState::Pending);
+
+        let repo = get_repository_state(&conn, "lib-1").unwrap().unwrap();
+        assert_eq!(repo.local_state, LocalState::Dirty);
+    }
+
+    #[test]
+    fn recovery_prepared_generation_mismatch_is_conflicted() {
+        let (_dir, conn) = fresh_db();
+        let op = make_operation(
+            "op-1",
+            "lib-1",
+            OperationState::Prepared,
+            Some("digest-aaa"),
+            Some(2),
+        );
+        upsert_operation(&conn, &op).unwrap();
+        // committed_generation advanced to 3 independently
+        upsert_repository_state(&conn, &make_repo_state("lib-1", 3)).unwrap();
+
+        let resolver = MapDigestResolver::new(
+            [("lib-1".to_owned(), "digest-bbb".to_owned())]
+                .into_iter()
+                .collect(),
+        );
+        let report = run_recovery(&conn, &resolver, &fixed_clock(5000)).unwrap();
+
+        assert_eq!(report.conflicted, vec!["op-1".to_owned()]);
+        let loaded = get_operation(&conn, "op-1").unwrap().unwrap();
+        assert_eq!(loaded.state, OperationState::Conflicted);
+    }
+
+    // --- Idempotency: re-running recovery does not create duplicates ---
+
+    #[test]
+    fn recovery_is_idempotent() {
+        let (_dir, conn) = fresh_db();
+        let op = make_operation("op-1", "lib-1", OperationState::Running, None, None);
+        upsert_operation(&conn, &op).unwrap();
+
+        let report1 = run_recovery(&conn, &NullDigestResolver, &fixed_clock(5000)).unwrap();
+        assert_eq!(report1.transitioned_to_retry_wait, vec!["op-1".to_owned()]);
+
+        // Second run: op-1 is now retry_wait, not in the in-flight set.
+        let report2 = run_recovery(&conn, &NullDigestResolver, &fixed_clock(6000)).unwrap();
+        assert!(report2.transitioned_to_retry_wait.is_empty());
+
+        // Still exactly one row.
+        let all = control_db::list_operations(&conn).unwrap();
+        assert_eq!(all.len(), 1);
+    }
+
+    // --- Per-library commit serialization ---
+
+    #[test]
+    fn commit_lock_serializes_same_library() {
+        use std::sync::{Arc, Mutex};
+        use std::thread;
+
+        let lock: Arc<Mutex<()>> = Arc::new(Mutex::new(()));
+        let mut locks: std::collections::HashMap<String, Arc<Mutex<()>>> =
+            std::collections::HashMap::new();
+        locks.insert("lib-1".to_owned(), Arc::clone(&lock));
+
+        // Hold the lock from the main thread.
+        let guard = lock.lock().unwrap();
+        let lock_clone = Arc::clone(&lock);
+        let handle = thread::spawn(move || {
+            // This blocks until the main thread drops its guard.
+            let _g = lock_clone.lock().unwrap();
+            true
+        });
+
+        // The thread cannot have finished yet because we still hold the lock.
+        // Use a short sleep + is_finished check rather than a timed join.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        assert!(
+            !handle.is_finished(),
+            "concurrent acquire for the same library must block"
+        );
+
+        drop(guard);
+        assert!(handle.join().expect("thread should complete after unlock"));
+    }
+
+    #[test]
+    fn commit_lock_different_libraries_proceed_concurrently() {
+        use std::sync::{Arc, Mutex};
+
+        let mut locks: std::collections::HashMap<String, Arc<Mutex<()>>> =
+            std::collections::HashMap::new();
+        locks.insert("lib-1".to_owned(), Arc::new(Mutex::new(())));
+        locks.insert("lib-2".to_owned(), Arc::new(Mutex::new(())));
+
+        // Holding lib-1's lock must not block lib-2's lock.
+        let _guard1 = acquire_commit_lock(&locks, "lib-1").unwrap();
+        let guard2 = acquire_commit_lock(&locks, "lib-2");
+        assert!(guard2.is_some());
+        // guard2 acquired while guard1 held — different libraries proceed.
+    }
+
+    // --- Placeholder tests for PR#4/#5 ---
+
+    // TODO(PR#5): incomplete transfers resume from verified offsets.
+    #[test]
+    #[ignore = "PR#5: resumable uploads/downloads from verified offsets"]
+    fn recovery_resumes_incomplete_transfers_from_offsets() {
+        // PR#5 will implement resume-from-offset using remote_transfer_parts.
+    }
+
+    // TODO(PR#4): an accepted remote commit is detected even when the process
+    // died before recording success.
+    #[test]
+    #[ignore = "PR#4: detect accepted remote commit after process death"]
+    fn recovery_detects_accepted_commit_after_death() {
+        // PR#4 will verify the remote manifest generation to detect commits
+        // that succeeded remotely but were not recorded locally.
+    }
+}

--- a/src-tauri/src/remote/sync/upload_status.rs
+++ b/src-tauri/src/remote/sync/upload_status.rs
@@ -267,6 +267,16 @@ pub fn get_all_upload_statuses(state: &AppState) -> CommandResult<Vec<UploadStat
     let snapshots: Vec<UploadStatusSnapshot> = operations
         .iter()
         .filter(|op| op.operation_kind == OperationKind::Publish)
+        // Skip batch outbox entries that have no song_ids — these are
+        // internal recovery bookkeeping (e.g. prepare_and_mutate records
+        // a placeholder before song_ids are known). Surfacing them as
+        // user-visible uploads would show a phantom "Running" entry that
+        // never completes.
+        .filter(|op| {
+            OperationPayload::from_json(&op.payload_json)
+                .map(|p| !p.song_ids.is_empty())
+                .unwrap_or(false)
+        })
         .map(operation_to_snapshot)
         .collect();
 
@@ -406,5 +416,53 @@ mod tests {
         let conn = state.remote.control_db.lock().unwrap();
         let ops = list_operations(&conn).unwrap();
         assert!(ops.is_empty());
+    }
+
+    #[test]
+    fn get_all_upload_statuses_filters_batch_rows_with_empty_song_ids() {
+        let (state, _dir) = test_state_with_control_db();
+
+        // Insert a batch outbox entry with empty song_ids (as produced by
+        // prepare_and_mutate before song_ids are known).
+        let now = control_db_now_ms();
+        upsert_operation(
+            &state.remote.control_db.lock().unwrap(),
+            &OperationRow {
+                operation_id: "publish-batch-123".to_owned(),
+                library_id: "lib-1".to_owned(),
+                operation_kind: OperationKind::Publish,
+                state: OperationState::Pending,
+                expected_generation: None,
+                target_generation: None,
+                source_db_digest: None,
+                candidate_db_digest: None,
+                payload_json: r#"{"song_ids":[],"percent":0}"#.to_owned(),
+                attempt_count: 0,
+                next_attempt_at_ms: None,
+                error_code: None,
+                error_detail: None,
+                created_at_ms: now,
+                updated_at_ms: now,
+            },
+        )
+        .unwrap();
+
+        // Insert a real per-song upload row.
+        mark_upload_status(
+            &state,
+            "song-1",
+            Some("lib-1".to_owned()),
+            UploadState::Running,
+            50,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let statuses = get_all_upload_statuses(&state).unwrap();
+        // Only the per-song row should appear; the batch placeholder is
+        // filtered out.
+        assert_eq!(statuses.len(), 1);
+        assert_eq!(statuses[0].song_id, "song-1");
     }
 }

--- a/src-tauri/src/remote/sync/upload_status.rs
+++ b/src-tauri/src/remote/sync/upload_status.rs
@@ -1,5 +1,9 @@
 use crate::{
     commands::error::{state_lock_error, CommandError, CommandResult},
+    remote::control_db::{
+        get_operation, list_operations, upsert_operation, OperationKind, OperationPayload,
+        OperationRow, OperationState,
+    },
     AppState,
 };
 use tauri::{AppHandle, Emitter};
@@ -9,6 +13,97 @@ use super::super::types::{
     UploadStatusSnapshot,
 };
 
+/// Derive the durable operation state from the in-memory `UploadState`.
+///
+/// The in-memory `UploadState` enum is the IPC-facing projection (Idle /
+/// Running / Completed / Failed). The durable `OperationState` is richer and
+/// tracks the full outbox lifecycle. This mapping records the projection back
+/// into the durable row.
+fn upload_state_to_operation_state(upload_state: UploadState) -> OperationState {
+    match upload_state {
+        UploadState::Idle => OperationState::Pending,
+        UploadState::Running => OperationState::Running,
+        UploadState::Completed => OperationState::Completed,
+        UploadState::Failed => OperationState::Failed,
+    }
+}
+
+/// Derive the in-memory `UploadState` from a durable `OperationState`.
+fn operation_state_to_upload_state(op_state: OperationState) -> UploadState {
+    match op_state {
+        OperationState::Prepared | OperationState::Pending | OperationState::RetryWait => {
+            UploadState::Running
+        }
+        OperationState::Running | OperationState::Committing | OperationState::Verifying => {
+            UploadState::Running
+        }
+        OperationState::Completed => UploadState::Completed,
+        OperationState::Failed => UploadState::Failed,
+        OperationState::Conflicted | OperationState::Cancelled => UploadState::Failed,
+    }
+}
+
+/// Derive the percent value from a durable operation row's payload.
+fn percent_from_operation(op: &OperationRow) -> u8 {
+    match op.state {
+        OperationState::Completed => 100,
+        OperationState::Failed | OperationState::Conflicted | OperationState::Cancelled => 0,
+        _ => OperationPayload::from_json(&op.payload_json)
+            .map(|p| p.percent)
+            .unwrap_or(0),
+    }
+}
+
+/// Derive the detail string from a durable operation row.
+fn detail_from_operation(op: &OperationRow) -> Option<String> {
+    if let Ok(payload) = OperationPayload::from_json(&op.payload_json) {
+        payload.detail
+    } else {
+        None
+    }
+}
+
+/// Derive the error from a durable operation row's `error_code`/`error_detail`.
+fn error_from_operation(op: &OperationRow) -> Option<CommandError> {
+    op.error_code.as_deref().map(|code| {
+        CommandError::from(crate::library::error::LibraryError::Internal(
+            op.error_detail.clone().unwrap_or_else(|| code.to_owned()),
+        ))
+    })
+}
+
+/// Map a `remote_operations` row to an `UploadStatusSnapshot`.
+///
+/// For publish operations, `payload_json` carries the song_ids and percent.
+/// The first song_id in the payload is used as the snapshot's `song_id` so
+/// each song in a multi-song publish gets its own row when listed. When the
+/// payload has no song_ids, the operation_id is used as a fallback key.
+pub(crate) fn operation_to_snapshot(op: &OperationRow) -> UploadStatusSnapshot {
+    let payload = OperationPayload::from_json(&op.payload_json).ok();
+    let song_id = payload
+        .as_ref()
+        .and_then(|p| p.song_ids.first().cloned())
+        .unwrap_or_else(|| op.operation_id.clone());
+    UploadStatusSnapshot {
+        song_id,
+        state: operation_state_to_upload_state(op.state),
+        percent: percent_from_operation(op),
+        remote_library_id: Some(op.library_id.clone()),
+        detail: detail_from_operation(op),
+        error: error_from_operation(op),
+    }
+}
+
+/// Record or update an upload status.
+///
+/// This persists the operation to the durable `remote_operations` table (the
+/// source of truth) AND updates the in-memory projection (used for event
+/// delivery so we don't re-emit events for unchanged state).
+///
+/// The `payload_json` shape is:
+/// ```json
+/// {"song_ids": ["hash-a"], "percent": 42, "detail": "Uploading stems"}
+/// ```
 pub(crate) fn mark_upload_status(
     state: &AppState,
     song_id: &str,
@@ -22,11 +117,67 @@ pub(crate) fn mark_upload_status(
         song_id: song_id.to_owned(),
         state: upload_state,
         percent,
-        remote_library_id,
-        detail,
-        error,
+        remote_library_id: remote_library_id.clone(),
+        detail: detail.clone(),
+        error: error.clone(),
     };
 
+    // Persist to the durable control DB. The operation_id is derived from the
+    // song_id so repeated status updates for the same song update the same row
+    // rather than creating duplicates.
+    if let Some(ref library_id) = remote_library_id {
+        let operation_id = publish_operation_id(song_id);
+        let now = control_db_now_ms();
+
+        // Try to load the existing row to preserve created_at_ms and
+        // attempt_count across updates.
+        let existing = {
+            let conn = state
+                .remote
+                .control_db
+                .lock()
+                .map_err(|_| state_lock_error("control DB lock was poisoned"))?;
+            get_operation(&conn, &operation_id)?
+        };
+
+        let payload = OperationPayload {
+            song_ids: vec![song_id.to_owned()],
+            percent,
+            detail: detail.clone(),
+        };
+
+        let op_state = upload_state_to_operation_state(snapshot.state.clone());
+        let (error_code, error_detail) = sanitize_error(error.as_ref());
+
+        let row = OperationRow {
+            operation_id: operation_id.clone(),
+            library_id: library_id.clone(),
+            operation_kind: OperationKind::Publish,
+            state: op_state,
+            expected_generation: existing.as_ref().and_then(|e| e.expected_generation),
+            target_generation: existing.as_ref().and_then(|e| e.target_generation),
+            source_db_digest: existing.as_ref().and_then(|e| e.source_db_digest.clone()),
+            candidate_db_digest: existing
+                .as_ref()
+                .and_then(|e| e.candidate_db_digest.clone()),
+            payload_json: payload.to_json()?,
+            attempt_count: existing.as_ref().map(|e| e.attempt_count).unwrap_or(0),
+            next_attempt_at_ms: existing.as_ref().and_then(|e| e.next_attempt_at_ms),
+            error_code,
+            error_detail,
+            created_at_ms: existing.as_ref().map(|e| e.created_at_ms).unwrap_or(now),
+            updated_at_ms: now,
+        };
+
+        let conn = state
+            .remote
+            .control_db
+            .lock()
+            .map_err(|_| state_lock_error("control DB lock was poisoned"))?;
+        upsert_operation(&conn, &row)?;
+    }
+
+    // Update the in-memory projection.
     let mut guard = state
         .remote
         .remote_upload_statuses
@@ -34,6 +185,33 @@ pub(crate) fn mark_upload_status(
         .map_err(|_| state_lock_error("remote upload status lock was poisoned"))?;
     guard.insert(song_id.to_owned(), snapshot.clone());
     Ok(snapshot)
+}
+
+/// Derive a stable operation_id for a publish operation from the song_id.
+/// This ensures repeated `mark_upload_status` calls for the same song update
+/// the same durable row.
+pub(crate) fn publish_operation_id(song_id: &str) -> String {
+    format!("publish-{song_id}")
+}
+
+/// Current time in milliseconds. Centralized so tests could inject a clock
+/// in the future.
+fn control_db_now_ms() -> i64 {
+    crate::remote::types::current_unix_time_ms()
+}
+
+/// Sanitize an error into machine-readable code + detail strings for durable
+/// storage. Never persists OAuth tokens, passwords, or raw provider responses.
+fn sanitize_error(error: Option<&CommandError>) -> (Option<String>, Option<String>) {
+    match error {
+        Some(err) => {
+            let code = format!("{:?}", err.code);
+            // The error message is already sanitized by the command error
+            // layer (static user-facing messages). We store it as the detail.
+            (Some(code), Some(err.message.clone()))
+        }
+        None => (None, None),
+    }
 }
 
 pub(crate) fn emit_upload_progress<R: tauri::Runtime>(
@@ -73,11 +251,160 @@ pub(crate) fn emit_upload_error<R: tauri::Runtime>(
     let _ = app_handle.emit("upload-error", payload);
 }
 
+/// Read all upload statuses from the durable `remote_operations` table.
+///
+/// The durable table is the source of truth. The in-memory `HashMap` is only a
+/// projection for event delivery, so after a restart this command still
+/// returns meaningful statuses.
 pub fn get_all_upload_statuses(state: &AppState) -> CommandResult<Vec<UploadStatusSnapshot>> {
-    let guard = state
+    let conn = state
+        .remote
+        .control_db
+        .lock()
+        .map_err(|_| state_lock_error("control DB lock was poisoned"))?;
+
+    let operations = list_operations(&conn)?;
+    let snapshots: Vec<UploadStatusSnapshot> = operations
+        .iter()
+        .filter(|op| op.operation_kind == OperationKind::Publish)
+        .map(operation_to_snapshot)
+        .collect();
+
+    // Sync the in-memory projection so subsequent event delivery has a
+    // baseline to diff against.
+    let mut guard = state
         .remote
         .remote_upload_statuses
         .lock()
         .map_err(|_| state_lock_error("remote upload status lock was poisoned"))?;
-    Ok(guard.values().cloned().collect())
+    for snapshot in &snapshots {
+        guard.insert(snapshot.song_id.clone(), snapshot.clone());
+    }
+
+    Ok(snapshots)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::remote::control_db::{
+        get_operation, open_control_db, upsert_operation, OperationKind, OperationRow,
+        OperationState,
+    };
+    use std::sync::{Arc, Mutex};
+    use tempfile::TempDir;
+
+    fn test_state_with_control_db() -> (AppState, TempDir) {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("remote-state.db");
+        let conn = open_control_db(&path).expect("open control DB");
+
+        let mut state = AppState::test_fixture();
+        state.remote.control_db = Arc::new(Mutex::new(conn));
+        (state, dir)
+    }
+
+    #[test]
+    fn mark_upload_status_persists_to_control_db() {
+        let (state, _dir) = test_state_with_control_db();
+
+        mark_upload_status(
+            &state,
+            "song-1",
+            Some("lib-1".to_owned()),
+            UploadState::Running,
+            42,
+            Some("Uploading".to_owned()),
+            None,
+        )
+        .unwrap();
+
+        let conn = state.remote.control_db.lock().unwrap();
+        let op = get_operation(&conn, "publish-song-1").unwrap().unwrap();
+        assert_eq!(op.operation_kind, OperationKind::Publish);
+        assert_eq!(op.state, OperationState::Running);
+        let payload = OperationPayload::from_json(&op.payload_json).unwrap();
+        assert_eq!(payload.song_ids, vec!["song-1".to_owned()]);
+        assert_eq!(payload.percent, 42);
+    }
+
+    #[test]
+    fn get_all_upload_statuses_reads_from_control_db() {
+        let (state, _dir) = test_state_with_control_db();
+
+        mark_upload_status(
+            &state,
+            "song-1",
+            Some("lib-1".to_owned()),
+            UploadState::Completed,
+            100,
+            None,
+            None,
+        )
+        .unwrap();
+
+        // Simulate restart: clear the in-memory projection.
+        state.remote.remote_upload_statuses.lock().unwrap().clear();
+
+        let statuses = get_all_upload_statuses(&state).unwrap();
+        assert_eq!(statuses.len(), 1);
+        assert_eq!(statuses[0].song_id, "song-1");
+        assert_eq!(statuses[0].state, UploadState::Completed);
+        assert_eq!(statuses[0].percent, 100);
+    }
+
+    #[test]
+    fn get_all_upload_statuses_returns_rows_after_close_and_reopen() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("remote-state.db");
+
+        // Write a row using one connection (simulates a prior session).
+        {
+            let conn = open_control_db(&path).unwrap();
+            upsert_operation(
+                &conn,
+                &OperationRow {
+                    operation_id: "publish-song-x".to_owned(),
+                    library_id: "lib-1".to_owned(),
+                    operation_kind: OperationKind::Publish,
+                    state: OperationState::Failed,
+                    expected_generation: None,
+                    target_generation: None,
+                    source_db_digest: None,
+                    candidate_db_digest: None,
+                    payload_json: r#"{"song_ids":["song-x"],"percent":0}"#.to_owned(),
+                    attempt_count: 1,
+                    next_attempt_at_ms: None,
+                    error_code: Some("Internal".to_owned()),
+                    error_detail: Some("network error".to_owned()),
+                    created_at_ms: 1000,
+                    updated_at_ms: 2000,
+                },
+            )
+            .unwrap();
+        }
+
+        // Reopen (simulates restart) and read.
+        let conn = open_control_db(&path).unwrap();
+        let mut state = AppState::test_fixture();
+        state.remote.control_db = Arc::new(Mutex::new(conn));
+
+        let statuses = get_all_upload_statuses(&state).unwrap();
+        assert_eq!(statuses.len(), 1);
+        assert_eq!(statuses[0].song_id, "song-x");
+        assert_eq!(statuses[0].state, UploadState::Failed);
+        assert!(statuses[0].error.is_some());
+    }
+
+    #[test]
+    fn mark_upload_status_without_library_does_not_persist() {
+        let (state, _dir) = test_state_with_control_db();
+
+        // No remote_library_id — should not create a durable row.
+        mark_upload_status(&state, "song-1", None, UploadState::Running, 0, None, None).unwrap();
+
+        let conn = state.remote.control_db.lock().unwrap();
+        let ops = list_operations(&conn).unwrap();
+        assert!(ops.is_empty());
+    }
 }

--- a/src-tauri/src/state/remote.rs
+++ b/src-tauri/src/state/remote.rs
@@ -1,15 +1,32 @@
 use crate::audio::chunked_cache::CacheManager;
+use crate::remote::control_db;
 use crate::remote::{RemoteAuthSession, UploadStatusSnapshot};
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
+/// Per-library commit serialization locks.
+///
+/// Two concurrent commit attempts for the same library block each other;
+/// independent asset downloads for different libraries proceed in parallel.
+/// PR#5 will use this to coordinate resumable transfers.
+pub type CommitLockMap = Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>;
+
 #[derive(Clone)]
 pub struct RemoteState {
     pub remote_auth_sessions: Arc<Mutex<HashMap<String, RemoteAuthSession>>>,
+    /// In-memory projection of upload statuses for event delivery. The durable
+    /// source of truth is the `remote_operations` table in the control DB; this
+    /// map is kept only so we avoid re-emitting events for unchanged state.
     pub remote_upload_statuses: Arc<Mutex<HashMap<String, UploadStatusSnapshot>>>,
     /// LRU-managed on-disk caches for remote streaming playback.
     pub remote_chunk_cache: Arc<Mutex<CacheManager>>,
+    /// Durable control-plane database handle (`remote-state.db`). Holds the
+    /// authoritative local record of remote operation/outbox state, repository
+    /// cleanliness, and resumable transfer offsets. Never uploaded.
+    pub control_db: Arc<Mutex<rusqlite::Connection>>,
+    /// Per-library commit locks. See `CommitLockMap`.
+    pub commit_locks: CommitLockMap,
 }
 
 impl RemoteState {
@@ -20,10 +37,30 @@ impl RemoteState {
         // Eviction logic uses saturating arithmetic so this is safe.
         let max_bytes = remote_cache_bytes_limit.unwrap_or(u64::MAX);
 
+        // Open the durable control DB. This stays outside every portable
+        // library and is never uploaded. WAL mode is enabled on open so
+        // concurrent readers (upload-status queries) do not block the writer.
+        let control_db_path = control_db::control_db_path(app_data_dir);
+        let control_db_conn =
+            control_db::open_control_db(&control_db_path).unwrap_or_else(|error| {
+                eprintln!(
+                    "warning: failed to open remote control DB at {}: {:?}",
+                    control_db_path.display(),
+                    error
+                );
+                // Fall back to an in-memory connection so the app can still
+                // start; operation state will not persist across restarts in
+                // this degraded mode.
+                rusqlite::Connection::open_in_memory()
+                    .expect("in-memory control DB fallback should always open")
+            });
+
         Self {
             remote_auth_sessions: Arc::new(Mutex::new(HashMap::new())),
             remote_upload_statuses: Arc::new(Mutex::new(HashMap::new())),
             remote_chunk_cache: Arc::new(Mutex::new(CacheManager::new(cache_dir, max_bytes))),
+            control_db: Arc::new(Mutex::new(control_db_conn)),
+            commit_locks: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -33,5 +70,23 @@ impl RemoteState {
 
     pub fn test_fixture() -> Self {
         Self::new(Path::new("/tmp/openkara-test-remote-cache"))
+    }
+
+    /// Resolve the per-library commit lock, creating it on first use. The
+    /// caller should call `.lock()` on the returned `Arc` to serialize
+    /// concurrent commit attempts for the same library. Different libraries
+    /// proceed concurrently.
+    ///
+    /// The lock is kept in the `commit_locks` map for the lifetime of
+    /// `RemoteState`, so the `Arc` is not leaked — it is also held by the map.
+    pub fn commit_lock(&self, library_id: &str) -> Arc<Mutex<()>> {
+        let mut locks = self
+            .commit_locks
+            .lock()
+            .expect("commit lock map was poisoned");
+        locks
+            .entry(library_id.to_owned())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
     }
 }

--- a/src-tauri/src/state/remote.rs
+++ b/src-tauri/src/state/remote.rs
@@ -50,9 +50,14 @@ impl RemoteState {
                 );
                 // Fall back to an in-memory connection so the app can still
                 // start; operation state will not persist across restarts in
-                // this degraded mode.
-                rusqlite::Connection::open_in_memory()
-                    .expect("in-memory control DB fallback should always open")
+                // this degraded mode. Apply migrations so the recovery and
+                // upload-status paths can query remote_operations etc.
+                // without hitting "no such table" errors.
+                let conn = rusqlite::Connection::open_in_memory()
+                    .expect("in-memory control DB fallback should always open");
+                control_db::apply_migrations(&conn)
+                    .expect("in-memory control DB migrations should always succeed");
+                conn
             });
 
         Self {


### PR DESCRIPTION
## Summary
- Durable `remote-state.db` control plane with operation state machine and startup recovery.
- Replaces in-memory upload status map with a SQLite-backed operation log.
- Schema: `remote_operations`, `remote_transfer_parts`, `remote_cache_entries` tables.

#### Test plan
- [x] `cargo test -q`
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`

Part 2/8 of issue #151. Stacked on #157.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thedavidweng/openkara/pull/158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->