### PR TITLE
feat(remote): persistent verified cache catalog with bounded eviction (#151)

### DIFF
--- a/docs/references/contracts/settings.md
+++ b/docs/references/contracts/settings.md
@@ -81,3 +81,29 @@ stays explicitly dark regardless of the primary preference.
 - `set_crossfade_enabled(enabled: bool) -> AppSettings`
 - `set_crossfade_duration_ms(duration_ms: u32) -> AppSettings`
 - `restart_app() -> ()`
+
+## Remote streaming cache
+
+The remote streaming cache stores byte-range downloads of remote media files
+so playback can resume without re-fetching. The cache is content-addressed by
+the SHA-256 of `(library_id, relative_path, provider_revision,
+expected_size)`, so a replaced remote object (new revision or size) does not
+reuse bytes from an older version. The durable catalog lives in the local-only
+`remote_cache_entries` table (`remote-state.db`); on-disk data files live in
+`<app-data>/remote-cache/`.
+
+When `remote_cache_bytes_limit` is unset, the cache defaults to a finite 2 GiB
+budget. The configured limit is read at startup from `AppConfig`.
+
+### Commands
+
+- `get_remote_cache_usage() -> CacheUsage` — Report cache usage.
+  - `used_bytes`: total bytes used by reconciled catalog entries.
+  - `limit_bytes`: the configured byte budget (2 GiB default).
+  - `entry_count`: number of catalog entries.
+  - `pinned_count`: number of entries currently pinned by active playback
+    (exempt from eviction).
+- `clear_remote_cache() -> usize` — Evict all unpinned cache entries. Pinned
+  entries (files in active use by playback) remain until playback releases
+  them, then a subsequent clear or LRU eviction removes them. Returns the
+  number of entries evicted.

--- a/src-tauri/src/audio/chunked_cache.rs
+++ b/src-tauri/src/audio/chunked_cache.rs
@@ -63,6 +63,15 @@ impl ChunkedCache {
             .truncate(false)
             .open(&data_path)?;
 
+        // Pre-allocate the file to the expected size so that partial downloads
+        // (where only some ranges have been written) still report the correct
+        // file length. Without this, a file with ranges [0,50) and [100,50)
+        // would be 150 bytes, not `file_size`, and the persistent catalog's
+        // startup reconciliation would discard it as a size mismatch.
+        if file.metadata()?.len() < file_size {
+            file.set_len(file_size)?;
+        }
+
         let downloaded = if index_path.exists() {
             let json = fs::read_to_string(&index_path)?;
             serde_json::from_str(&json).unwrap_or_else(|_| RangeSet::new())
@@ -75,6 +84,43 @@ impl ChunkedCache {
             inner: Mutex::new(CacheInner {
                 file,
                 downloaded,
+                file_size,
+                last_access: Instant::now(),
+            }),
+            data_available: Condvar::new(),
+        })
+    }
+
+    /// Open a cache file and initialize the downloaded range set from the
+    /// persistent catalog instead of the `.index` sidecar. Used by the
+    /// persistent cache catalog (PR#6) so ranges survive restart even when
+    /// the `.index` sidecar was deleted on completion.
+    pub fn open_with_ranges(
+        cache_dir: &Path,
+        cache_key: &str,
+        file_size: u64,
+        ranges: RangeSet,
+    ) -> Result<Self, CacheError> {
+        let data_path = cache_dir.join(format!("{cache_key}.cache"));
+
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&data_path)?;
+
+        // Pre-allocate to `file_size` so partial entries report the correct
+        // length during startup reconciliation.
+        if file.metadata()?.len() < file_size {
+            file.set_len(file_size)?;
+        }
+
+        Ok(Self {
+            path: data_path,
+            inner: Mutex::new(CacheInner {
+                file,
+                downloaded: ranges,
                 file_size,
                 last_access: Instant::now(),
             }),
@@ -496,7 +542,9 @@ mod tests {
         let c2 = mgr.get_or_create("b", 2000).unwrap();
         c2.write_at(0, &[0u8; 200]).unwrap();
 
-        assert_eq!(mgr.total_bytes(), 300);
+        // Files are pre-allocated to their declared size so partial downloads
+        // report the correct length for the persistent catalog reconciliation.
+        assert_eq!(mgr.total_bytes(), 3000);
 
         cleanup(&dir);
     }
@@ -540,14 +588,17 @@ mod tests {
         let dir = temp_dir("data_bytes");
         let cache = ChunkedCache::open(&dir, "db1", 500).unwrap();
 
-        assert_eq!(cache.data_bytes(), 0);
+        // File is pre-allocated to the declared size so partial downloads
+        // report the correct length for the persistent catalog reconciliation.
+        assert_eq!(cache.data_bytes(), 500);
 
         cache.write_at(0, &[0u8; 100]).unwrap();
-        assert_eq!(cache.data_bytes(), 100);
+        assert_eq!(cache.data_bytes(), 500);
 
-        // Non-contiguous write extends the file.
+        // Non-contiguous write does not extend the file past the pre-allocated
+        // size.
         cache.write_at(300, &[0u8; 50]).unwrap();
-        assert_eq!(cache.data_bytes(), 350);
+        assert_eq!(cache.data_bytes(), 500);
 
         cleanup(&dir);
     }

--- a/src-tauri/src/audio/remote_source.rs
+++ b/src-tauri/src/audio/remote_source.rs
@@ -594,15 +594,20 @@ pub fn spawn_fetch_thread(
         cache,
         Box::new(ReqwestFetcher { client }),
         RetryConfig::default(),
+        None,
     )
 }
 
 /// Spawn a fetch thread with a custom `HttpFetcher` and `RetryConfig` (for testing).
+/// `on_range_written` is called after each successful range write so the
+/// caller can persist download progress to the cache catalog. Pass `None`
+/// when persistence is not needed (e.g. tests).
 pub fn spawn_fetch_thread_with_fetcher(
     url: String,
     cache: Arc<ChunkedCache>,
     fetcher: Box<dyn HttpFetcher>,
     retry_config: RetryConfig,
+    on_range_written: Option<Arc<dyn Fn() + Send + Sync>>,
 ) -> (
     mpsc::Sender<FetchCommand>,
     mpsc::Receiver<FetchEvent>,
@@ -625,6 +630,7 @@ pub fn spawn_fetch_thread_with_fetcher(
             &event_tx,
             &retry_config,
             &monitor_clone,
+            on_range_written.as_ref(),
         );
     });
 
@@ -682,6 +688,7 @@ fn fetch_loop(
     event_tx: &mpsc::Sender<FetchEvent>,
     retry_config: &RetryConfig,
     monitor: &BandwidthMonitor,
+    on_range_written: Option<&Arc<dyn Fn() + Send + Sync>>,
 ) {
     let current_url = url.to_string();
     let mut consecutive_failures: u32 = 0;
@@ -710,6 +717,9 @@ fn fetch_loop(
             match outcome {
                 FetchOutcome::Ok => {
                     *consecutive_failures = 0;
+                    if let Some(cb) = on_range_written {
+                        cb();
+                    }
                 }
                 FetchOutcome::UrlExpired => {
                     let _ = event_tx.send(FetchEvent::UrlExpired);
@@ -742,6 +752,9 @@ fn fetch_loop(
                 match outcome {
                     FetchOutcome::Ok => {
                         consecutive_failures = 0;
+                        if let Some(cb) = on_range_written {
+                            cb();
+                        }
                     }
                     FetchOutcome::UrlExpired => {
                         let _ = event_tx.send(FetchEvent::UrlExpired);
@@ -1107,6 +1120,7 @@ mod tests {
                 max_retries: 3,
                 consecutive_failure_threshold: 5,
             },
+            None,
         );
 
         // Send fetch command and wait for it to complete.
@@ -1149,6 +1163,7 @@ mod tests {
                 max_retries: 0,
                 consecutive_failure_threshold: 5,
             },
+            None,
         );
 
         tx.send(FetchCommand::Fetch {
@@ -1192,6 +1207,7 @@ mod tests {
                 max_retries: 0,
                 consecutive_failure_threshold: 5,
             },
+            None,
         );
 
         // Send 5 fetch commands.
@@ -1239,6 +1255,7 @@ mod tests {
                 max_retries: 3,
                 consecutive_failure_threshold: 5,
             },
+            None,
         );
 
         tx.send(FetchCommand::Fetch {
@@ -1359,6 +1376,7 @@ mod tests {
                 max_retries: 4,
                 consecutive_failure_threshold: 5,
             },
+            None,
         );
 
         tx.send(FetchCommand::Fetch {
@@ -1433,6 +1451,7 @@ mod tests {
                 max_retries: 0,
                 consecutive_failure_threshold: 5,
             },
+            None,
         );
 
         tx.send(FetchCommand::Fetch {
@@ -1500,6 +1519,7 @@ mod tests {
                 &event_tx,
                 &RetryConfig::default(),
                 &monitor,
+                None,
             );
         });
 

--- a/src-tauri/src/commands/remote_library/mod.rs
+++ b/src-tauri/src/commands/remote_library/mod.rs
@@ -15,6 +15,10 @@ pub use remote::{
     UploadState, UploadStatusSnapshot,
 };
 
+/// Re-export the cache usage snapshot type so the IPC command signature stays
+/// stable even if the internal module path changes.
+pub use remote::cache_catalog::CacheUsage;
+
 #[tauri::command]
 pub fn begin_remote_auth(
     state: State<'_, AppState>,
@@ -151,4 +155,31 @@ pub fn get_all_upload_statuses(
     state: State<'_, AppState>,
 ) -> CommandResult<Vec<UploadStatusSnapshot>> {
     remote::get_all_upload_statuses(&state)
+}
+
+/// Report remote streaming cache usage: total bytes used, the configured byte
+/// limit, the number of catalog entries, and how many are currently pinned
+/// (in use by playback and exempt from eviction).
+#[tauri::command]
+pub fn get_remote_cache_usage(state: State<'_, AppState>) -> CommandResult<CacheUsage> {
+    let manager = state
+        .remote
+        .remote_chunk_cache
+        .lock()
+        .map_err(|_| internal_error("remote chunk cache manager lock was poisoned"))?;
+    manager.usage()
+}
+
+/// Evict all unpinned remote cache entries. Pinned entries (files in active
+/// use by playback) are left in the catalog until playback releases them, at
+/// which point a subsequent clear or LRU eviction removes them. Returns the
+/// number of entries evicted.
+#[tauri::command]
+pub fn clear_remote_cache(state: State<'_, AppState>) -> CommandResult<usize> {
+    let mut manager = state
+        .remote
+        .remote_chunk_cache
+        .lock()
+        .map_err(|_| internal_error("remote chunk cache manager lock was poisoned"))?;
+    manager.clear_unpinned()
 }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -492,8 +492,8 @@ pub struct AppConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub theme_preference: Option<ThemePreference>,
     /// When set, the cache directory is trimmed to stay under this limit,
-    /// deleting the least-recently-used files. When absent the cache grows
-    /// unbounded.
+    /// deleting the least-recently-used files. When absent the cache defaults
+    /// to a finite 2 GiB budget (see `DEFAULT_CACHE_BYTES_LIMIT`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub remote_cache_bytes_limit: Option<u64>,
     /// Crash-recovery marker for mirror operations. `mirror_local_library_to_remote`

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -122,6 +122,8 @@ pub fn run() {
             commands::remote_library::publish_song_to_remote,
             commands::remote_library::publish_songs_to_remote,
             commands::remote_library::get_all_upload_statuses,
+            commands::remote_library::get_remote_cache_usage,
+            commands::remote_library::clear_remote_cache,
             commands::lyrics::fetch_lyrics,
             commands::lyrics::set_lyrics_offset,
             commands::lyrics::save_manual_lyrics,

--- a/src-tauri/src/remote/cache_catalog.rs
+++ b/src-tauri/src/remote/cache_catalog.rs
@@ -1,0 +1,1262 @@
+//! Persistent, verified cache catalog for remote streaming playback.
+//!
+//! The `remote_cache_entries` table in the control DB is the authoritative
+//! catalog. On-disk data files are content-addressed by the SHA-256 of the
+//! identity tuple `(library_id, relative_path, provider_revision,
+//! expected_size)`. This replaces the old `ChunkedCache`-only manager that:
+//!
+//! - deleted the range index on completion (forgetting completion across
+//!   restart),
+//! - counted only entries opened in the current process,
+//! - defaulted to `u64::MAX` (unbounded) when no limit was set, and
+//! - keyed caches by `format!("remote-{}", song.hash)`, which reused bytes
+//!   from an older provider revision when the remote object was replaced.
+//!
+//! ## Startup reconciliation
+//!
+//! On open, the catalog is reconciled against disk: orphaned data files (no
+//! catalog row) are deleted; catalog rows whose data file is missing or whose
+//! length does not match `expected_size` are deleted. Complete entries that
+//! have not been verified since the last process start are re-hashed before
+//! first reuse so an unclean shutdown cannot expose a corrupted file as
+//! verified.
+//!
+//! ## LRU eviction
+//!
+//! Eviction uses the persistent wall-clock `last_access_at_ms` column (not a
+//! process-local `Instant`) so LRU order survives restarts. Only entries with
+//! `pinned_count == 0` are evicted. Eviction removes the catalog row first
+//! (transactional), then deletes the data file; if the file deletion fails the
+//! orphaned file is cleaned on the next startup scan.
+
+use crate::audio::chunked_cache::{CacheError, ChunkedCache};
+use crate::audio::range_set::RangeSet;
+use crate::commands::error::{internal_error, CommandError, CommandResult};
+use crate::hash;
+use crate::remote::atomic_download::sha256_file;
+use crate::remote::control_db::{self, CacheEntryRow};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Default cache budget when `remote_cache_bytes_limit` is `None`. A finite
+/// 2 GiB default prevents unbounded disk growth on a fresh install while
+/// staying large enough that a typical karaoke session does not thrash.
+pub const DEFAULT_CACHE_BYTES_LIMIT: u64 = 2 * 1024 * 1024 * 1024;
+
+/// Identity tuple that uniquely identifies a remote cacheable file. Two files
+/// with the same identity are byte-for-byte interchangeable; a changed
+/// `provider_revision` or `expected_size` yields a different `cache_key`.
+#[derive(Debug, Clone)]
+pub struct CacheIdentity {
+    pub library_id: String,
+    pub relative_path: String,
+    /// Provider revision token (ETag / Dropbox rev / Google Drive
+    /// headRevisionId). When unavailable, the caller may substitute a content
+    /// digest after the first full download.
+    pub provider_revision: Option<String>,
+    pub expected_size: u64,
+}
+
+impl CacheIdentity {
+    /// Compute the stable SHA-256 hex digest of the identity tuple. This is
+    /// used as both the `cache_key` primary key and the on-disk filename.
+    pub fn cache_key(&self) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(b"library_id=");
+        hasher.update(self.library_id.as_bytes());
+        hasher.update(b"\nrelative_path=");
+        hasher.update(self.relative_path.as_bytes());
+        hasher.update(b"\nprovider_revision=");
+        if let Some(rev) = &self.provider_revision {
+            hasher.update(rev.as_bytes());
+        }
+        hasher.update(b"\nexpected_size=");
+        hasher.update(self.expected_size.to_le_bytes());
+        hash::hex_lower(hasher.finalize())
+    }
+}
+
+/// Snapshot of cache usage returned by `get_remote_cache_usage`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CacheUsage {
+    pub used_bytes: u64,
+    pub limit_bytes: u64,
+    pub entry_count: usize,
+    pub pinned_count: usize,
+}
+
+/// A pinned cache guard. Dropping it decrements the pin count so the entry
+/// becomes eligible for eviction again. RAII ensures unpin always happens,
+/// even if the playback thread panics.
+pub struct CachePinGuard {
+    cache_key: String,
+    manager: Arc<Mutex<CacheCatalog>>,
+}
+
+impl Drop for CachePinGuard {
+    fn drop(&mut self) {
+        if let Ok(mut manager) = self.manager.lock() {
+            let _ = manager.unpin(&self.cache_key);
+        }
+    }
+}
+
+/// Persistent, verified cache catalog backed by `remote_cache_entries`.
+///
+/// The catalog is the source of truth; on-disk data files are
+/// content-addressed by the `cache_key` digest. The in-memory `ChunkedCache`
+/// handles are opened lazily and cached for the lifetime of the process, but
+/// all durable state (ranges, completion, LRU timestamp, pin count) lives in
+/// the control DB so it survives restarts.
+pub struct CacheCatalog {
+    cache_dir: PathBuf,
+    control_db: Arc<Mutex<rusqlite::Connection>>,
+    max_bytes: u64,
+    /// In-memory handles keyed by `cache_key`. The handles are purely a
+    /// performance optimization; the catalog row is the durable state.
+    caches: HashMap<String, Arc<ChunkedCache>>,
+}
+
+fn current_unix_time_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}
+
+/// JSON shape for `downloaded_ranges_json`: an array of `[start, length]`
+/// pairs. This is separate from `RangeSet`'s own serde format so the catalog
+/// schema stays stable even if `RangeSet`'s serialization changes.
+#[derive(Serialize, Deserialize)]
+struct RangesJson(Vec<[u64; 2]>);
+
+fn ranges_to_json(ranges: &RangeSet) -> CommandResult<String> {
+    let pairs: Vec<[u64; 2]> = ranges
+        .ranges()
+        .iter()
+        .map(|r| [r.start, r.length])
+        .collect();
+    serde_json::to_string(&RangesJson(pairs))
+        .map_err(|e| internal_error(format!("failed to serialize ranges: {e}")))
+}
+
+fn ranges_from_json(json: &str) -> CommandResult<RangeSet> {
+    let parsed: RangesJson = serde_json::from_str(json).map_err(|e| {
+        internal_error(format!("failed to deserialize downloaded_ranges_json: {e}"))
+    })?;
+    let mut set = RangeSet::new();
+    for [start, length] in parsed.0 {
+        set.add_range(start, length);
+    }
+    Ok(set)
+}
+
+/// Validate that a `downloaded_ranges_json` does not claim ranges beyond the
+/// actual data file length. A corrupted sidecar that claims bytes past the
+/// file end would expose zero-filled sparse gaps as downloaded data, so the
+/// entry is rejected on verification.
+fn ranges_within_file(ranges: &RangeSet, file_len: u64) -> bool {
+    ranges.ranges().iter().all(|r| r.end() <= file_len)
+}
+
+impl CacheCatalog {
+    /// Open the persistent cache catalog. Runs startup reconciliation: orphaned
+    /// data files are deleted, catalog rows with missing/inconsistent data
+    /// files are removed, and usage is recalculated from the reconciled
+    /// catalog. The `control_db` handle is held for the lifetime of the
+    /// manager so range/pin/access updates are durable.
+    pub fn open(
+        cache_dir: PathBuf,
+        control_db: Arc<Mutex<rusqlite::Connection>>,
+        max_bytes: u64,
+    ) -> CommandResult<Self> {
+        fs::create_dir_all(&cache_dir).map_err(|e| {
+            internal_error(format!(
+                "failed to create cache directory {}: {e}",
+                cache_dir.display()
+            ))
+        })?;
+
+        let mut manager = Self {
+            cache_dir,
+            control_db,
+            max_bytes,
+            caches: HashMap::new(),
+        };
+        manager.reconcile_on_startup()?;
+        Ok(manager)
+    }
+
+    /// The configured byte budget. Exposed for the usage IPC command.
+    pub fn limit_bytes(&self) -> u64 {
+        self.max_bytes
+    }
+
+    /// Reconcile the catalog against disk at startup.
+    ///
+    /// 1. For each catalog row: verify the `data_path` file exists and its
+    ///    length matches `expected_size`. Discard rows whose file is missing
+    ///    or whose length mismatches. Complete entries are NOT re-hashed here
+    ///    (that happens lazily on first reuse) to avoid hashing every file at
+    ///    startup.
+    /// 2. Delete orphaned data files in the cache directory that have no
+    ///    catalog row.
+    fn reconcile_on_startup(&mut self) -> CommandResult<()> {
+        let conn = self
+            .control_db
+            .lock()
+            .map_err(|_| internal_error("control DB lock was poisoned during reconciliation"))?;
+
+        let rows = control_db::list_cache_entries(&conn)?;
+
+        // Track the set of valid data filenames so orphaned files can be
+        // detected.
+        let mut known_files: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+        for row in &rows {
+            let data_path = Path::new(&row.data_path);
+            // Resolve the data path relative to the cache dir when it is not
+            // absolute (catalog stores a relative filename for portability
+            // across app-data-dir moves).
+            let absolute = if data_path.is_absolute() {
+                data_path.to_path_buf()
+            } else {
+                self.cache_dir.join(data_path)
+            };
+
+            let file_ok = match fs::metadata(&absolute) {
+                Ok(meta) => meta.len() == row.expected_size as u64,
+                Err(_) => false,
+            };
+
+            if !file_ok {
+                // Catalog row is inconsistent with disk — discard the row.
+                // The data file (if present but wrong size) is left for the
+                // orphan scan below to clean up.
+                let _ = control_db::delete_cache_entry(&conn, &row.cache_key);
+                continue;
+            }
+
+            known_files.insert(row.data_path.clone());
+        }
+
+        // Orphan scan: delete data files in the cache dir with no catalog row.
+        // Only files ending in `.cache` are considered so temp/part files from
+        // other subsystems are not touched.
+        if let Ok(entries) = fs::read_dir(&self.cache_dir) {
+            for entry in entries.flatten() {
+                let name = entry.file_name();
+                let name_str = name.to_string_lossy();
+                if name_str.ends_with(".cache") && !known_files.contains(name_str.as_ref()) {
+                    let _ = fs::remove_file(entry.path());
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Total bytes used by the cache, calculated from the catalog (which has
+    /// been reconciled against disk). This includes entries not yet opened in
+    /// the current process.
+    pub fn total_bytes(&self) -> CommandResult<u64> {
+        let conn = self
+            .control_db
+            .lock()
+            .map_err(|_| internal_error("control DB lock was poisoned"))?;
+        let rows = control_db::list_cache_entries(&conn)?;
+        Ok(rows.iter().map(|r| r.expected_size as u64).sum())
+    }
+
+    /// Number of catalog entries (reconciled).
+    pub fn entry_count(&self) -> CommandResult<usize> {
+        let conn = self
+            .control_db
+            .lock()
+            .map_err(|_| internal_error("control DB lock was poisoned"))?;
+        let rows = control_db::list_cache_entries(&conn)?;
+        Ok(rows.len())
+    }
+
+    /// Number of pinned entries.
+    pub fn pinned_count(&self) -> CommandResult<usize> {
+        let conn = self
+            .control_db
+            .lock()
+            .map_err(|_| internal_error("control DB lock was poisoned"))?;
+        let rows = control_db::list_cache_entries(&conn)?;
+        Ok(rows.iter().filter(|r| r.pinned_count > 0).count())
+    }
+
+    /// Usage snapshot for the IPC command.
+    pub fn usage(&self) -> CommandResult<CacheUsage> {
+        Ok(CacheUsage {
+            used_bytes: self.total_bytes()?,
+            limit_bytes: self.max_bytes,
+            entry_count: self.entry_count()?,
+            pinned_count: self.pinned_count()?,
+        })
+    }
+
+    /// The on-disk data filename for a cache key.
+    fn data_filename(cache_key: &str) -> String {
+        format!("{cache_key}.cache")
+    }
+
+    /// Get or create a `ChunkedCache` for the given identity. On a cache hit,
+    /// the catalog row + data file length are verified before reuse; on
+    /// mismatch the stale entry is discarded and a fresh one is created.
+    ///
+    /// Before returning a complete entry that has not been verified since the
+    /// last process start, the data file is re-hashed and `verified_at_ms` is
+    /// set. This prevents an unclean shutdown from exposing a corrupted file
+    /// as verified.
+    pub fn get_or_create(&mut self, identity: &CacheIdentity) -> CommandResult<Arc<ChunkedCache>> {
+        let cache_key = identity.cache_key();
+
+        // Fast path: an in-memory handle already exists.
+        if let Some(cache) = self.caches.get(&cache_key) {
+            self.touch_access(&cache_key)?;
+            return Ok(Arc::clone(cache));
+        }
+
+        // Verify the catalog row + data file before reuse.
+        let verified = self.verify_entry(&cache_key, identity)?;
+
+        if !verified {
+            // Stale or missing — discard any leftover row/file and recreate.
+            self.discard_entry(&cache_key)?;
+        }
+
+        // Reserve space and evict if needed before creating the new entry.
+        self.evict_if_needed(identity.expected_size)?;
+
+        // Create or open the on-disk file + in-memory handle. When the entry
+        // was verified (catalog hit), initialize the ChunkedCache with the
+        // persisted ranges from the catalog so completion and partial state
+        // survive restart. The `.index` sidecar is no longer the source of
+        // truth for ranges — the catalog is.
+        let cache = if verified {
+            let conn = self
+                .control_db
+                .lock()
+                .map_err(|_| internal_error("control DB lock was poisoned"))?;
+            let row = control_db::get_cache_entry(&conn, &cache_key)?.ok_or_else(|| {
+                internal_error("verified entry disappeared between verify and open")
+            })?;
+            let ranges = ranges_from_json(&row.downloaded_ranges_json)?;
+            ChunkedCache::open_with_ranges(
+                &self.cache_dir,
+                &cache_key,
+                identity.expected_size,
+                ranges,
+            )
+            .map_err(cache_error_to_command)?
+        } else {
+            ChunkedCache::open(&self.cache_dir, &cache_key, identity.expected_size)
+                .map_err(cache_error_to_command)?
+        };
+        let cache = Arc::new(cache);
+
+        // Persist the catalog row (upsert so a verified hit keeps its ranges).
+        if verified {
+            // The entry was verified — just touch the access time.
+            self.touch_access(&cache_key)?;
+        } else {
+            // Fresh entry — insert the catalog row.
+            let now = current_unix_time_ms();
+            let data_filename = Self::data_filename(&cache_key);
+            let row = CacheEntryRow {
+                cache_key: cache_key.clone(),
+                library_id: identity.library_id.clone(),
+                relative_path: identity.relative_path.clone(),
+                provider_revision: identity.provider_revision.clone(),
+                content_digest: None,
+                expected_size: identity.expected_size as i64,
+                downloaded_ranges_json: ranges_to_json(&RangeSet::new())?,
+                complete: false,
+                pinned_count: 0,
+                last_access_at_ms: now,
+                verified_at_ms: None,
+                data_path: data_filename,
+            };
+            let conn = self
+                .control_db
+                .lock()
+                .map_err(|_| internal_error("control DB lock was poisoned"))?;
+            control_db::upsert_cache_entry(&conn, &row)?;
+        }
+
+        self.caches.insert(cache_key.clone(), Arc::clone(&cache));
+        Ok(cache)
+    }
+
+    /// Verify a catalog entry against the identity and disk. Returns `true`
+    /// when the entry is reusable (catalog row exists, data file length
+    /// matches, ranges are within the file). Complete entries that have not
+    /// been verified since process start are re-hashed here.
+    fn verify_entry(&self, cache_key: &str, identity: &CacheIdentity) -> CommandResult<bool> {
+        let conn = self
+            .control_db
+            .lock()
+            .map_err(|_| internal_error("control DB lock was poisoned"))?;
+        let Some(row) = control_db::get_cache_entry(&conn, cache_key)? else {
+            return Ok(false);
+        };
+
+        // Identity mismatch (should not happen since cache_key is derived from
+        // the identity, but defend against a manually-edited catalog).
+        if row.library_id != identity.library_id
+            || row.relative_path != identity.relative_path
+            || row.expected_size != identity.expected_size as i64
+        {
+            return Ok(false);
+        }
+
+        let data_path = self.cache_dir.join(&row.data_path);
+        let file_len = match fs::metadata(&data_path) {
+            Ok(meta) => meta.len(),
+            Err(_) => return Ok(false),
+        };
+
+        if file_len != row.expected_size as u64 {
+            return Ok(false);
+        }
+
+        // Validate persisted ranges against the actual file length so a
+        // corrupted sidecar cannot expose zero-filled sparse gaps as
+        // downloaded data.
+        let ranges = ranges_from_json(&row.downloaded_ranges_json)?;
+        if !ranges_within_file(&ranges, file_len) {
+            return Ok(false);
+        }
+
+        // Complete entries must be re-verified (re-hashed) before first reuse
+        // after an unclean shutdown. `verified_at_ms` is set on successful
+        // verification; a `None` value means "not yet verified this session".
+        if row.complete && row.verified_at_ms.is_none() {
+            if let Some(expected_digest) = &row.content_digest {
+                let actual = sha256_file(&data_path)?;
+                if !actual.eq_ignore_ascii_case(expected_digest) {
+                    return Ok(false);
+                }
+                // Digest matches — mark as verified for this session.
+                control_db::update_cache_entry_ranges(
+                    &conn,
+                    cache_key,
+                    &row.downloaded_ranges_json,
+                    true,
+                    None,
+                    Some(current_unix_time_ms()),
+                )?;
+            } else {
+                // No stored digest — compute and store one now so future
+                // verifications are cheap. This is the content-digest fallback
+                // path for providers that do not expose a revision token.
+                let digest = sha256_file(&data_path)?;
+                control_db::update_cache_entry_ranges(
+                    &conn,
+                    cache_key,
+                    &row.downloaded_ranges_json,
+                    true,
+                    Some(&digest),
+                    Some(current_unix_time_ms()),
+                )?;
+            }
+        }
+
+        Ok(true)
+    }
+
+    /// Discard a catalog row and its data file. Used when verification fails.
+    fn discard_entry(&self, cache_key: &str) -> CommandResult<()> {
+        let conn = self
+            .control_db
+            .lock()
+            .map_err(|_| internal_error("control DB lock was poisoned"))?;
+        // Remove the catalog row first; if the file deletion fails the
+        // orphaned file is cleaned on the next startup scan.
+        let _ = control_db::delete_cache_entry(&conn, cache_key);
+        let data_path = self.cache_dir.join(Self::data_filename(cache_key));
+        let _ = fs::remove_file(&data_path);
+        Ok(())
+    }
+
+    /// Bump `last_access_at_ms` (wall-clock LRU touch).
+    fn touch_access(&self, cache_key: &str) -> CommandResult<()> {
+        let conn = self
+            .control_db
+            .lock()
+            .map_err(|_| internal_error("control DB lock was poisoned"))?;
+        control_db::touch_cache_entry_access(&conn, cache_key, current_unix_time_ms())
+    }
+
+    /// Persist the current downloaded ranges + completion state for an entry.
+    /// Called after each range write so a restart can resume from the
+    /// persisted ranges.
+    pub fn persist_ranges(&self, cache_key: &str) -> CommandResult<()> {
+        let cache = self
+            .caches
+            .get(cache_key)
+            .ok_or_else(|| internal_error(format!("no open cache for key {cache_key}")))?;
+        let ranges = cache.downloaded();
+        let complete = cache.is_complete();
+        let json = ranges_to_json(&ranges)?;
+
+        // When the entry becomes complete, compute and store the content
+        // digest so future verifications can re-hash cheaply. Mark
+        // verified_at_ms = None so the next reuse re-verifies the full file
+        // (defense against unclean shutdown corruption).
+        let (digest, verified_at) = if complete {
+            let digest = sha256_file(cache.path())?;
+            (Some(digest), None)
+        } else {
+            (None, None)
+        };
+
+        let conn = self
+            .control_db
+            .lock()
+            .map_err(|_| internal_error("control DB lock was poisoned"))?;
+        control_db::update_cache_entry_ranges(
+            &conn,
+            cache_key,
+            &json,
+            complete,
+            digest.as_deref(),
+            verified_at,
+        )?;
+        Ok(())
+    }
+
+    /// Pin an entry so eviction cannot remove it while in use. Returns a guard
+    /// that decrements the pin count on drop. This is a free function on the
+    /// `Arc<Mutex<CacheCatalog>>` because the guard needs to hold a reference
+    /// to the manager to unpin on drop.
+    pub fn pin_cache_entry(
+        manager: &Arc<Mutex<CacheCatalog>>,
+        cache_key: &str,
+    ) -> CommandResult<CachePinGuard> {
+        let manager_guard = manager
+            .lock()
+            .map_err(|_| internal_error("cache manager lock was poisoned"))?;
+        let conn = manager_guard
+            .control_db
+            .lock()
+            .map_err(|_| internal_error("control DB lock was poisoned"))?;
+        control_db::pin_cache_entry(&conn, cache_key)?;
+        drop(conn);
+        drop(manager_guard);
+        Ok(CachePinGuard {
+            cache_key: cache_key.to_owned(),
+            manager: Arc::clone(manager),
+        })
+    }
+
+    /// Decrement the pin count for an entry. Called by `CachePinGuard::drop`.
+    fn unpin(&mut self, cache_key: &str) -> CommandResult<()> {
+        let conn = self
+            .control_db
+            .lock()
+            .map_err(|_| internal_error("control DB lock was poisoned"))?;
+        control_db::unpin_cache_entry(&conn, cache_key)?;
+        Ok(())
+    }
+
+    /// Evict unpinned entries with the oldest `last_access_at_ms` until adding
+    /// `needed_bytes` would fit under the budget. Atomically removes the
+    /// catalog row first, then the data file.
+    fn evict_if_needed(&mut self, needed_bytes: u64) -> CommandResult<()> {
+        let conn = self
+            .control_db
+            .lock()
+            .map_err(|_| internal_error("control DB lock was poisoned"))?;
+        let rows = control_db::list_cache_entries(&conn)?;
+        drop(conn);
+
+        let current: u64 = rows.iter().map(|r| r.expected_size as u64).sum();
+        if current.saturating_add(needed_bytes) <= self.max_bytes {
+            return Ok(());
+        }
+
+        // Evict unpinned entries, oldest access first.
+        let mut evictable: Vec<&CacheEntryRow> =
+            rows.iter().filter(|r| r.pinned_count == 0).collect();
+        evictable.sort_by_key(|r| r.last_access_at_ms);
+
+        let mut freed = current;
+        for row in evictable {
+            if freed.saturating_add(needed_bytes) <= self.max_bytes {
+                break;
+            }
+            // Remove the catalog row first (transactional), then the file.
+            let conn = self
+                .control_db
+                .lock()
+                .map_err(|_| internal_error("control DB lock was poisoned"))?;
+            let _ = control_db::delete_cache_entry(&conn, &row.cache_key);
+            drop(conn);
+            let data_path = self.cache_dir.join(&row.data_path);
+            let _ = fs::remove_file(&data_path);
+            self.caches.remove(&row.cache_key);
+            freed = freed.saturating_sub(row.expected_size as u64);
+        }
+
+        Ok(())
+    }
+
+    /// Evict all unpinned entries. Pinned entries are left in the catalog so
+    /// they survive until playback releases them (their pin count drops to 0),
+    /// at which point a subsequent clear or eviction removes them. Returns the
+    /// number of entries evicted.
+    pub fn clear_unpinned(&mut self) -> CommandResult<usize> {
+        let conn = self
+            .control_db
+            .lock()
+            .map_err(|_| internal_error("control DB lock was poisoned"))?;
+        let rows = control_db::delete_unpinned_cache_entries(&conn)?;
+        drop(conn);
+
+        let mut count = 0;
+        for row in &rows {
+            let data_path = self.cache_dir.join(&row.data_path);
+            let _ = fs::remove_file(&data_path);
+            self.caches.remove(&row.cache_key);
+            count += 1;
+        }
+        Ok(count)
+    }
+
+    /// Remove an entry explicitly (catalog row + data file). Used by tests and
+    /// the discard path.
+    pub fn remove(&mut self, cache_key: &str) -> CommandResult<()> {
+        let conn = self
+            .control_db
+            .lock()
+            .map_err(|_| internal_error("control DB lock was poisoned"))?;
+        let _ = control_db::delete_cache_entry(&conn, cache_key);
+        drop(conn);
+        let data_path = self.cache_dir.join(Self::data_filename(cache_key));
+        let _ = fs::remove_file(&data_path);
+        self.caches.remove(cache_key);
+        Ok(())
+    }
+
+    /// Save all in-memory range state to the catalog. Called at shutdown.
+    pub fn persist_all(&self) -> CommandResult<()> {
+        for (cache_key, cache) in &self.caches {
+            let ranges = cache.downloaded();
+            let complete = cache.is_complete();
+            let json = ranges_to_json(&ranges)?;
+            let (digest, verified_at) = if complete {
+                let digest = sha256_file(cache.path())?;
+                (Some(digest), None)
+            } else {
+                (None, None)
+            };
+            let conn = self
+                .control_db
+                .lock()
+                .map_err(|_| internal_error("control DB lock was poisoned"))?;
+            control_db::update_cache_entry_ranges(
+                &conn,
+                cache_key,
+                &json,
+                complete,
+                digest.as_deref(),
+                verified_at,
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Look up the catalog row for a cache key. Used by the revision-aware
+    /// `ensure_remote_file_cached` to check whether a complete, verified entry
+    /// already exists.
+    pub fn get_entry(&self, cache_key: &str) -> CommandResult<Option<CacheEntryRow>> {
+        let conn = self
+            .control_db
+            .lock()
+            .map_err(|_| internal_error("control DB lock was poisoned"))?;
+        control_db::get_cache_entry(&conn, cache_key)
+    }
+}
+
+/// Map a `CacheError` to a `CommandError`. A disk-full write error is mapped
+/// to a clear disk-space message so the caller can surface a specific error.
+fn cache_error_to_command(error: CacheError) -> CommandError {
+    match error {
+        CacheError::Io(ref e) if is_disk_full(e) => internal_error(format!(
+            "remote cache is full: insufficient disk space to write the cache file ({e})"
+        )),
+        other => internal_error(format!("remote cache error: {other}")),
+    }
+}
+
+/// Detect ENOSPC (disk full) from an `io::Error`. `ErrorKind::Other` may wrap
+/// the raw OS error on some platforms.
+fn is_disk_full(error: &std::io::Error) -> bool {
+    if error.kind() == std::io::ErrorKind::Other && error.raw_os_error() == Some(28) {
+        return true;
+    }
+    // Some platforms report `StorageFull` directly.
+    #[cfg(unix)]
+    if error.raw_os_error() == Some(28) {
+        return true;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::remote::control_db::open_control_db;
+    use rusqlite::params;
+    use tempfile::TempDir;
+
+    /// Build a fresh catalog backed by a temp control DB and temp cache dir.
+    fn fresh_catalog(
+        max_bytes: u64,
+    ) -> (
+        TempDir,
+        TempDir,
+        Arc<Mutex<rusqlite::Connection>>,
+        Arc<Mutex<CacheCatalog>>,
+    ) {
+        let db_dir = TempDir::new().expect("db temp dir");
+        let cache_dir = TempDir::new().expect("cache temp dir");
+        let conn = open_control_db(&db_dir.path().join("remote-state.db")).expect("open db");
+        let control_db = Arc::new(Mutex::new(conn));
+        let catalog = CacheCatalog::open(
+            cache_dir.path().to_path_buf(),
+            Arc::clone(&control_db),
+            max_bytes,
+        )
+        .expect("open catalog");
+        (db_dir, cache_dir, control_db, Arc::new(Mutex::new(catalog)))
+    }
+
+    fn identity(library_id: &str, path: &str, revision: Option<&str>, size: u64) -> CacheIdentity {
+        CacheIdentity {
+            library_id: library_id.to_owned(),
+            relative_path: path.to_owned(),
+            provider_revision: revision.map(str::to_owned),
+            expected_size: size,
+        }
+    }
+
+    // ---- complete and partial entries reopen correctly after restart ----
+
+    #[test]
+    fn complete_entry_reopens_verified_after_restart() {
+        let (_db_dir, cache_dir, control_db, catalog_arc) =
+            fresh_catalog(DEFAULT_CACHE_BYTES_LIMIT);
+        let id = identity("lib-1", "media/a.mp3", Some("rev-1"), 100);
+
+        let cache = {
+            let mut catalog = catalog_arc.lock().unwrap();
+            catalog.get_or_create(&id).unwrap()
+        };
+        cache.write_at(0, &[42u8; 100]).unwrap();
+        {
+            let catalog = catalog_arc.lock().unwrap();
+            catalog.persist_ranges(&id.cache_key()).unwrap();
+        }
+
+        // Simulate restart: drop the in-memory handles and reopen.
+        drop(catalog_arc);
+        let catalog = CacheCatalog::open(
+            cache_dir.path().to_path_buf(),
+            Arc::clone(&control_db),
+            DEFAULT_CACHE_BYTES_LIMIT,
+        )
+        .expect("reopen");
+
+        let row = catalog.get_entry(&id.cache_key()).unwrap().unwrap();
+        assert!(row.complete);
+        // Reopening should verify (re-hash) the complete entry and mark it
+        // verified.
+        let mut catalog = catalog;
+        let cache2 = catalog.get_or_create(&id).unwrap();
+        assert!(cache2.is_complete());
+
+        let row = catalog.get_entry(&id.cache_key()).unwrap().unwrap();
+        assert!(
+            row.verified_at_ms.is_some(),
+            "complete entry must be verified after reopen"
+        );
+    }
+
+    #[test]
+    fn partial_entry_resumes_with_ranges_intact() {
+        let (_db_dir, cache_dir, control_db, catalog_arc) =
+            fresh_catalog(DEFAULT_CACHE_BYTES_LIMIT);
+        let id = identity("lib-1", "media/b.mp3", Some("rev-1"), 200);
+
+        let cache = {
+            let mut catalog = catalog_arc.lock().unwrap();
+            catalog.get_or_create(&id).unwrap()
+        };
+        cache.write_at(0, &[1u8; 50]).unwrap();
+        cache.write_at(100, &[2u8; 50]).unwrap();
+        {
+            let catalog = catalog_arc.lock().unwrap();
+            catalog.persist_ranges(&id.cache_key()).unwrap();
+        }
+
+        drop(catalog_arc);
+        let mut catalog = CacheCatalog::open(
+            cache_dir.path().to_path_buf(),
+            Arc::clone(&control_db),
+            DEFAULT_CACHE_BYTES_LIMIT,
+        )
+        .expect("reopen");
+
+        let cache2 = catalog.get_or_create(&id).unwrap();
+        assert!(cache2.is_cached(0, 50));
+        assert!(cache2.is_cached(100, 50));
+        assert!(!cache2.is_complete());
+
+        let row = catalog.get_entry(&id.cache_key()).unwrap().unwrap();
+        assert!(!row.complete);
+    }
+
+    // ---- orphaned data file with no catalog row is removed on startup ----
+
+    #[test]
+    fn orphaned_data_file_removed_on_startup() {
+        let (_db_dir, cache_dir, control_db, _catalog_arc) =
+            fresh_catalog(DEFAULT_CACHE_BYTES_LIMIT);
+        // Drop the catalog so only the orphan file remains.
+        drop(_catalog_arc);
+        let orphan = cache_dir.path().join("orphan.cache");
+        fs::write(&orphan, b"junk").unwrap();
+        assert!(orphan.exists());
+
+        let _catalog = CacheCatalog::open(
+            cache_dir.path().to_path_buf(),
+            Arc::clone(&control_db),
+            DEFAULT_CACHE_BYTES_LIMIT,
+        )
+        .expect("reopen");
+
+        assert!(
+            !orphan.exists(),
+            "orphaned data file must be removed on startup scan"
+        );
+    }
+
+    // ---- changed provider revision is NOT reused ----
+
+    #[test]
+    fn changed_revision_creates_new_entry() {
+        let (_db_dir, _cache_dir, _control_db, catalog_arc) =
+            fresh_catalog(DEFAULT_CACHE_BYTES_LIMIT);
+        let id_v1 = identity("lib-1", "media/c.mp3", Some("rev-1"), 100);
+        let id_v2 = identity("lib-1", "media/c.mp3", Some("rev-2"), 100);
+
+        let cache_v1 = {
+            let mut catalog = catalog_arc.lock().unwrap();
+            catalog.get_or_create(&id_v1).unwrap()
+        };
+        cache_v1.write_at(0, &[9u8; 100]).unwrap();
+        {
+            catalog_arc
+                .lock()
+                .unwrap()
+                .persist_ranges(&id_v1.cache_key())
+                .unwrap();
+        }
+
+        let key_v1 = id_v1.cache_key();
+        let key_v2 = id_v2.cache_key();
+        assert_ne!(
+            key_v1, key_v2,
+            "different revisions must yield different cache keys"
+        );
+
+        let cache_v2 = {
+            let mut catalog = catalog_arc.lock().unwrap();
+            catalog.get_or_create(&id_v2).unwrap()
+        };
+        assert!(
+            !cache_v2.is_complete(),
+            "new revision must not reuse old entry's data"
+        );
+
+        // Old entry remains until evicted.
+        let catalog = catalog_arc.lock().unwrap();
+        assert!(catalog.get_entry(&key_v1).unwrap().is_some());
+        assert!(catalog.get_entry(&key_v2).unwrap().is_some());
+    }
+
+    // ---- mismatched size is rejected ----
+
+    #[test]
+    fn mismatched_size_is_rejected() {
+        let (_db_dir, cache_dir, control_db, catalog_arc) =
+            fresh_catalog(DEFAULT_CACHE_BYTES_LIMIT);
+        let id = identity("lib-1", "media/d.mp3", Some("rev-1"), 100);
+
+        let cache = {
+            let mut catalog = catalog_arc.lock().unwrap();
+            catalog.get_or_create(&id).unwrap()
+        };
+        cache.write_at(0, &[0u8; 100]).unwrap();
+        {
+            catalog_arc
+                .lock()
+                .unwrap()
+                .persist_ranges(&id.cache_key())
+                .unwrap();
+        }
+        drop(catalog_arc);
+
+        // Corrupt the data file: truncate it so the length no longer matches.
+        let data_path = cache_dir.path().join(format!("{}.cache", id.cache_key()));
+        let _ = fs::write(&data_path, b"short");
+
+        let catalog = CacheCatalog::open(
+            cache_dir.path().to_path_buf(),
+            Arc::clone(&control_db),
+            DEFAULT_CACHE_BYTES_LIMIT,
+        )
+        .expect("reopen");
+
+        // The stale row should have been discarded during reconciliation.
+        let row = catalog.get_entry(&id.cache_key()).unwrap();
+        assert!(
+            row.is_none(),
+            "entry with mismatched size must be discarded"
+        );
+    }
+
+    // ---- default budget is 2 GiB ----
+
+    #[test]
+    fn default_budget_is_2_gib() {
+        assert_eq!(DEFAULT_CACHE_BYTES_LIMIT, 2 * 1024 * 1024 * 1024);
+    }
+
+    // ---- startup accounting includes pre-existing disk files ----
+
+    #[test]
+    fn startup_accounting_includes_preexisting_files() {
+        let (_db_dir, cache_dir, control_db, catalog_arc) =
+            fresh_catalog(DEFAULT_CACHE_BYTES_LIMIT);
+
+        let id = identity("lib-1", "media/e.mp3", Some("rev-1"), 100);
+        let cache = {
+            let mut catalog = catalog_arc.lock().unwrap();
+            catalog.get_or_create(&id).unwrap()
+        };
+        cache.write_at(0, &[0u8; 100]).unwrap();
+        {
+            catalog_arc
+                .lock()
+                .unwrap()
+                .persist_ranges(&id.cache_key())
+                .unwrap();
+        }
+        drop(catalog_arc);
+
+        let catalog = CacheCatalog::open(
+            cache_dir.path().to_path_buf(),
+            Arc::clone(&control_db),
+            DEFAULT_CACHE_BYTES_LIMIT,
+        )
+        .expect("reopen");
+
+        let usage = catalog.usage().unwrap();
+        assert_eq!(usage.used_bytes, 100);
+        assert_eq!(usage.entry_count, 1);
+    }
+
+    // ---- LRU uses persistent timestamps ----
+
+    #[test]
+    fn lru_evicts_oldest_access_first() {
+        let (_db_dir, _cache_dir, _control_db, catalog_arc) = fresh_catalog(250);
+
+        let id_a = identity("lib-1", "media/a.mp3", Some("rev-1"), 100);
+        let id_b = identity("lib-1", "media/b.mp3", Some("rev-1"), 100);
+
+        let cache_a = {
+            let mut catalog = catalog_arc.lock().unwrap();
+            catalog.get_or_create(&id_a).unwrap()
+        };
+        cache_a.write_at(0, &[1u8; 100]).unwrap();
+        {
+            catalog_arc
+                .lock()
+                .unwrap()
+                .persist_ranges(&id_a.cache_key())
+                .unwrap();
+        }
+
+        // Sleep so B's access timestamp is strictly greater than A's.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+
+        let cache_b = {
+            let mut catalog = catalog_arc.lock().unwrap();
+            catalog.get_or_create(&id_b).unwrap()
+        };
+        cache_b.write_at(0, &[2u8; 100]).unwrap();
+        {
+            catalog_arc
+                .lock()
+                .unwrap()
+                .persist_ranges(&id_b.cache_key())
+                .unwrap();
+        }
+
+        // Adding a third 100-byte entry (total 300 > 250) forces eviction.
+        let id_c = identity("lib-1", "media/c.mp3", Some("rev-1"), 100);
+        {
+            let mut catalog = catalog_arc.lock().unwrap();
+            catalog.get_or_create(&id_c).unwrap();
+        }
+
+        let catalog = catalog_arc.lock().unwrap();
+        // A (oldest) should be evicted; B and C remain.
+        assert!(
+            catalog.get_entry(&id_a.cache_key()).unwrap().is_none(),
+            "oldest entry must be evicted first"
+        );
+        assert!(catalog.get_entry(&id_b.cache_key()).unwrap().is_some());
+        assert!(catalog.get_entry(&id_c.cache_key()).unwrap().is_some());
+    }
+
+    #[test]
+    fn lru_persists_across_restart() {
+        let (_db_dir, cache_dir, control_db, catalog_arc) = fresh_catalog(250);
+
+        let id_a = identity("lib-1", "media/a.mp3", Some("rev-1"), 100);
+        let id_b = identity("lib-1", "media/b.mp3", Some("rev-1"), 100);
+
+        let cache_a = {
+            let mut catalog = catalog_arc.lock().unwrap();
+            catalog.get_or_create(&id_a).unwrap()
+        };
+        cache_a.write_at(0, &[1u8; 100]).unwrap();
+        {
+            catalog_arc
+                .lock()
+                .unwrap()
+                .persist_ranges(&id_a.cache_key())
+                .unwrap();
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let cache_b = {
+            let mut catalog = catalog_arc.lock().unwrap();
+            catalog.get_or_create(&id_b).unwrap()
+        };
+        cache_b.write_at(0, &[2u8; 100]).unwrap();
+        {
+            catalog_arc
+                .lock()
+                .unwrap()
+                .persist_ranges(&id_b.cache_key())
+                .unwrap();
+        }
+        drop(catalog_arc);
+
+        let mut catalog =
+            CacheCatalog::open(cache_dir.path().to_path_buf(), Arc::clone(&control_db), 250)
+                .expect("reopen");
+
+        let id_c = identity("lib-1", "media/c.mp3", Some("rev-1"), 100);
+        catalog.get_or_create(&id_c).unwrap();
+
+        assert!(catalog.get_entry(&id_a.cache_key()).unwrap().is_none());
+        assert!(catalog.get_entry(&id_b.cache_key()).unwrap().is_some());
+        assert!(catalog.get_entry(&id_c.cache_key()).unwrap().is_some());
+    }
+
+    // ---- pinned entries are never evicted ----
+
+    #[test]
+    fn pinned_entry_surves_eviction() {
+        let (_db_dir, _cache_dir, _control_db, catalog_arc) = fresh_catalog(200);
+
+        let id_a = identity("lib-1", "media/a.mp3", Some("rev-1"), 100);
+        let id_b = identity("lib-1", "media/b.mp3", Some("rev-1"), 100);
+
+        let cache_a = {
+            let mut catalog = catalog_arc.lock().unwrap();
+            catalog.get_or_create(&id_a).unwrap()
+        };
+        cache_a.write_at(0, &[1u8; 100]).unwrap();
+        {
+            catalog_arc
+                .lock()
+                .unwrap()
+                .persist_ranges(&id_a.cache_key())
+                .unwrap();
+        }
+
+        // Pin A.
+        let _guard = CacheCatalog::pin_cache_entry(&catalog_arc, &id_a.cache_key()).unwrap();
+
+        let cache_b = {
+            let mut catalog = catalog_arc.lock().unwrap();
+            catalog.get_or_create(&id_b).unwrap()
+        };
+        cache_b.write_at(0, &[2u8; 100]).unwrap();
+        {
+            catalog_arc
+                .lock()
+                .unwrap()
+                .persist_ranges(&id_b.cache_key())
+                .unwrap();
+        }
+
+        // Adding a third entry would exceed budget; A is pinned so B (the
+        // next oldest unpinned) is evicted instead.
+        let id_c = identity("lib-1", "media/c.mp3", Some("rev-1"), 100);
+        {
+            let mut catalog = catalog_arc.lock().unwrap();
+            catalog.get_or_create(&id_c).unwrap();
+        }
+
+        let catalog = catalog_arc.lock().unwrap();
+        assert!(
+            catalog.get_entry(&id_a.cache_key()).unwrap().is_some(),
+            "pinned entry must survive eviction"
+        );
+    }
+
+    // ---- clearing cache defers pinned deletion ----
+
+    #[test]
+    fn clear_cache_keeps_pinned_entries() {
+        let (_db_dir, _cache_dir, _control_db, catalog_arc) =
+            fresh_catalog(DEFAULT_CACHE_BYTES_LIMIT);
+
+        let id_a = identity("lib-1", "media/a.mp3", Some("rev-1"), 100);
+        let id_b = identity("lib-1", "media/b.mp3", Some("rev-1"), 100);
+
+        let cache_a = {
+            let mut catalog = catalog_arc.lock().unwrap();
+            catalog.get_or_create(&id_a).unwrap()
+        };
+        cache_a.write_at(0, &[1u8; 100]).unwrap();
+        {
+            catalog_arc
+                .lock()
+                .unwrap()
+                .persist_ranges(&id_a.cache_key())
+                .unwrap();
+        }
+
+        let _guard = CacheCatalog::pin_cache_entry(&catalog_arc, &id_a.cache_key()).unwrap();
+
+        let cache_b = {
+            let mut catalog = catalog_arc.lock().unwrap();
+            catalog.get_or_create(&id_b).unwrap()
+        };
+        cache_b.write_at(0, &[2u8; 100]).unwrap();
+        {
+            catalog_arc
+                .lock()
+                .unwrap()
+                .persist_ranges(&id_b.cache_key())
+                .unwrap();
+        }
+
+        let evicted = {
+            let mut catalog = catalog_arc.lock().unwrap();
+            catalog.clear_unpinned().unwrap()
+        };
+        assert_eq!(evicted, 1, "only the unpinned entry should be evicted");
+
+        {
+            let catalog = catalog_arc.lock().unwrap();
+            assert!(
+                catalog.get_entry(&id_a.cache_key()).unwrap().is_some(),
+                "pinned entry must remain after clear"
+            );
+            assert!(
+                catalog.get_entry(&id_b.cache_key()).unwrap().is_none(),
+                "unpinned entry must be evicted by clear"
+            );
+        }
+
+        // Dropping the guard makes A eligible for a future clear. The guard's
+        // Drop impl locks the manager, so the manager lock above must be
+        // released first (the block scope ensures this).
+        drop(_guard);
+        let evicted2 = {
+            let mut catalog = catalog_arc.lock().unwrap();
+            catalog.clear_unpinned().unwrap()
+        };
+        assert_eq!(evicted2, 1, "deferred pinned entry is evicted after unpin");
+    }
+
+    // ---- corrupted range metadata is rejected ----
+
+    #[test]
+    fn corrupted_ranges_beyond_file_length_rejected() {
+        let (_db_dir, cache_dir, control_db, catalog_arc) =
+            fresh_catalog(DEFAULT_CACHE_BYTES_LIMIT);
+        let id = identity("lib-1", "media/f.mp3", Some("rev-1"), 100);
+
+        let cache = {
+            let mut catalog = catalog_arc.lock().unwrap();
+            catalog.get_or_create(&id).unwrap()
+        };
+        cache.write_at(0, &[0u8; 50]).unwrap();
+        {
+            catalog_arc
+                .lock()
+                .unwrap()
+                .persist_ranges(&id.cache_key())
+                .unwrap();
+        }
+        drop(catalog_arc);
+
+        // Corrupt the downloaded_ranges_json to claim a range beyond the file.
+        let conn = control_db.lock().unwrap();
+        conn.execute(
+            "UPDATE remote_cache_entries SET downloaded_ranges_json = ?2 WHERE cache_key = ?1",
+            params![id.cache_key(), r#"[[0,999]]"#],
+        )
+        .unwrap();
+        drop(conn);
+
+        let mut catalog = CacheCatalog::open(
+            cache_dir.path().to_path_buf(),
+            Arc::clone(&control_db),
+            DEFAULT_CACHE_BYTES_LIMIT,
+        )
+        .expect("reopen");
+
+        // The corrupted entry should be rejected on verification (get_or_create
+        // discards it and creates a fresh one).
+        let cache2 = catalog.get_or_create(&id).unwrap();
+        assert!(
+            !cache2.is_cached(0, 999),
+            "corrupted ranges must not be trusted"
+        );
+    }
+
+    // ---- cache key is deterministic ----
+
+    #[test]
+    fn cache_key_is_deterministic() {
+        let id1 = identity("lib-1", "media/a.mp3", Some("rev-1"), 100);
+        let id2 = identity("lib-1", "media/a.mp3", Some("rev-1"), 100);
+        assert_eq!(id1.cache_key(), id2.cache_key());
+
+        let id3 = identity("lib-1", "media/a.mp3", Some("rev-2"), 100);
+        assert_ne!(id1.cache_key(), id3.cache_key());
+
+        let id4 = identity("lib-1", "media/a.mp3", Some("rev-1"), 200);
+        assert_ne!(id1.cache_key(), id4.cache_key());
+    }
+}

--- a/src-tauri/src/remote/cache_catalog.rs
+++ b/src-tauri/src/remote/cache_catalog.rs
@@ -333,8 +333,12 @@ impl CacheCatalog {
             self.discard_entry(&cache_key)?;
         }
 
-        // Reserve space and evict if needed before creating the new entry.
-        self.evict_if_needed(identity.expected_size)?;
+        // Reserve space and evict if needed before creating a NEW entry. A
+        // verified hit is already counted in the catalog, so evicting for it
+        // would double-count and could delete the entry being reused.
+        if !verified {
+            self.evict_if_needed(identity.expected_size)?;
+        }
 
         // Create or open the on-disk file + in-memory handle. When the entry
         // was verified (catalog hit), initialize the ChunkedCache with the

--- a/src-tauri/src/remote/control_db.rs
+++ b/src-tauri/src/remote/control_db.rs
@@ -314,8 +314,6 @@ pub struct TransferPartRow {
 }
 
 /// Row of `remote_cache_entries`.
-// used by PR#6: persistent cache catalog
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct CacheEntryRow {
     pub cache_key: String,
@@ -845,11 +843,6 @@ pub fn delete_transfer_parts(connection: &Connection, operation_id: &str) -> Com
 // ---------------------------------------------------------------------------
 
 /// Insert or replace a cache entry row.
-///
-/// PR#6 will populate this table; PR#2 only provides the accessor so the
-/// schema is in place.
-// used by PR#6: persistent cache catalog
-#[allow(dead_code)]
 pub fn upsert_cache_entry(connection: &Connection, row: &CacheEntryRow) -> CommandResult<()> {
     connection
         .execute(
@@ -889,9 +882,190 @@ pub fn upsert_cache_entry(connection: &Connection, row: &CacheEntryRow) -> Comma
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// Digest helper
-// ---------------------------------------------------------------------------
+/// Load a cache entry row by its primary key (`cache_key`).
+pub fn get_cache_entry(
+    connection: &Connection,
+    cache_key: &str,
+) -> CommandResult<Option<CacheEntryRow>> {
+    let mut stmt = connection
+        .prepare(
+            "SELECT cache_key, library_id, relative_path, provider_revision, content_digest,
+                    expected_size, downloaded_ranges_json, complete, pinned_count,
+                    last_access_at_ms, verified_at_ms, data_path
+             FROM remote_cache_entries WHERE cache_key = ?1",
+        )
+        .map_err(|e| database_error(format!("failed to prepare cache entry query: {e}")))?;
+    let row = stmt
+        .query_row([cache_key], map_cache_entry_row)
+        .optional()
+        .map_err(|e| database_error(format!("failed to query cache entry: {e}")))?;
+    Ok(row)
+}
+
+/// Load all cache entry rows. Used by the startup reconciliation scan and by
+/// the usage/clear-cache IPC commands.
+pub fn list_cache_entries(connection: &Connection) -> CommandResult<Vec<CacheEntryRow>> {
+    let mut stmt = connection
+        .prepare(
+            "SELECT cache_key, library_id, relative_path, provider_revision, content_digest,
+                    expected_size, downloaded_ranges_json, complete, pinned_count,
+                    last_access_at_ms, verified_at_ms, data_path
+             FROM remote_cache_entries",
+        )
+        .map_err(|e| database_error(format!("failed to prepare cache entry list: {e}")))?;
+    let rows = stmt
+        .query_map([], map_cache_entry_row)
+        .map_err(|e| database_error(format!("failed to list cache entries: {e}")))?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|e| database_error(format!("failed to collect cache entries: {e}")))?;
+    Ok(rows)
+}
+
+/// Delete a cache entry row by its primary key. The caller is responsible for
+/// removing the on-disk data file; this only removes the catalog row. Removing
+/// the catalog row first (in the same logical transaction as marking the file
+/// for deletion) means an orphaned file left by a failed deletion is cleaned
+/// up on the next startup scan.
+pub fn delete_cache_entry(connection: &Connection, cache_key: &str) -> CommandResult<()> {
+    connection
+        .execute(
+            "DELETE FROM remote_cache_entries WHERE cache_key = ?1",
+            params![cache_key],
+        )
+        .map_err(|e| database_error(format!("failed to delete cache entry: {e}")))?;
+    Ok(())
+}
+
+/// Update the downloaded ranges JSON, complete flag, content digest, and
+/// verified timestamp for a cache entry. Called after each range write so a
+/// restart can resume from the persisted ranges.
+pub fn update_cache_entry_ranges(
+    connection: &Connection,
+    cache_key: &str,
+    downloaded_ranges_json: &str,
+    complete: bool,
+    content_digest: Option<&str>,
+    verified_at_ms: Option<i64>,
+) -> CommandResult<()> {
+    connection
+        .execute(
+            "UPDATE remote_cache_entries SET
+                downloaded_ranges_json = ?2,
+                complete = ?3,
+                content_digest = COALESCE(?4, content_digest),
+                verified_at_ms = ?5
+             WHERE cache_key = ?1",
+            params![
+                cache_key,
+                downloaded_ranges_json,
+                complete,
+                content_digest,
+                verified_at_ms,
+            ],
+        )
+        .map_err(|e| database_error(format!("failed to update cache entry ranges: {e}")))?;
+    Ok(())
+}
+
+/// Bump `last_access_at_ms` for a cache entry (wall-clock LRU touch).
+pub fn touch_cache_entry_access(
+    connection: &Connection,
+    cache_key: &str,
+    last_access_at_ms: i64,
+) -> CommandResult<()> {
+    connection
+        .execute(
+            "UPDATE remote_cache_entries SET last_access_at_ms = ?2 WHERE cache_key = ?1",
+            params![cache_key, last_access_at_ms],
+        )
+        .map_err(|e| database_error(format!("failed to touch cache entry access: {e}")))?;
+    Ok(())
+}
+
+/// Atomically increment `pinned_count` for a cache entry. Returns the new
+/// pinned count. A row that does not exist is a no-op returning 0.
+pub fn pin_cache_entry(connection: &Connection, cache_key: &str) -> CommandResult<i64> {
+    connection
+        .execute(
+            "UPDATE remote_cache_entries SET pinned_count = pinned_count + 1 WHERE cache_key = ?1",
+            params![cache_key],
+        )
+        .map_err(|e| database_error(format!("failed to pin cache entry: {e}")))?;
+    let pinned: Option<i64> = connection
+        .query_row(
+            "SELECT pinned_count FROM remote_cache_entries WHERE cache_key = ?1",
+            params![cache_key],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|e| database_error(format!("failed to query pinned count: {e}")))?;
+    Ok(pinned.unwrap_or(0))
+}
+
+/// Atomically decrement `pinned_count` for a cache entry, clamped at 0.
+/// Returns the new pinned count. A row that does not exist is a no-op
+/// returning 0.
+pub fn unpin_cache_entry(connection: &Connection, cache_key: &str) -> CommandResult<i64> {
+    connection
+        .execute(
+            "UPDATE remote_cache_entries SET pinned_count = MAX(0, pinned_count - 1) WHERE cache_key = ?1",
+            params![cache_key],
+        )
+        .map_err(|e| database_error(format!("failed to unpin cache entry: {e}")))?;
+    let pinned: Option<i64> = connection
+        .query_row(
+            "SELECT pinned_count FROM remote_cache_entries WHERE cache_key = ?1",
+            params![cache_key],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|e| database_error(format!("failed to query pinned count: {e}")))?;
+    Ok(pinned.unwrap_or(0))
+}
+
+/// Mark a cache entry for deferred eviction by setting `pinned_count = 0` only
+/// if it is already 0. Pinned entries are left untouched so the clear-cache
+/// command does not force-delete files in use. Returns the cache keys of
+/// entries that were actually deleted (pinned_count was already 0).
+pub fn delete_unpinned_cache_entries(connection: &Connection) -> CommandResult<Vec<CacheEntryRow>> {
+    let mut stmt = connection
+        .prepare(
+            "SELECT cache_key, library_id, relative_path, provider_revision, content_digest,
+                    expected_size, downloaded_ranges_json, complete, pinned_count,
+                    last_access_at_ms, verified_at_ms, data_path
+             FROM remote_cache_entries WHERE pinned_count = 0",
+        )
+        .map_err(|e| database_error(format!("failed to prepare unpinned cache query: {e}")))?;
+    let rows: Vec<CacheEntryRow> = stmt
+        .query_map([], map_cache_entry_row)
+        .map_err(|e| database_error(format!("failed to query unpinned cache entries: {e}")))?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|e| database_error(format!("failed to collect unpinned cache entries: {e}")))?;
+    connection
+        .execute(
+            "DELETE FROM remote_cache_entries WHERE pinned_count = 0",
+            [],
+        )
+        .map_err(|e| database_error(format!("failed to delete unpinned cache entries: {e}")))?;
+    Ok(rows)
+}
+
+fn map_cache_entry_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CacheEntryRow> {
+    Ok(CacheEntryRow {
+        cache_key: row.get(0)?,
+        library_id: row.get(1)?,
+        relative_path: row.get(2)?,
+        provider_revision: row.get(3)?,
+        content_digest: row.get(4)?,
+        expected_size: row.get(5)?,
+        downloaded_ranges_json: row.get(6)?,
+        complete: row.get::<_, i64>(7)? != 0,
+        pinned_count: row.get(8)?,
+        last_access_at_ms: row.get(9)?,
+        verified_at_ms: row.get(10)?,
+        data_path: row.get(11)?,
+    })
+}
 
 /// Compute the SHA-256 hex digest of a file's contents.
 ///

--- a/src-tauri/src/remote/mod.rs
+++ b/src-tauri/src/remote/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod atomic_download;
 mod auth;
 mod auth_binding;
 mod bootstrap;
+pub(crate) mod cache_catalog;
 pub(crate) mod control_db;
 mod dropbox;
 pub(crate) mod errors;

--- a/src-tauri/src/remote/sync/revision.rs
+++ b/src-tauri/src/remote/sync/revision.rs
@@ -374,6 +374,21 @@ pub fn ensure_remote_file_cached(app_data_dir: &Path, relative_path: &str) -> Co
         }
     }
 
+    // Fallback fast-path: if the destination file already exists and its
+    // size matches the remote size, skip the download. The catalog lookup
+    // above only succeeds when a `remote_cache_entries` row exists, but
+    // `atomic_download` does not create catalog rows — it writes directly
+    // to the destination. Without this fallback, non-streaming remote media,
+    // CDG graphics, and imported remote files are re-downloaded on every
+    // access even when a valid copy is already present.
+    if let Some(size) = remote_size {
+        if destination.exists()
+            && std::fs::metadata(&destination).map(|m| m.len()).ok() == Some(size)
+        {
+            return Ok(());
+        }
+    }
+
     // Download to a temp file, validate size when known, then atomically
     // rename. This replaces the old direct-to-destination download that
     // could leave a truncated file at the final path (defect #5).

--- a/src-tauri/src/remote/sync/revision.rs
+++ b/src-tauri/src/remote/sync/revision.rs
@@ -326,28 +326,58 @@ pub fn ensure_remote_file_cached(app_data_dir: &Path, relative_path: &str) -> Co
 
     let provider = create_provider(app_data_dir, &library)?;
 
-    // Fast-path: if the destination exists AND the remote size matches,
-    // skip re-download. This is a minimal cache-validity check; the full
-    // verified cache catalog is PR #6.
-    // TODO(PR#6): replace existence+size check with verified cache
-    // catalog lookup.
-    //
-    // Note: we do NOT compare per-file revisions here because
-    // `library.remote_revision()` holds the revision of `openkara.db`,
-    // not the individual asset file. Comparing them would never match
-    // and cause every asset to be re-downloaded on each playback.
-    if destination.exists() {
-        let local_size = std::fs::metadata(&destination).map(|m| m.len()).ok();
-        let remote_size = provider.get_file_size(relative_path)?;
-        if local_size.is_some() && remote_size == local_size {
-            return Ok(());
+    // Verified cache catalog lookup. The cache key is derived from the
+    // identity tuple (library_id, relative_path, provider_revision,
+    // expected_size). A complete, verified catalog entry means the file is
+    // already cached and reusable; otherwise fall through to an atomic
+    // download. This replaces the old existence+revision+size check that could
+    // reuse bytes from an older provider revision (defect #7).
+    let provider_revision = provider.get_revision(relative_path)?;
+    let remote_size = provider.get_file_size(relative_path)?;
+    let revision = provider_revision
+        .clone()
+        .or_else(|| library.remote_revision().map(str::to_owned));
+
+    // Open the control DB to consult the cache catalog. This is the same DB
+    // the AppState holds; opening a short-lived read connection here is safe
+    // because WAL mode allows concurrent readers.
+    let control_db_path = crate::remote::control_db::control_db_path(app_data_dir);
+    if let Ok(conn) = crate::remote::control_db::open_control_db(&control_db_path) {
+        if let (Some(size), Some(rev)) = (remote_size, revision.as_deref()) {
+            let identity = crate::remote::cache_catalog::CacheIdentity {
+                library_id: library.id().to_owned(),
+                relative_path: relative_path.to_owned(),
+                provider_revision: Some(rev.to_owned()),
+                expected_size: size,
+            };
+            let cache_key = identity.cache_key();
+            if let Ok(Some(row)) = crate::remote::control_db::get_cache_entry(&conn, &cache_key) {
+                if row.complete
+                    && row.expected_size == size as i64
+                    && std::path::Path::new(&row.data_path).is_absolute()
+                    && std::fs::metadata(&row.data_path).is_ok()
+                {
+                    // Complete + verified catalog entry — the file is cached.
+                    return Ok(());
+                }
+                // For the working-copy destination path (not the streaming
+                // cache), check the destination directly when the catalog row
+                // is complete and the data file matches.
+                if row.complete
+                    && row.expected_size == size as i64
+                    && destination.exists()
+                    && std::fs::metadata(&destination).map(|m| m.len()).ok() == Some(size)
+                {
+                    return Ok(());
+                }
+            }
         }
     }
 
     // Download to a temp file, validate size when known, then atomically
     // rename. This replaces the old direct-to-destination download that
     // could leave a truncated file at the final path (defect #5).
-    let expected_size = provider.get_file_size(relative_path)?;
+    let expected_size = remote_size;
     let operation_id = format!("cache-{}", current_unix_time_ms());
     crate::remote::atomic_download::atomic_download(
         provider.as_ref(),

--- a/src-tauri/src/services/playback.rs
+++ b/src-tauri/src/services/playback.rs
@@ -292,7 +292,15 @@ fn play_track_background<R: Runtime>(
             let event_request_id = request_id;
             let event_library_root = library_root.clone();
             let event_app_data_dir = app_data_dir.to_path_buf();
+            // Move the cache pin guard into the fetch event thread so it lives
+            // for the duration of playback. When the fetch channel closes
+            // (playback stops / track skips), the guard is dropped, which
+            // decrements the pin count and makes the entry eligible for
+            // eviction.
+            let _pin_guard = streaming_source.cache_pin_guard;
             std::thread::spawn(move || {
+                // Keep the pin guard alive for the lifetime of this thread.
+                let _pin = _pin_guard;
                 for event in fetch_event_rx {
                     match event {
                         remote_source::FetchEvent::ConsecutiveFailures { count } => {

--- a/src-tauri/src/services/playback_source.rs
+++ b/src-tauri/src/services/playback_source.rs
@@ -307,12 +307,25 @@ fn load_remote_streaming_source(
         )
     };
 
+    // Create a persistence callback so the fetch thread can persist
+    // download progress to the cache catalog after each successful range
+    // write. Without this, downloaded_ranges_json stays empty and complete
+    // stays false, so cached remote audio is re-downloaded after restart.
+    let persist_catalog = Arc::clone(remote_chunk_cache);
+    let persist_key = cache_key.clone();
+    let on_range_written: Arc<dyn Fn() + Send + Sync> = Arc::new(move || {
+        if let Ok(manager) = persist_catalog.lock() {
+            let _ = manager.persist_ranges(&persist_key);
+        }
+    });
+
     let (fetch_tx, fetch_event_rx, _bandwidth_monitor, _fetch_handle) =
         remote_source::spawn_fetch_thread_with_fetcher(
             String::new(), // URL is embedded in the fetcher
             Arc::clone(&cache),
             fetcher,
             remote_source::RetryConfig::default(),
+            Some(on_range_written),
         );
 
     let extension = std::path::Path::new(song_path)

--- a/src-tauri/src/services/playback_source.rs
+++ b/src-tauri/src/services/playback_source.rs
@@ -1,6 +1,5 @@
 use crate::{
     audio::{
-        chunked_cache::{CacheError, CacheManager},
         decode,
         error::PlaybackError,
         playback::{LoadedStems, StemSet},
@@ -12,6 +11,7 @@ use crate::{
     library_root::LibraryRoot,
     media_g::{self, MEDIA_G_ZIP},
     remote,
+    remote::cache_catalog::{CacheCatalog, CacheIdentity, CachePinGuard},
     remote::provider::RemoteProvider,
 };
 use anyhow::{Context, Result};
@@ -176,6 +176,12 @@ pub(crate) struct StreamingPlaybackSource {
     /// Receiver for fetch events (only present for remote streaming).
     /// The caller should consume these to handle ConsecutiveFailures, etc.
     pub(crate) fetch_event_rx: Option<mpsc::Receiver<FetchEvent>>,
+    /// RAII pin guard for the remote cache entry. When dropped (on source
+    /// release / track skip / stop), the pin count decrements so the entry
+    /// becomes eligible for eviction. `None` for local sources. The field is
+    /// never read directly — it exists only for its `Drop` side effect.
+    #[allow(dead_code)]
+    pub(crate) cache_pin_guard: Option<CachePinGuard>,
 }
 
 /// For local files, decodes directly from disk. For remote songs, creates a
@@ -187,7 +193,7 @@ pub(crate) struct StreamingPlaybackSource {
 /// byte extraction).
 pub(crate) fn load_playback_source_streaming(
     app_data_dir: Option<&Path>,
-    remote_chunk_cache: &Mutex<CacheManager>,
+    remote_chunk_cache: &Arc<Mutex<CacheCatalog>>,
     library_root: &LibraryRoot,
     song: &Song,
 ) -> Result<Option<StreamingPlaybackSource>, PlaybackError> {
@@ -225,6 +231,7 @@ pub(crate) fn load_playback_source_streaming(
         metadata,
         decode_handle,
         fetch_event_rx: None,
+        cache_pin_guard: None,
     }))
 }
 
@@ -232,7 +239,7 @@ pub(crate) fn load_playback_source_streaming(
 /// requests (caller should fall back to full-file download).
 fn load_remote_streaming_source(
     app_data_dir: Option<&Path>,
-    remote_chunk_cache: &Mutex<CacheManager>,
+    remote_chunk_cache: &Arc<Mutex<CacheCatalog>>,
     _library_root: &LibraryRoot,
     song: &Song,
 ) -> Result<Option<StreamingPlaybackSource>, PlaybackError> {
@@ -265,14 +272,39 @@ fn load_remote_streaming_source(
         return Ok(None); // Can't determine size — fall back.
     }
 
-    let cache_key = format!("remote-{}", song.hash);
+    // Build a revision-aware cache identity so a replaced remote object (new
+    // provider revision or changed size) does not reuse bytes from an older
+    // version. The cache key is the SHA-256 of (library_id, relative_path,
+    // provider_revision, expected_size). When the provider does not expose a
+    // revision token, fall back to the library's stored remote_revision; if
+    // that is also unavailable, the content-digest fallback path in the
+    // catalog computes a SHA-256 of the cached file after the first full
+    // download and uses that for future lookups.
+    let provider_revision = provider.get_revision(song_path).ok().flatten();
+    let revision = provider_revision.or_else(|| library.remote_revision().map(str::to_owned));
+    let identity = CacheIdentity {
+        library_id: library.id().to_owned(),
+        relative_path: song_path.to_owned(),
+        provider_revision: revision,
+        expected_size: file_size,
+    };
+    let cache_key = identity.cache_key();
+
     let cache = {
         let mut manager = remote_chunk_cache.lock().map_err(|_| {
             PlaybackError::Internal("remote chunk cache manager lock was poisoned".to_owned())
         })?;
-        manager
-            .get_or_create(&cache_key, file_size)
-            .map_err(map_cache_error)?
+        manager.get_or_create(&identity).map_err(map_cache_error)?
+    };
+
+    // Pin the cache entry so eviction cannot remove the file while playback is
+    // active. The guard decrements the pin count on drop (source release /
+    // track skip / stop), making the entry eligible for eviction again.
+    let cache_pin_guard = {
+        Some(
+            CacheCatalog::pin_cache_entry(remote_chunk_cache, &cache_key)
+                .map_err(map_cache_error)?,
+        )
     };
 
     let (fetch_tx, fetch_event_rx, _bandwidth_monitor, _fetch_handle) =
@@ -315,6 +347,7 @@ fn load_remote_streaming_source(
         metadata: probe_metadata,
         decode_handle,
         fetch_event_rx: Some(fetch_event_rx),
+        cache_pin_guard,
     }))
 }
 
@@ -874,17 +907,18 @@ fn decode_stem_entry(
     }
 }
 
-fn map_cache_error(error: CacheError) -> PlaybackError {
-    PlaybackError::Internal(error.to_string())
+fn map_cache_error(error: crate::commands::error::CommandError) -> PlaybackError {
+    PlaybackError::Internal(error.message)
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::audio::chunked_cache::CacheManager;
     use crate::cache::stems::StemCacheEntry;
     use crate::commands::error::{CommandError, CommandResult};
     use crate::library::Song;
     use crate::library_root::LibraryRoot;
+    use crate::remote::cache_catalog::{CacheCatalog, CacheIdentity, DEFAULT_CACHE_BYTES_LIMIT};
+    use crate::remote::control_db::open_control_db;
     use crate::remote::provider::RemoteProvider;
     use std::collections::HashMap;
     use std::path::Path;
@@ -893,18 +927,44 @@ mod tests {
 
     #[test]
     fn remote_cache_manager_evicts_lru_when_over_budget() {
-        let dir = tempdir().expect("temp dir");
-        let mut manager = CacheManager::new(dir.path().to_path_buf(), 200);
+        let db_dir = tempdir().expect("db temp dir");
+        let cache_dir = tempdir().expect("cache temp dir");
+        let conn = open_control_db(&db_dir.path().join("remote-state.db")).expect("open db");
+        let control_db = Arc::new(Mutex::new(conn));
+        let mut manager = CacheCatalog::open(cache_dir.path().to_path_buf(), control_db, 200)
+            .expect("open catalog");
 
-        let c1 = manager.get_or_create("song-a", 150).expect("cache a");
+        let id_a = CacheIdentity {
+            library_id: "lib-1".to_owned(),
+            relative_path: "media/a.mp3".to_owned(),
+            provider_revision: Some("rev-1".to_owned()),
+            expected_size: 150,
+        };
+        let id_b = CacheIdentity {
+            library_id: "lib-1".to_owned(),
+            relative_path: "media/b.mp3".to_owned(),
+            provider_revision: Some("rev-1".to_owned()),
+            expected_size: 150,
+        };
+
+        let c1 = manager.get_or_create(&id_a).expect("cache a");
         c1.write_at(0, &[0u8; 150]).expect("write a");
+        manager
+            .persist_ranges(&id_a.cache_key())
+            .expect("persist a");
 
-        let c2 = manager.get_or_create("song-b", 150).expect("cache b");
+        let c2 = manager.get_or_create(&id_b).expect("cache b");
         c2.write_at(0, &[0u8; 150]).expect("write b");
+        manager
+            .persist_ranges(&id_b.cache_key())
+            .expect("persist b");
 
-        assert_eq!(manager.len(), 1);
-        assert!(dir.path().join("song-b.cache").exists());
-        assert!(!dir.path().join("song-a.cache").exists());
+        // A (oldest) should be evicted; B remains.
+        assert!(
+            manager.get_entry(&id_a.cache_key()).unwrap().is_none(),
+            "oldest entry must be evicted"
+        );
+        assert!(manager.get_entry(&id_b.cache_key()).unwrap().is_some());
     }
 
     // ---- Test infrastructure for remote stem set caching ----
@@ -1093,15 +1153,22 @@ mod tests {
         // return Ok(None) WITHOUT calling resolve_song_file_path, which would
         // fail.  Ok(None) makes the caller fall back to the non-streaming
         // load_playback_source that handles remote stems.
-        let dir = tempdir().expect("temp dir");
-        let lib = LibraryRoot::create(&dir.path().join("Lib")).expect("library");
+        let db_dir = tempdir().expect("db temp dir");
+        let cache_dir = tempdir().expect("cache temp dir");
+        let lib = LibraryRoot::create(&cache_dir.path().join("Lib")).expect("library");
         let song = remote_stems_song("song-a");
-        let cache = Arc::new(Mutex::new(CacheManager::new(
-            dir.path().join("cache"),
-            1024 * 1024,
-        )));
+        let conn = open_control_db(&db_dir.path().join("remote-state.db")).expect("open db");
+        let control_db = Arc::new(Mutex::new(conn));
+        let catalog = CacheCatalog::open(
+            db_dir.path().join("cache"),
+            control_db,
+            DEFAULT_CACHE_BYTES_LIMIT,
+        )
+        .expect("open catalog");
+        let cache = Arc::new(Mutex::new(catalog));
 
-        let result = super::load_playback_source_streaming(Some(dir.path()), &cache, &lib, &song);
+        let result =
+            super::load_playback_source_streaming(Some(cache_dir.path()), &cache, &lib, &song);
 
         assert!(
             result.is_ok(),

--- a/src-tauri/src/state/remote.rs
+++ b/src-tauri/src/state/remote.rs
@@ -1,4 +1,4 @@
-use crate::audio::chunked_cache::CacheManager;
+use crate::remote::cache_catalog::{CacheCatalog, DEFAULT_CACHE_BYTES_LIMIT};
 use crate::remote::control_db;
 use crate::remote::{RemoteAuthSession, UploadStatusSnapshot};
 use std::collections::HashMap;
@@ -19,8 +19,11 @@ pub struct RemoteState {
     /// source of truth is the `remote_operations` table in the control DB; this
     /// map is kept only so we avoid re-emitting events for unchanged state.
     pub remote_upload_statuses: Arc<Mutex<HashMap<String, UploadStatusSnapshot>>>,
-    /// LRU-managed on-disk caches for remote streaming playback.
-    pub remote_chunk_cache: Arc<Mutex<CacheManager>>,
+    /// Persistent, verified cache catalog for remote streaming playback. The
+    /// `remote_cache_entries` table in the control DB is the authoritative
+    /// catalog; on-disk data files are content-addressed by the cache key
+    /// digest. Replaces the old in-memory-only `CacheManager`.
+    pub remote_chunk_cache: Arc<Mutex<CacheCatalog>>,
     /// Durable control-plane database handle (`remote-state.db`). Holds the
     /// authoritative local record of remote operation/outbox state, repository
     /// cleanliness, and resumable transfer offsets. Never uploaded.
@@ -33,9 +36,11 @@ impl RemoteState {
     pub fn new_with_limit(app_data_dir: &Path, remote_cache_bytes_limit: Option<u64>) -> Self {
         let cache_dir = app_data_dir.join("remote-cache");
 
-        // When absent in config, allow the cache to grow unbounded (u64::MAX).
-        // Eviction logic uses saturating arithmetic so this is safe.
-        let max_bytes = remote_cache_bytes_limit.unwrap_or(u64::MAX);
+        // Default to a finite 2 GiB budget when no limit is configured. The
+        // old default of u64::MAX (unbounded) let the cache grow without bound
+        // on a fresh install. A finite default prevents disk exhaustion while
+        // staying large enough that a typical session does not thrash.
+        let max_bytes = remote_cache_bytes_limit.unwrap_or(DEFAULT_CACHE_BYTES_LIMIT);
 
         // Open the durable control DB. This stays outside every portable
         // library and is never uploaded. WAL mode is enabled on open so
@@ -60,11 +65,30 @@ impl RemoteState {
                 conn
             });
 
+        let control_db = Arc::new(Mutex::new(control_db_conn));
+
+        // Open the persistent cache catalog. This runs startup reconciliation
+        // (orphaned files removed, inconsistent rows discarded) before any
+        // playback uses the cache.
+        let remote_chunk_cache = CacheCatalog::open(cache_dir, Arc::clone(&control_db), max_bytes)
+            .unwrap_or_else(|error| {
+                eprintln!(
+                    "warning: failed to open remote cache catalog: {:?}; \
+                 falling back to an empty in-memory-only catalog",
+                    error
+                );
+                // Fall back to an empty catalog backed by a temp dir so the app
+                // can still start in degraded mode (cache will not persist).
+                let fallback_dir = std::env::temp_dir().join("openkara-remote-cache-fallback");
+                CacheCatalog::open(fallback_dir, Arc::clone(&control_db), max_bytes)
+                    .expect("fallback cache catalog should always open")
+            });
+
         Self {
             remote_auth_sessions: Arc::new(Mutex::new(HashMap::new())),
             remote_upload_statuses: Arc::new(Mutex::new(HashMap::new())),
-            remote_chunk_cache: Arc::new(Mutex::new(CacheManager::new(cache_dir, max_bytes))),
-            control_db: Arc::new(Mutex::new(control_db_conn)),
+            remote_chunk_cache: Arc::new(Mutex::new(remote_chunk_cache)),
+            control_db,
             commit_locks: Arc::new(Mutex::new(HashMap::new())),
         }
     }


### PR DESCRIPTION
## Summary
- Rebuild remote chunk cache as persistent, revision-aware, verified catalog backed by `remote_cache_entries`.
- Cache keys derive from `(library_id, relative_path, provider_revision, expected_size)` — replaced remote objects cannot reuse stale bytes.
- Default budget 2 GiB (was unbounded). LRU uses persistent wall-clock timestamps.
- Pinned active/buffering tracks survive eviction. Startup reconciliation removes orphaned files and inconsistent rows.
- New IPC: `get_remote_cache_usage`, `clear_remote_cache`.

#### Test plan
- [x] `cargo test -q` (863 tests pass)
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`

Part 6/8 of issue #151. Stacked on #161.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thedavidweng/openkara/pull/162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->