### PR TITLE
fix(ci): use GitHub compare API for push-event file list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,11 +100,17 @@ jobs:
               "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
               > changed-files.txt
           elif [ "$EVENT_NAME" = "push" ]; then
-            # Diff before/after. Handle the zero-SHA (new branch) edge case.
+            # Use the GitHub API instead of git diff: the checkout is shallow
+            # (fetch-depth: 1) so the BEFORE SHA is not in local history.
             if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
-              git diff --name-only HEAD~1..HEAD > changed-files.txt
+              # New branch — list files in the pushed commit.
+              gh api --jq '.files[].filename' \
+                "repos/${GITHUB_REPOSITORY}/commits/${AFTER}" \
+                > changed-files.txt
             else
-              git diff --name-only "$BEFORE".."$AFTER" > changed-files.txt
+              gh api --paginate --jq '.files[].filename' \
+                "repos/${GITHUB_REPOSITORY}/compare/${BEFORE}...${AFTER}" \
+                > changed-files.txt
             fi
           else
             # workflow_dispatch — no changed files; classifier returns full CI.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,17 +100,23 @@ jobs:
               "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
               > changed-files.txt
           elif [ "$EVENT_NAME" = "push" ]; then
-            # Use the GitHub API instead of git diff: the checkout is shallow
-            # (fetch-depth: 1) so the BEFORE SHA is not in local history.
+            # Fetch BEFORE so we can diff locally. The GitHub compare/commit
+            # APIs cap their `files` arrays at 300 entries, which would
+            # silently drop changed paths; a local git diff has no such
+            # limit. The checkout is shallow (fetch-depth: 1) so BEFORE is
+            # not in local history until we fetch it.
             if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
-              # New branch — list files in the pushed commit.
-              gh api --jq '.files[].filename' \
-                "repos/${GITHUB_REPOSITORY}/commits/${AFTER}" \
-                > changed-files.txt
+              # New branch — deepen by one to get the parent of AFTER.
+              git fetch --no-tags --deepen=1 origin
+              if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+                git diff --name-only HEAD~1..HEAD > changed-files.txt
+              else
+                # Initial commit (no parent) — list all tracked files.
+                git ls-tree -r --name-only HEAD > changed-files.txt
+              fi
             else
-              gh api --paginate --jq '.files[].filename' \
-                "repos/${GITHUB_REPOSITORY}/compare/${BEFORE}...${AFTER}" \
-                > changed-files.txt
+              git fetch --no-tags --depth=1 origin "$BEFORE"
+              git diff --name-only "$BEFORE".."$AFTER" > changed-files.txt
             fi
           else
             # workflow_dispatch — no changed files; classifier returns full CI.

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -72,10 +72,16 @@ jobs:
               "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
               > changed-files.txt
           elif [ "$EVENT_NAME" = "push" ]; then
+            # Use the GitHub API instead of git diff: the checkout is shallow
+            # (fetch-depth: 1) so the BEFORE SHA is not in local history.
             if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
-              git diff --name-only HEAD~1..HEAD > changed-files.txt
+              gh api --jq '.files[].filename' \
+                "repos/${GITHUB_REPOSITORY}/commits/${AFTER}" \
+                > changed-files.txt
             else
-              git diff --name-only "$BEFORE".."$AFTER" > changed-files.txt
+              gh api --paginate --jq '.files[].filename' \
+                "repos/${GITHUB_REPOSITORY}/compare/${BEFORE}...${AFTER}" \
+                > changed-files.txt
             fi
           else
             : > changed-files.txt

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -72,16 +72,23 @@ jobs:
               "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
               > changed-files.txt
           elif [ "$EVENT_NAME" = "push" ]; then
-            # Use the GitHub API instead of git diff: the checkout is shallow
-            # (fetch-depth: 1) so the BEFORE SHA is not in local history.
+            # Fetch BEFORE so we can diff locally. The GitHub compare/commit
+            # APIs cap their `files` arrays at 300 entries, which would
+            # silently drop changed paths; a local git diff has no such
+            # limit. The checkout is shallow (fetch-depth: 1) so BEFORE is
+            # not in local history until we fetch it.
             if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
-              gh api --jq '.files[].filename' \
-                "repos/${GITHUB_REPOSITORY}/commits/${AFTER}" \
-                > changed-files.txt
+              # New branch — deepen by one to get the parent of AFTER.
+              git fetch --no-tags --deepen=1 origin
+              if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+                git diff --name-only HEAD~1..HEAD > changed-files.txt
+              else
+                # Initial commit (no parent) — list all tracked files.
+                git ls-tree -r --name-only HEAD > changed-files.txt
+              fi
             else
-              gh api --paginate --jq '.files[].filename' \
-                "repos/${GITHUB_REPOSITORY}/compare/${BEFORE}...${AFTER}" \
-                > changed-files.txt
+              git fetch --no-tags --depth=1 origin "$BEFORE"
+              git diff --name-only "$BEFORE".."$AFTER" > changed-files.txt
             fi
           else
             : > changed-files.txt


### PR DESCRIPTION
## Summary
- The Triage job in both `ci.yml` and `packaging.yml` used `git diff $BEFORE..$AFTER` to collect changed files on push events, but the checkout is shallow (`fetch-depth: 1`) so the BEFORE SHA is not in local history. This caused `fatal: Invalid revision range` on every push to main, failing CI before any job could run.
- Replaced the `git diff` call with the GitHub compare API (`repos/.../compare/$BEFORE...$AFTER`), which does not depend on local git history. For the zero-SHA (new branch) edge case, use the commits API to list files in the pushed commit.

#### Test plan
- [x] CI workflow contract tests pass (`pnpm vitest run tests/ci/`)
- [x] Full frontend test suite passes (1875 tests)
- [ ] CI run on this PR confirms Triage no longer fails on push events