### PR TITLE
feat(separation): cancel single-song runs and surface cache hits

### DIFF
--- a/src-tauri/src/commands/batch_separation.rs
+++ b/src-tauri/src/commands/batch_separation.rs
@@ -65,5 +65,12 @@ pub fn cancel_batch_separation(state: State<'_, AppState>) -> CommandResult<()> 
         );
     }
     state.separation.batch_cancel.store(true, Ordering::Relaxed);
+    // Also flag the in-flight song so the batch stops mid-song rather than
+    // after the current track finishes.
+    if let Ok(current) = state.separation.batch_current_song.lock() {
+        if let Some(song_id) = current.as_ref() {
+            separation::request_cancel(&state.separation.separation_cancels, song_id);
+        }
+    }
     Ok(())
 }

--- a/src-tauri/src/commands/error.rs
+++ b/src-tauri/src/commands/error.rs
@@ -124,6 +124,15 @@ impl From<crate::separator::error::SeparationError> for CommandError {
                 true,
                 FallbackAction::Retry,
             ),
+            // Cancellation is routed to a `separation-cancelled` event before it
+            // reaches the frontend, so this mapping only exists to keep the
+            // conversion total; the resulting error is never surfaced.
+            Cancelled => CommandError::new(
+                ErrorCode::SeparationFailed,
+                err.to_string(),
+                false,
+                FallbackAction::KeepCurrentState,
+            ),
         }
     }
 }

--- a/src-tauri/src/commands/separation.rs
+++ b/src-tauri/src/commands/separation.rs
@@ -15,9 +15,9 @@ use tauri::{AppHandle, State};
 // Re-export contract types and helpers for callers/tests that import from commands.
 pub use crate::services::separation::{
     completed_status, completed_status_with_model, failed_status, get_separation_status_from_map,
-    idle_status, running_status, SeparationCompleteEvent, SeparationErrorEvent,
-    SeparationProgressEvent, SeparationState, SEPARATION_COMPLETE_EVENT, SEPARATION_ERROR_EVENT,
-    SEPARATION_PROGRESS_EVENT,
+    idle_status, running_status, SeparationCancelledEvent, SeparationCompleteEvent,
+    SeparationErrorEvent, SeparationProgressEvent, SeparationState, SEPARATION_CANCELLED_EVENT,
+    SEPARATION_COMPLETE_EVENT, SEPARATION_ERROR_EVENT, SEPARATION_PROGRESS_EVENT,
 };
 
 #[tauri::command]
@@ -95,6 +95,14 @@ pub fn get_separation_status(
     song_id: String,
 ) -> CommandResult<SeparationStatusSnapshot> {
     separation::get_separation_status_from_map(&state.separation.separation_statuses, &song_id)
+}
+
+/// Request cancellation of a running single-song separation. No-op success if
+/// the song is not currently separating.
+#[tauri::command]
+pub fn cancel_separation(state: State<'_, AppState>, song_id: String) -> CommandResult<()> {
+    separation::request_cancel(&state.separation.separation_cancels, &song_id);
+    Ok(())
 }
 
 /// Returns separation statuses for all songs that have cached stems in the database.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -155,6 +155,7 @@ pub fn run() {
             commands::batch_separation::batch_separate,
             commands::batch_separation::cancel_batch_separation,
             commands::separation::separate,
+            commands::separation::cancel_separation,
             commands::separation::get_separation_status,
             commands::separation::get_all_separation_statuses,
             commands::separation::upgrade_to_four_stem,

--- a/src-tauri/src/separator/error.rs
+++ b/src-tauri/src/separator/error.rs
@@ -10,4 +10,18 @@ pub enum SeparationError {
 
     #[error("separation failed: {0}")]
     Failed(String),
+
+    /// A run was aborted at a cancellation checkpoint. The streaming writers
+    /// are dropped without finalizing, so no partial stem set is promoted.
+    #[error("separation was cancelled")]
+    Cancelled,
+}
+
+/// True when `error` (or any error it wraps via `anyhow` context) is a
+/// [`SeparationError::Cancelled`]. Used to distinguish an intentional
+/// cancellation from a genuine failure.
+pub fn is_cancelled(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<SeparationError>()
+        .is_some_and(|e| matches!(e, SeparationError::Cancelled))
 }

--- a/src-tauri/src/separator/inference.rs
+++ b/src-tauri/src/separator/inference.rs
@@ -21,10 +21,13 @@ use crate::{
     audio::decode::DecodedAudio,
     audio::encode::StreamingOggWriter,
     config::StemMode,
-    separator::{model::LoadedModel, preprocess, workspace::SeparationWorkspace},
+    separator::{
+        error::SeparationError, model::LoadedModel, preprocess, workspace::SeparationWorkspace,
+    },
 };
 use anyhow::{bail, Context, Result};
 use ort::{session::SessionInputValue, value::TensorRef};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 pub const DEMUCS_STEM_NAMES: [&str; 4] = ["drums", "bass", "other", "vocals"];
 /// Stem name order for two-stem bundles that provide vocals + accompaniment
@@ -282,6 +285,11 @@ fn chunk_schedule(input_frame_count: usize, chunk_size: usize) -> (usize, usize)
 /// correct output paths and for finalizing them after this function
 /// returns successfully. On error, the writers are dropped and their
 /// temp files are cleaned up automatically.
+///
+/// `cancel` is checked at the top of every chunk iteration. When it is set,
+/// the loop returns `SeparationError::Cancelled` without finalizing any
+/// writer, so an aborted run leaves no partial stem set (matching the
+/// interrupted-run restart-from-chunk-0 guarantee).
 #[allow(clippy::too_many_arguments)]
 pub fn separate_streaming(
     model: &LoadedModel,
@@ -289,6 +297,7 @@ pub fn separate_streaming(
     stem_mode: StemMode,
     writers: &mut StemWriters,
     workspace: &mut SeparationWorkspace,
+    cancel: &AtomicBool,
     mut on_chunk_complete: impl FnMut(usize, usize),
 ) -> Result<SeparationOutcome> {
     let channels = normalized_audio.channels;
@@ -318,6 +327,12 @@ pub fn separate_streaming(
 
     let mut chunk_index = 0usize;
     for chunk_start_frame in (0..input_frame_count).step_by(hop_size) {
+        // Cancellation checkpoint: bail before doing any work for this chunk.
+        // The writers are dropped on the error path, cleaning up temp files.
+        if cancel.load(Ordering::Relaxed) {
+            return Err(SeparationError::Cancelled.into());
+        }
+
         let chunk_frame_count = (input_frame_count - chunk_start_frame).min(chunk_size);
 
         // 1. Fill planar input directly from the normalized source.

--- a/src-tauri/src/separator/job.rs
+++ b/src-tauri/src/separator/job.rs
@@ -16,7 +16,7 @@ use anyhow::{Context, Result};
 use rusqlite::Connection;
 use std::{
     path::Path,
-    sync::{Arc, LazyLock, Mutex},
+    sync::{atomic::AtomicBool, Arc, LazyLock, Mutex},
 };
 
 /// Global lock that serializes audio decoding for separation jobs.
@@ -40,6 +40,7 @@ pub struct SeparationArtifacts {
     pub other_path: Option<String>,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn separate_song_into_cache(
     connection: &Connection,
     library_root: &LibraryRoot,
@@ -49,6 +50,7 @@ pub fn separate_song_into_cache(
     stem_mode: StemMode,
     model_variant: &str,
     ep_preference: ExecutionProviderPreference,
+    cancel: &AtomicBool,
     mut report_progress: impl FnMut(u8),
 ) -> Result<SeparationArtifacts> {
     if let Some(cached) =
@@ -276,6 +278,7 @@ pub fn separate_song_into_cache(
         stem_mode,
         &mut writers,
         &mut workspace,
+        cancel,
         inference_progress,
     )
     .with_context(|| format!("failed to separate stems for song {song_hash}"))?;

--- a/src-tauri/src/services/separation.rs
+++ b/src-tauri/src/services/separation.rs
@@ -26,6 +26,7 @@ use tauri::{AppHandle, Emitter, Manager, Runtime};
 pub const SEPARATION_PROGRESS_EVENT: &str = "separation-progress";
 pub const SEPARATION_COMPLETE_EVENT: &str = "separation-complete";
 pub const SEPARATION_ERROR_EVENT: &str = "separation-error";
+pub const SEPARATION_CANCELLED_EVENT: &str = "separation-cancelled";
 
 pub const BATCH_SEPARATION_PROGRESS_EVENT: &str = "batch-separation-progress";
 pub const BATCH_SEPARATION_COMPLETE_EVENT: &str = "batch-separation-complete";
@@ -71,6 +72,11 @@ pub struct SeparationCompleteEvent {
 pub struct SeparationErrorEvent {
     pub song_id: String,
     pub error: CommandError,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SeparationCancelledEvent {
+    pub song_id: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -192,6 +198,8 @@ pub struct SeparationExecutionContext {
     pub runtime_bootstrap_status: Arc<Mutex<RuntimeBootstrapStatusSnapshot>>,
     pub statuses: Arc<Mutex<HashMap<String, SeparationStatusSnapshot>>>,
     pub model_cache: Arc<Mutex<ModelCache<LoadedModel>>>,
+    pub cancels: Arc<Mutex<HashMap<String, Arc<AtomicBool>>>>,
+    pub batch_current_song: Arc<Mutex<Option<String>>>,
 }
 
 pub fn build_execution_context(state: &AppState) -> CommandResult<SeparationExecutionContext> {
@@ -223,7 +231,57 @@ pub fn build_execution_context(state: &AppState) -> CommandResult<SeparationExec
         runtime_bootstrap_status: Arc::clone(&state.shell.runtime_bootstrap_status),
         statuses: Arc::clone(&state.separation.separation_statuses),
         model_cache: Arc::clone(&state.separation.separator_model_cache),
+        cancels: Arc::clone(&state.separation.separation_cancels),
+        batch_current_song: Arc::clone(&state.separation.batch_current_song),
     })
+}
+
+/// Registry alias for per-song cancellation flags.
+pub type CancelRegistry = Arc<Mutex<HashMap<String, Arc<AtomicBool>>>>;
+
+/// Register a fresh cancellation flag for `song_id` and return it. The caller
+/// keeps the returned handle for the duration of the job and must call
+/// [`deregister_cancel_flag`] on exit (both success and failure paths).
+pub fn register_cancel_flag(cancels: &CancelRegistry, song_id: &str) -> Arc<AtomicBool> {
+    let flag = Arc::new(AtomicBool::new(false));
+    if let Ok(mut map) = cancels.lock() {
+        map.insert(song_id.to_owned(), Arc::clone(&flag));
+    }
+    flag
+}
+
+pub fn deregister_cancel_flag(cancels: &CancelRegistry, song_id: &str) {
+    if let Ok(mut map) = cancels.lock() {
+        map.remove(song_id);
+    }
+}
+
+/// Request cancellation of `song_id`. Returns `true` if the song was currently
+/// separating (a flag was set), `false` if it was not — a no-op success.
+pub fn request_cancel(cancels: &CancelRegistry, song_id: &str) -> bool {
+    if let Ok(map) = cancels.lock() {
+        if let Some(flag) = map.get(song_id) {
+            flag.store(true, Ordering::Relaxed);
+            return true;
+        }
+    }
+    false
+}
+
+/// Emit `separation-cancelled` and reset the song's status to idle. Cancelled
+/// runs never surface a `separation-error` event or an error toast.
+pub fn emit_separation_cancelled<R: Runtime>(
+    app_handle: &AppHandle<R>,
+    statuses: &Arc<Mutex<HashMap<String, SeparationStatusSnapshot>>>,
+    song_id: &str,
+) {
+    store_status(statuses, song_id, idle_status(song_id));
+    let _ = app_handle.emit(
+        SEPARATION_CANCELLED_EVENT,
+        SeparationCancelledEvent {
+            song_id: song_id.to_owned(),
+        },
+    );
 }
 
 /// Seam: production path uses command bootstrap helpers; tests can call
@@ -405,6 +463,7 @@ pub fn validate_song_can_be_separated(
 }
 
 /// Does not touch bootstrap or remote publish — those are caller responsibilities.
+#[allow(clippy::too_many_arguments)]
 pub fn run_job_blocking(
     library_root: &LibraryRoot,
     model_cache: &Arc<Mutex<ModelCache<LoadedModel>>>,
@@ -413,6 +472,7 @@ pub fn run_job_blocking(
     stem_mode: StemMode,
     model_variant: &str,
     ep_preference: ExecutionProviderPreference,
+    cancel: &AtomicBool,
     report_progress: impl FnMut(u8),
 ) -> CommandResult<SeparationArtifacts> {
     let connection = cache::open_database(&library_root.database_path())
@@ -426,6 +486,7 @@ pub fn run_job_blocking(
         stem_mode,
         model_variant,
         ep_preference,
+        cancel,
         report_progress,
     )
     .map_err(|error| SeparationError::Failed(error.to_string()).into())
@@ -448,15 +509,20 @@ pub fn start_job<R: Runtime>(
         runtime_bootstrap_status,
         statuses,
         model_cache,
+        cancels,
         stem_mode: _,
+        batch_current_song: _,
     } = execution_context;
     let progress_song_id = song_id.clone();
     let progress_app_handle = app_handle.clone();
     let progress_statuses = Arc::clone(&statuses);
 
+    let cancel_flag = register_cancel_flag(&cancels, &song_id);
+
     tauri::async_runtime::spawn(async move {
         let worker_library_root = library_root.clone();
         let worker_song_id = song_id.clone();
+        let worker_cancel = Arc::clone(&cancel_flag);
         let prerequisite_app_handle = app_handle.clone();
         let prerequisite_app_data_dir = app_data_dir.clone();
         let prerequisite_model_status = Arc::clone(&model_bootstrap_status);
@@ -485,6 +551,7 @@ pub fn start_job<R: Runtime>(
                 stem_mode,
                 &model_variant,
                 ep_preference,
+                &worker_cancel,
                 |percent| {
                     report_progress_to_status_and_events(
                         &progress_app_handle,
@@ -496,6 +563,16 @@ pub fn start_job<R: Runtime>(
             )
         })
         .await;
+
+        let requested_cancel = cancel_flag.load(Ordering::Relaxed);
+        deregister_cancel_flag(&cancels, &song_id);
+
+        // A run that finished successfully completed before cancellation could
+        // take effect, so only failures are reinterpreted as cancellations.
+        if requested_cancel && !matches!(result, Ok(Ok(_))) {
+            emit_separation_cancelled(&app_handle, &statuses, &song_id);
+            return;
+        }
 
         let final_status = match result {
             Ok(Ok(artifacts)) => status_from_job_result(&song_id, Ok(artifacts)),
@@ -589,6 +666,8 @@ pub fn start_batch_job<R: Runtime>(
         runtime_bootstrap_status,
         statuses: separation_statuses,
         model_cache,
+        cancels,
+        batch_current_song,
     } = execution_context;
 
     let total = plan.to_separate.len();
@@ -697,6 +776,13 @@ pub fn start_batch_job<R: Runtime>(
                 }
             }
 
+            // Register this song's cancel flag and mark it current so a batch
+            // cancel can flag it and stop mid-song.
+            let cancel_flag = register_cancel_flag(&cancels, song_id);
+            if let Ok(mut current) = batch_current_song.lock() {
+                *current = Some(song_id.clone());
+            }
+
             let _ = app_handle.emit(
                 BATCH_SEPARATION_PROGRESS_EVENT,
                 BatchSeparationProgress {
@@ -714,6 +800,7 @@ pub fn start_batch_job<R: Runtime>(
             let worker_song_id = song_id.clone();
             let worker_statuses = Arc::clone(&separation_statuses);
             let worker_model_cache = Arc::clone(&model_cache);
+            let worker_cancel = Arc::clone(&cancel_flag);
             let progress_song_id = song_id.clone();
             let progress_app_handle = app_handle.clone();
             let batch_progress_app_handle = app_handle.clone();
@@ -732,6 +819,7 @@ pub fn start_batch_job<R: Runtime>(
                     stem_mode,
                     &worker_model_variant,
                     ep_preference,
+                    &worker_cancel,
                     |percent| {
                         report_progress_to_status_and_events(
                             &progress_app_handle,
@@ -755,6 +843,12 @@ pub fn start_batch_job<R: Runtime>(
             })
             .await;
 
+            let requested_cancel = cancel_flag.load(Ordering::Relaxed);
+            deregister_cancel_flag(&cancels, song_id);
+            if let Ok(mut current) = batch_current_song.lock() {
+                *current = None;
+            }
+
             match result {
                 Ok(Ok(artifacts)) => {
                     let status = status_from_job_result(song_id, Ok(artifacts));
@@ -765,15 +859,24 @@ pub fn start_batch_job<R: Runtime>(
                     completed += 1;
                 }
                 Ok(Err(error)) => {
-                    let status = status_from_job_result(song_id, Err(error));
-                    emit_terminal_status(&app_handle, &separation_statuses, status, |_| {});
-                    failed_count += 1;
+                    if requested_cancel {
+                        emit_separation_cancelled(&app_handle, &separation_statuses, song_id);
+                    } else {
+                        let status = status_from_job_result(song_id, Err(error));
+                        emit_terminal_status(&app_handle, &separation_statuses, status, |_| {});
+                        failed_count += 1;
+                    }
                 }
                 Err(error) => {
-                    let cmd_error: CommandError = SeparationError::Failed(error.to_string()).into();
-                    let status = status_from_job_result(song_id, Err(cmd_error));
-                    emit_terminal_status(&app_handle, &separation_statuses, status, |_| {});
-                    failed_count += 1;
+                    if requested_cancel {
+                        emit_separation_cancelled(&app_handle, &separation_statuses, song_id);
+                    } else {
+                        let cmd_error: CommandError =
+                            SeparationError::Failed(error.to_string()).into();
+                        let status = status_from_job_result(song_id, Err(cmd_error));
+                        emit_terminal_status(&app_handle, &separation_statuses, status, |_| {});
+                        failed_count += 1;
+                    }
                 }
             }
         }
@@ -885,11 +988,14 @@ pub fn downgrade_to_two_stem_and_publish<R: Runtime>(
         cache::stems::downgrade_to_two_stem(&connection, &library_root, song_id)
             .map_err(|e| SeparationError::Failed(e.to_string()))?;
 
+    // `cache_hit` drives the "Using cached separation" cue on the completion
+    // event. A downgrade is an explicit user action, not a cache-served
+    // separation request, so it must not raise that cue.
     let completed = completed_status(
         song_id,
         &updated_entry.vocals_path,
         &updated_entry.accomp_path,
-        true,
+        false,
         updated_entry.drums_path,
         updated_entry.bass_path,
         updated_entry.other_path,
@@ -1021,6 +1127,44 @@ mod tests {
             .expect_err("instrumental songs should be rejected");
 
         assert!(error.message.contains("marked instrumental"));
+    }
+
+    #[test]
+    fn request_cancel_flags_only_the_target_song() {
+        let cancels: CancelRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let flag_a = register_cancel_flag(&cancels, "song-a");
+        let flag_b = register_cancel_flag(&cancels, "song-b");
+
+        assert!(
+            request_cancel(&cancels, "song-a"),
+            "cancelling a registered song should report success"
+        );
+        assert!(flag_a.load(Ordering::Relaxed), "target flag must be set");
+        assert!(
+            !flag_b.load(Ordering::Relaxed),
+            "unrelated song flag must be untouched"
+        );
+    }
+
+    #[test]
+    fn request_cancel_is_a_noop_for_unknown_song() {
+        let cancels: CancelRegistry = Arc::new(Mutex::new(HashMap::new()));
+        assert!(
+            !request_cancel(&cancels, "never-registered"),
+            "cancelling an unregistered song must be a no-op returning false"
+        );
+    }
+
+    #[test]
+    fn deregister_cancel_flag_removes_the_entry() {
+        let cancels: CancelRegistry = Arc::new(Mutex::new(HashMap::new()));
+        register_cancel_flag(&cancels, "song-a");
+        deregister_cancel_flag(&cancels, "song-a");
+
+        assert!(
+            !request_cancel(&cancels, "song-a"),
+            "a deregistered song can no longer be cancelled"
+        );
     }
 
     #[test]

--- a/src-tauri/src/smoke.rs
+++ b/src-tauri/src/smoke.rs
@@ -203,6 +203,7 @@ pub fn run_local_audio_smoke(config: LocalAudioSmokeConfig) -> Result<LocalAudio
                             StemMode::default(),
                             "htdemucs",
                             ep_preference,
+                            &std::sync::atomic::AtomicBool::new(false),
                             |_| {},
                         ) {
                             Ok(artifacts) => (

--- a/src-tauri/src/state/separation.rs
+++ b/src-tauri/src/state/separation.rs
@@ -11,6 +11,13 @@ pub struct SeparationState {
     pub separator_model_cache: Arc<Mutex<ModelCache<LoadedModel>>>,
     pub batch_running: Arc<AtomicBool>,
     pub batch_cancel: Arc<AtomicBool>,
+    /// Per-song cancellation flags (song_hash → flag). A running job registers
+    /// its flag on start and removes it on exit; `cancel_separation` sets a
+    /// flag to request an early return from the chunk loop.
+    pub separation_cancels: Arc<Mutex<HashMap<String, Arc<AtomicBool>>>>,
+    /// The song currently being processed by the batch loop, so batch cancel
+    /// can flag it and stop mid-song instead of after the current track.
+    pub batch_current_song: Arc<Mutex<Option<String>>>,
 }
 
 impl Default for SeparationState {
@@ -26,6 +33,8 @@ impl SeparationState {
             separator_model_cache: Arc::new(Mutex::new(ModelCache::default())),
             batch_running: Arc::new(AtomicBool::new(false)),
             batch_cancel: Arc::new(AtomicBool::new(false)),
+            separation_cancels: Arc::new(Mutex::new(HashMap::new())),
+            batch_current_song: Arc::new(Mutex::new(None)),
         }
     }
 

--- a/src-tauri/tests/phase3_inference.rs
+++ b/src-tauri/tests/phase3_inference.rs
@@ -1,6 +1,7 @@
 use std::{
     fs,
     path::{Path, PathBuf},
+    sync::atomic::{AtomicBool, Ordering},
 };
 
 mod support;
@@ -109,6 +110,7 @@ fn separate_four_stem_to_dir(
         StemMode::FourStem,
         &mut writers,
         &mut workspace,
+        &AtomicBool::new(false),
         |_, _| {},
     )
     .expect("streaming separation should succeed");
@@ -116,6 +118,164 @@ fn separate_four_stem_to_dir(
     writers.finish_all().expect("writers should finalize");
 
     normalized
+}
+
+/// Run a cancellable FourStem streaming pass. The writers are intentionally
+/// NOT finalized, so on the cancel path they are dropped and their temp files
+/// cleaned up — no final stem files should ever be promoted.
+fn run_streaming_with_cancel(
+    decoded: openkara_lib::audio::decode::DecodedAudio,
+    output_dir: &Path,
+    cancel: &AtomicBool,
+    on_chunk: impl FnMut(usize, usize),
+) -> anyhow::Result<()> {
+    initialize_test_runtime();
+    let loaded_model = model::load_from_path(&model_path(), ExecutionProviderPreference::Cpu)
+        .expect("demucs model should load");
+
+    let normalized =
+        preprocess::normalize_audio_for_model(decoded).expect("audio should normalize for model");
+
+    let channels = normalized.channels;
+    let input_frame_count = normalized.samples.len() / channels;
+    let chunk_size =
+        preprocess::target_frame_count(&loaded_model, input_frame_count).expect("chunk size");
+    let hop_size = chunk_size / 2;
+
+    fs::create_dir_all(output_dir).expect("output dir should be created");
+
+    let sample_rate = normalized.sample_rate;
+    let mut writers = StemWriters {
+        mode: StemMode::FourStem,
+        vocals: StreamingOggWriter::new(
+            &output_dir.join("vocals.ogg"),
+            sample_rate,
+            channels,
+            None,
+            None,
+        )
+        .expect("vocals writer"),
+        accompaniment: None,
+        drums: Some(
+            StreamingOggWriter::new(
+                &output_dir.join("drums.ogg"),
+                sample_rate,
+                channels,
+                None,
+                None,
+            )
+            .expect("drums writer"),
+        ),
+        bass: Some(
+            StreamingOggWriter::new(
+                &output_dir.join("bass.ogg"),
+                sample_rate,
+                channels,
+                None,
+                None,
+            )
+            .expect("bass writer"),
+        ),
+        other: Some(
+            StreamingOggWriter::new(
+                &output_dir.join("other.ogg"),
+                sample_rate,
+                channels,
+                None,
+                None,
+            )
+            .expect("other writer"),
+        ),
+    };
+
+    let mut workspace = SeparationWorkspace::new(
+        StemMode::FourStem,
+        channels,
+        chunk_size,
+        hop_size,
+        input_frame_count,
+    );
+
+    inference::separate_streaming(
+        &loaded_model,
+        &normalized,
+        StemMode::FourStem,
+        &mut writers,
+        &mut workspace,
+        cancel,
+        on_chunk,
+    )
+    .map(|_| ())
+}
+
+fn assert_no_stem_files(output_dir: &Path) {
+    for stem_name in ["vocals", "drums", "bass", "other"] {
+        let stem_path = output_dir.join(format!("{stem_name}.ogg"));
+        assert!(
+            !stem_path.exists(),
+            "{} must not exist after a cancelled run",
+            stem_path.display()
+        );
+    }
+}
+
+#[test]
+fn streaming_separation_cancelled_before_first_chunk_writes_no_stems() {
+    let decoded = decode::decode_file(&fixture_path("audio", "fixture.wav"))
+        .expect("wav fixture should decode");
+
+    let output_dir = unique_output_dir();
+    cleanup_dir(&output_dir);
+
+    let cancel = AtomicBool::new(true);
+    let result = run_streaming_with_cancel(decoded, &output_dir, &cancel, |_, _| {});
+
+    let error = result.expect_err("a pre-cancelled run must return an error");
+    assert!(
+        openkara_lib::separator::error::is_cancelled(&error),
+        "error should be the cancellation sentinel, got: {error:?}"
+    );
+    assert_no_stem_files(&output_dir);
+
+    cleanup_dir(&output_dir);
+}
+
+#[test]
+fn streaming_separation_cancelled_after_first_chunk_writes_no_stems() {
+    let fixture = decode::decode_file(&fixture_path("audio", "fixture.wav"))
+        .expect("wav fixture should decode");
+    // Repeat so the schedule spans multiple chunks and a later iteration hits
+    // the cancellation checkpoint.
+    let mut long_audio = fixture.clone();
+    long_audio.samples = fixture.samples.repeat(8);
+
+    let output_dir = unique_output_dir();
+    cleanup_dir(&output_dir);
+
+    let cancel = AtomicBool::new(false);
+    let mut chunks_completed = 0usize;
+    let result =
+        run_streaming_with_cancel(long_audio, &output_dir, &cancel, |completed, _total| {
+            chunks_completed = completed;
+            // Flag cancellation after the first chunk finishes; the next iteration
+            // checkpoint returns early.
+            if completed == 1 {
+                cancel.store(true, Ordering::SeqCst);
+            }
+        });
+
+    let error = result.expect_err("a mid-run cancellation must return an error");
+    assert!(
+        openkara_lib::separator::error::is_cancelled(&error),
+        "error should be the cancellation sentinel, got: {error:?}"
+    );
+    assert!(
+        chunks_completed >= 1,
+        "at least one chunk should complete before cancellation"
+    );
+    assert_no_stem_files(&output_dir);
+
+    cleanup_dir(&output_dir);
 }
 
 #[test]

--- a/src-tauri/tests/phase3_job.rs
+++ b/src-tauri/tests/phase3_job.rs
@@ -94,6 +94,7 @@ fn separation_job_reports_monotonic_progress_and_hits_cache_on_second_run() {
         StemMode::default(),
         "htdemucs",
         ExecutionProviderPreference::Cpu,
+        &std::sync::atomic::AtomicBool::new(false),
         |percent| first_progress.push(percent),
     )
     .expect("first separation should succeed");
@@ -116,6 +117,7 @@ fn separation_job_reports_monotonic_progress_and_hits_cache_on_second_run() {
         StemMode::default(),
         "htdemucs",
         ExecutionProviderPreference::Cpu,
+        &std::sync::atomic::AtomicBool::new(false),
         |percent| second_progress.push(percent),
     )
     .expect("second separation should hit cache");

--- a/src-tauri/tests/phase5_flow.rs
+++ b/src-tauri/tests/phase5_flow.rs
@@ -101,6 +101,7 @@ fn backend_karaoke_flow_imports_plays_separates_fetches_lyrics_and_switches_mode
         StemMode::default(),
         "htdemucs",
         ExecutionProviderPreference::Cpu,
+        &std::sync::atomic::AtomicBool::new(false),
         |_| {},
     )
     .expect("separation should succeed for the imported fixture");

--- a/src/components/Layout/GlobalProgressBar.test.tsx
+++ b/src/components/Layout/GlobalProgressBar.test.tsx
@@ -1,6 +1,10 @@
+// @vitest-environment jsdom
+
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { GlobalProgressBar } from "./GlobalProgressBar";
+import * as api from "@/lib/tauri";
 import type {
   SeparationStatusSnapshot,
   Song,
@@ -39,6 +43,7 @@ vi.mock("@/stores/bootstrap-store", () => ({
 
 vi.mock("@/lib/tauri", () => ({
   cancelBatchSeparation: vi.fn(() => Promise.resolve()),
+  cancelSeparation: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock("@/lib/errors", () => ({
@@ -46,6 +51,38 @@ vi.mock("@/lib/errors", () => ({
 }));
 
 describe("GlobalProgressBar", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  test("cancels a single-song separation when its cancel affordance is clicked", () => {
+    mockLibraryState.batchSeparation = null;
+    mockLibraryState.uploadStatuses = {};
+    mockLibraryState.separationStatuses = {
+      "song-cancel": {
+        song_id: "song-cancel",
+        state: "running",
+        percent: 20,
+        cache_hit: false,
+        vocals_path: null,
+        accomp_path: null,
+        drums_path: null,
+        bass_path: null,
+        other_path: null,
+        model_variant: null,
+        error: null,
+      },
+    };
+    mockLibraryState.songs = [];
+
+    const { getByRole } = render(<GlobalProgressBar />);
+    fireEvent.click(getByRole("button"));
+
+    expect(api.cancelSeparation).toHaveBeenCalledWith("song-cancel");
+
+    mockLibraryState.separationStatuses = {};
+  });
   test("renders separation and upload tasks with the shared task bar", () => {
     mockLibraryState.separationStatuses = {
       "song-separate": {

--- a/src/components/Layout/GlobalProgressBar.tsx
+++ b/src/components/Layout/GlobalProgressBar.tsx
@@ -174,6 +174,8 @@ function useActiveTasks(modelDownloadCompleteFlash: boolean): ActiveTask[] {
         key: `sep-${runningSep.song_id}`,
         label: t("progress.separating", { title }),
         percent: runningSep.percent,
+        onCancel: () =>
+          api.cancelSeparation(runningSep.song_id).catch(notifyError),
       });
     }
   }

--- a/src/components/Library/SongListItem.test.tsx
+++ b/src/components/Library/SongListItem.test.tsx
@@ -1,5 +1,9 @@
+// @vitest-environment jsdom
+
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import * as api from "@/lib/tauri";
 import { SongListItem } from "./SongListItem";
 import { buildSongListContextMenuItems } from "./song-list-item-menu";
 
@@ -97,6 +101,7 @@ vi.mock("@/stores/queue-store", () => ({
 
 vi.mock("@/lib/tauri", () => ({
   separate: vi.fn(),
+  cancelSeparation: vi.fn(() => Promise.resolve()),
   deleteSongs: vi.fn(),
   batchSeparate: vi.fn(),
   extractEmbeddedLyrics: vi.fn(),
@@ -131,6 +136,59 @@ vi.mock("./SongPropertiesDialog", () => ({
 }));
 
 describe("SongListItem", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  test("shows a cancel affordance while separating and calls the API on click", () => {
+    mockLibraryState.selectedSongIds = new Set();
+    mockLibraryState.separationStatuses = {
+      "song-cancel": {
+        song_id: "song-cancel",
+        state: "running",
+        percent: 30,
+        cache_hit: false,
+        vocals_path: null,
+        accomp_path: null,
+        drums_path: null,
+        bass_path: null,
+        other_path: null,
+        model_variant: null,
+        error: null,
+      },
+    };
+
+    const { getByLabelText } = render(
+      <SongListItem
+        song={{
+          hash: "song-cancel",
+          file_path: "Artist/Song.mp3",
+          audio_source_kind: "original",
+          cdg_path: null,
+          media_g_container: null,
+          instrumental: false,
+          language: null,
+          title: "Song",
+          artist: "Artist",
+          album: null,
+          duration_ms: 180000,
+          cover_art: null,
+          has_cover_art: false,
+          imported_at: 0,
+          original_ext: "mp3",
+        }}
+        orderedHashes={["song-cancel"]}
+      />,
+    );
+
+    fireEvent.click(getByLabelText("library.cancelSeparation"));
+
+    expect(api.cancelSeparation).toHaveBeenCalledWith("song-cancel");
+
+    mockLibraryState.separationStatuses = {};
+  });
+
   test("renders media-g badges and duration in the trailing metadata slot", () => {
     const markup = renderToStaticMarkup(
       <SongListItem

--- a/src/components/Library/SongListItem.tsx
+++ b/src/components/Library/SongListItem.tsx
@@ -1,6 +1,6 @@
 import { useState, type CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
-import { Loader2 } from "lucide-react";
+import { Loader2, X } from "lucide-react";
 import { CoverArtThumbnail } from "@/components/Shared/CoverArtThumbnail";
 import { useBootstrapStore } from "@/stores/bootstrap-store";
 import { useLibraryStore } from "@/stores/library-store";
@@ -87,6 +87,11 @@ export function SongListItem({ song, orderedHashes }: SongListItemProps) {
   const handleSeparate = (e: React.MouseEvent) => {
     e.stopPropagation();
     api.separate(song.hash).catch((err) => notifyError(err));
+  };
+
+  const handleCancelSeparation = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    api.cancelSeparation(song.hash).catch((err) => notifyError(err));
   };
 
   const handleDeleteSongs = async (songIds: string[]) => {
@@ -238,6 +243,15 @@ export function SongListItem({ song, orderedHashes }: SongListItemProps) {
               <div className="flex items-center gap-1 text-[11px] text-[var(--color-text-dim)]">
                 <Loader2 size={10} className="animate-spin" />
                 <span>{separationStatus?.percent ?? 0}%</span>
+                <button
+                  onClick={handleCancelSeparation}
+                  title={t("library.cancelSeparation")}
+                  aria-label={t("library.cancelSeparation")}
+                  className="motion-icon-button rounded p-0.5 text-[var(--color-text-dim)] hover:bg-[var(--sidebar-row-overlay-bg)] hover:text-[var(--color-text)]"
+                  data-native-overlay-surface="song-action"
+                >
+                  <X size={12} />
+                </button>
               </div>
             )}
             {sepState === "completed" && (

--- a/src/hooks/use-playback-runtime.test.tsx
+++ b/src/hooks/use-playback-runtime.test.tsx
@@ -15,13 +15,17 @@ import type {
   TrackTransitionedEvent,
 } from "@/types/ipc";
 
-const { mockListen, mockSetPreloadCandidate, mockNotifyError } = vi.hoisted(
-  () => ({
-    mockListen: vi.fn(),
-    mockSetPreloadCandidate: vi.fn(),
-    mockNotifyError: vi.fn(),
-  }),
-);
+const {
+  mockListen,
+  mockSetPreloadCandidate,
+  mockNotifyError,
+  mockNotifySuccess,
+} = vi.hoisted(() => ({
+  mockListen: vi.fn(),
+  mockSetPreloadCandidate: vi.fn(),
+  mockNotifyError: vi.fn(),
+  mockNotifySuccess: vi.fn(),
+}));
 
 vi.mock("@tauri-apps/api/event", () => ({
   listen: mockListen,
@@ -37,6 +41,7 @@ vi.mock("@/lib/tauri", async (importOriginal) => {
 
 vi.mock("@/lib/errors", () => ({
   notifyError: mockNotifyError,
+  notifySuccess: mockNotifySuccess,
 }));
 
 // Track every rendered root so afterEach can unmount them all. Without this,
@@ -124,6 +129,7 @@ describe("usePreloadCandidateEffect", () => {
     mockSetPreloadCandidate.mockReset();
     mockSetPreloadCandidate.mockResolvedValue(undefined);
     mockNotifyError.mockReset();
+    mockNotifySuccess.mockReset();
     usePlayerStore.setState({
       snapshot: null,
       positionMs: 0,
@@ -210,6 +216,7 @@ describe("useTrackTransitionedQueueReconcile", () => {
     mockSetPreloadCandidate.mockReset();
     mockSetPreloadCandidate.mockResolvedValue(undefined);
     mockNotifyError.mockReset();
+    mockNotifySuccess.mockReset();
     usePlayerStore.setState({
       snapshot: null,
       positionMs: 0,
@@ -289,6 +296,7 @@ describe("usePlaybackPositionSubscription", () => {
     mockSetPreloadCandidate.mockReset();
     mockSetPreloadCandidate.mockResolvedValue(undefined);
     mockNotifyError.mockReset();
+    mockNotifySuccess.mockReset();
     usePlayerStore.setState({
       snapshot: null,
       positionMs: 0,
@@ -408,6 +416,7 @@ describe("useSeparationEvents", () => {
     mockSetPreloadCandidate.mockReset();
     mockSetPreloadCandidate.mockResolvedValue(undefined);
     mockNotifyError.mockReset();
+    mockNotifySuccess.mockReset();
     usePlayerStore.setState({
       snapshot: null,
       positionMs: 0,
@@ -549,6 +558,62 @@ describe("useSeparationEvents", () => {
 
     expect(updateSeparationStatus).toHaveBeenCalled();
     expect(mockNotifyError).toHaveBeenCalledWith("decode failed");
+  });
+
+  test("resets separation status to idle on separation-cancelled events", async () => {
+    const updateSeparationStatus = vi.fn();
+    useLibraryStore.setState({ updateSeparationStatus } as never);
+
+    const listeners = new Map<string, (e: { payload: unknown }) => void>();
+    mockListen.mockImplementation(
+      async (eventName: string, handler: (e: { payload: unknown }) => void) => {
+        listeners.set(eventName, handler);
+        return () => {};
+      },
+    );
+
+    const { useEventListeners } = await import("./use-playback-runtime");
+    await renderHook(() => useEventListeners(true));
+
+    const handler = listeners.get("separation-cancelled");
+    expect(handler).not.toBeUndefined();
+
+    handler!({ payload: { song_id: "song-a" } });
+
+    expect(updateSeparationStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ song_id: "song-a", state: "idle" }),
+    );
+    expect(mockNotifyError).not.toHaveBeenCalled();
+  });
+
+  test("surfaces a cache-hit toast when separation-complete reports cache_hit", async () => {
+    const updateSeparationStatus = vi.fn();
+    const loadStems = vi.fn().mockResolvedValue(undefined);
+    usePlayerStore.setState({ loadStems } as never);
+    useLibraryStore.setState({ updateSeparationStatus } as never);
+
+    const listeners = new Map<string, (e: { payload: unknown }) => void>();
+    mockListen.mockImplementation(
+      async (eventName: string, handler: (e: { payload: unknown }) => void) => {
+        listeners.set(eventName, handler);
+        return () => {};
+      },
+    );
+
+    const { useEventListeners } = await import("./use-playback-runtime");
+    await renderHook(() => useEventListeners(true));
+
+    const handler = listeners.get("separation-complete");
+    expect(handler).not.toBeUndefined();
+
+    handler!({
+      payload: {
+        song_id: "song-a",
+        status: { state: "completed", cache_hit: true },
+      },
+    });
+
+    expect(mockNotifySuccess).toHaveBeenCalledOnce();
   });
 
   test("updates separation status on separation-progress events", async () => {

--- a/src/hooks/use-playback-runtime.ts
+++ b/src/hooks/use-playback-runtime.ts
@@ -9,12 +9,13 @@ import { useLyricsStore } from "@/stores/lyrics-store";
 import { useBootstrapStore } from "@/stores/bootstrap-store";
 import { useRuntimeBootstrapStore } from "@/stores/runtime-bootstrap-store";
 import { useSettingsStore } from "@/stores/settings-store";
-import { notifyError } from "@/lib/errors";
+import { notifyError, notifySuccess } from "@/lib/errors";
 import i18next, { detectSystemLanguage } from "@/lib/i18n";
 import * as api from "@/lib/tauri";
 import {
   createBatchSeparationClearScheduler,
   createStatusClearScheduler,
+  separationCancelledStatus,
   separationErrorStatus,
   separationProgressStatus,
   uploadCompleteStatus,
@@ -32,6 +33,7 @@ import type {
   RemotePlaybackReconnectEvent,
   RemotePlaybackResyncEvent,
   RuntimeBootstrapStatusSnapshot,
+  SeparationCancelledEvent,
   SeparationCompleteEvent,
   SeparationErrorEvent,
   SeparationProgressEvent,
@@ -143,6 +145,13 @@ function useSeparationEvents(enabled: boolean) {
           if (cancelled) return;
           updateSeparationStatus(e.payload.status);
 
+          // An instant completion whose stems were already cached: surface a
+          // lightweight cue instead of leaving it indistinguishable from a
+          // fresh run.
+          if (e.payload.status.cache_hit) {
+            notifySuccess(i18next.t("library.usingCachedSeparation"));
+          }
+
           if (e.payload.song_id === currentSongIdRef.current) {
             loadStems().catch((err) => notifyError(err));
           }
@@ -159,12 +168,28 @@ function useSeparationEvents(enabled: boolean) {
         },
       );
 
+      // Cancelled runs reset the row to idle with no error toast.
+      const cancelledUnlisten = await listen<SeparationCancelledEvent>(
+        "separation-cancelled",
+        (e) => {
+          if (!cancelled) {
+            updateSeparationStatus(separationCancelledStatus(e.payload));
+          }
+        },
+      );
+
       if (cancelled) {
         progressUnlisten();
         completeUnlisten();
         errorUnlisten();
+        cancelledUnlisten();
       } else {
-        unlisteners.push(progressUnlisten, completeUnlisten, errorUnlisten);
+        unlisteners.push(
+          progressUnlisten,
+          completeUnlisten,
+          errorUnlisten,
+          cancelledUnlisten,
+        );
       }
     };
 

--- a/src/lib/tauri/separation.ts
+++ b/src/lib/tauri/separation.ts
@@ -5,6 +5,10 @@ export function separate(songId: string): Promise<SeparationStatusSnapshot> {
   return invoke<SeparationStatusSnapshot>("separate", { songId });
 }
 
+export function cancelSeparation(songId: string): Promise<void> {
+  return invoke<void>("cancel_separation", { songId });
+}
+
 export function getSeparationStatus(
   songId: string,
 ): Promise<SeparationStatusSnapshot> {

--- a/src/lib/tauri/tauri-wrappers.test.ts
+++ b/src/lib/tauri/tauri-wrappers.test.ts
@@ -728,6 +728,14 @@ describe("separation", () => {
     expect(returned).toBe(sepStatus);
   });
 
+  test("cancelSeparation invokes cancel_separation with songId", async () => {
+    mockInvoke.mockResolvedValueOnce(undefined);
+    await separation.cancelSeparation("song-1");
+    expect(mockInvoke).toHaveBeenCalledWith("cancel_separation", {
+      songId: "song-1",
+    });
+  });
+
   test("getSeparationStatus invokes get_separation_status", async () => {
     mockInvoke.mockResolvedValueOnce(sepStatus);
     const returned = await separation.getSeparationStatus("song-1");

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -158,7 +158,9 @@
       "confirmMessage": "Import {{songCount}} songs?",
       "confirmOk": "Import"
     },
-    "modelPreparing": "Preparing separation model…"
+    "modelPreparing": "Preparing separation model…",
+    "cancelSeparation": "Cancel separation",
+    "usingCachedSeparation": "Using cached separation"
   },
   "player": {
     "previous": "Previous",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -158,7 +158,9 @@
       "confirmMessage": "是否导入 {{songCount}} 首歌曲？",
       "confirmOk": "导入"
     },
-    "modelPreparing": "正在准备分离模型…"
+    "modelPreparing": "正在准备分离模型…",
+    "cancelSeparation": "取消分离",
+    "usingCachedSeparation": "已使用缓存的分离结果"
   },
   "player": {
     "previous": "上一首",

--- a/src/runtime/event-reducers.test.ts
+++ b/src/runtime/event-reducers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from "vitest";
 import {
   createBatchSeparationClearScheduler,
   createStatusClearScheduler,
+  separationCancelledStatus,
   separationErrorStatus,
   separationProgressStatus,
   uploadCompleteStatus,
@@ -32,6 +33,14 @@ describe("event reducers", () => {
       state: "failed",
       percent: 0,
       error,
+    });
+
+    expect(separationCancelledStatus({ song_id: "song-1" })).toMatchObject({
+      song_id: "song-1",
+      state: "idle",
+      percent: 0,
+      cache_hit: false,
+      error: null,
     });
   });
 

--- a/src/runtime/event-reducers.ts
+++ b/src/runtime/event-reducers.ts
@@ -1,4 +1,5 @@
 import type {
+  SeparationCancelledEvent,
   SeparationErrorEvent,
   SeparationProgressEvent,
   SeparationStatusSnapshot,
@@ -43,6 +44,24 @@ export function separationErrorStatus(
     other_path: null,
     model_variant: null,
     error: event.error,
+  };
+}
+
+export function separationCancelledStatus(
+  event: SeparationCancelledEvent,
+): SeparationStatusSnapshot {
+  return {
+    song_id: event.song_id,
+    state: "idle",
+    percent: 0,
+    cache_hit: false,
+    vocals_path: null,
+    accomp_path: null,
+    drums_path: null,
+    bass_path: null,
+    other_path: null,
+    model_variant: null,
+    error: null,
   };
 }
 

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -477,6 +477,10 @@ export interface SeparationErrorEvent {
   error: CommandError;
 }
 
+export interface SeparationCancelledEvent {
+  song_id: string;
+}
+
 export type UploadState = "idle" | "running" | "completed" | "failed";
 
 export interface UploadStatusSnapshot {


### PR DESCRIPTION
## Summary

Implements #180 and #181 — the two remaining UX gaps from the model-management audit.

### Cancel a running single-song separation (#180)

- `separate_streaming` gains a cancellation checkpoint at the top of every chunk iteration; cancellation returns the new typed `SeparationError::Cancelled`. The #176 streaming-writer semantics guarantee an aborted run promotes nothing: temp files are dropped, no cache entry is registered, restart is from chunk 0.
- Per-song cancel registry in the separation service (register on job start, deregister on both exit paths); new `cancel_separation(song_id)` command (no-op success when the song is not separating).
- Batch cancel now also flags the in-flight song, so cancelling a batch stops mid-song instead of after the current track.
- A cancelled run emits `separation-cancelled` (never `separation-error`) and resets the row to idle — no error toast. `ErrorCode` stays a frozen 12-value contract.
- UI: ✕ cancel affordance on the running `SongListItem` row and on the global progress bar for single runs; en/zh-CN copy.

### Cache-hit surfacing (#181)

The backend already populated `cache_hit` end-to-end; it was simply never displayed. A `separation-complete` event with `cache_hit=true` now shows a lightweight "Using cached separation / 已使用缓存的分离结果" toast. The explicit downgrade path sets `cache_hit=false` so downgrades don't raise the misleading cue.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`
- `cargo nextest run` (excluding the perf-threshold binary): 1142 passed, including two new real-model cancellation tests (pre-set flag and cancel-after-first-chunk both leave zero final stem files)
- `npx vitest run`: 1900 passed; `npx tsc --noEmit`, `pnpm lint` clean

Closes #180. Closes #181.
