### PR TITLE
fix(hooks): stop passing oxfmt-ignored src-tauri files to the pre-commit hook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,7 +3,10 @@ pre-commit:
   commands:
     oxfmt:
       glob: "*.{ts,tsx,js,jsx,json,css,md,html,yml,yaml}"
-      exclude: "pnpm-lock.yaml"
+      # src-tauri is entirely in oxfmt's ignorePatterns; passing only
+      # ignored files (e.g. a catalog snapshot bump) makes oxfmt exit
+      # non-zero with "no files to format" and blocks the commit.
+      exclude: 'pnpm-lock\.yaml|^src-tauri/'
       run: pnpm exec oxfmt {staged_files}
       stage_fixed: true
     cargo-fmt:


### PR DESCRIPTION
Pure-JSON commits under `src-tauri/` (catalog snapshot bumps) are blocked at pre-commit: the lefthook glob matches `*.json`, but `src-tauri` is entirely inside `.oxfmtrc.json` `ignorePatterns`, so oxfmt receives only ignored files and exits 2:

```
$ pnpm exec oxfmt src-tauri/catalog/stable-pointer.json; echo $?
Expected at least one target file. All matched files may have been excluded by ignore rules.
2
```

Fix: exclude `^src-tauri/` in the lefthook `oxfmt` command, mirroring the formatter's own ignore. Catalog snapshot files are byte-exact by contract (SHA-256 is the trust anchor) and must never be touched by a formatter, so this also removes a footgun. The pre-push `format-check` (whole-repo `oxfmt --check`) is unaffected — it applies the same ignorePatterns itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)