### PR TITLE
ci(separator): cross-target spectral candidate validation (#172 PR 4)

### DIFF
--- a/.github/workflows/spectral-candidate.yml
+++ b/.github/workflows/spectral-candidate.yml
@@ -96,12 +96,14 @@ jobs:
       - name: Resolve spectral candidate from the ${{ inputs.channel }} channel
         id: spectral
         shell: bash
+        env:
+          CHANNEL: ${{ inputs.channel }}
         run: |
           {
-            echo "url=$(node scripts/fetch-candidate-model.mjs --channel "${{ inputs.channel }}" --field url)"
-            echo "sha256=$(node scripts/fetch-candidate-model.mjs --channel "${{ inputs.channel }}" --field sha256)"
-            echo "file=$(node scripts/fetch-candidate-model.mjs --channel "${{ inputs.channel }}" --field filename)"
-            echo "release=$(node scripts/fetch-candidate-model.mjs --channel "${{ inputs.channel }}" --field release_id)"
+            echo "url=$(node scripts/fetch-candidate-model.mjs --channel "$CHANNEL" --field url)"
+            echo "sha256=$(node scripts/fetch-candidate-model.mjs --channel "$CHANNEL" --field sha256)"
+            echo "file=$(node scripts/fetch-candidate-model.mjs --channel "$CHANNEL" --field filename)"
+            echo "release=$(node scripts/fetch-candidate-model.mjs --channel "$CHANNEL" --field release_id)"
           } >> "$GITHUB_OUTPUT"
 
       - name: Restore model cache
@@ -177,10 +179,12 @@ jobs:
         env:
           OPENKARA_SPECTRAL_MODEL: ${{ github.workspace }}/src-tauri/models/${{ steps.spectral.outputs.file }}
           OPENKARA_BENCH_OUT: ${{ github.workspace }}/spectral-bench-${{ matrix.ort_target }}.json
+          BENCH_TARGET: ${{ matrix.ort_target }}
+          BENCH_RELEASE: ${{ steps.spectral.outputs.release }}
         run: |
           cargo test -q --release --test phase7_spectral_bench -- --nocapture
           {
-            echo '### Spectral candidate bench (${{ matrix.ort_target }}, release ${{ steps.spectral.outputs.release }})'
+            echo "### Spectral candidate bench (${BENCH_TARGET}, release ${BENCH_RELEASE})"
             echo '```json'
             cat "$OPENKARA_BENCH_OUT"
             echo '```'

--- a/.github/workflows/spectral-candidate.yml
+++ b/.github/workflows/spectral-candidate.yml
@@ -1,0 +1,195 @@
+name: Spectral candidate (cross-target)
+
+# Cross-target validation of a spectral-core catalog candidate (issue #172
+# PR 4). Resolves the model from the openkara-models CANDIDATE channel
+# (manifest bytes SHA-256-verified against the pointer), then on every
+# supported target: runs the golden-stage suite, the real-model equivalence
+# and streaming tests, the cancellation/restart contract, and the
+# measurement harness (size / cold load / warm latency / RTF / peak RSS).
+#
+# The stable channel and the embedded snapshot are untouched: promotion
+# happens only after every target here reports green (issue #172 PR 5).
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: "Catalog channel to validate"
+        type: choice
+        options: [candidate, stable]
+        default: candidate
+
+permissions:
+  contents: read
+
+concurrency:
+  group: spectral-candidate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-15
+            ort_target: aarch64-apple-darwin
+          - os: macos-15-intel
+            ort_target: x86_64-apple-darwin
+          - os: ubuntu-latest
+            ort_target: x86_64-unknown-linux-gnu
+          - os: ubuntu-24.04-arm
+            ort_target: aarch64-unknown-linux-gnu
+          - os: windows-2022
+            ort_target: x86_64-pc-windows-msvc
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+
+      - name: Restore Rust cache
+        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: spectral-candidate-${{ matrix.os }}
+          workspaces: ./src-tauri -> target
+          cache-bin: false
+
+      - name: Install Linux test dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            curl \
+            libasound2-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev
+
+      - name: Resolve waveform model from catalog snapshot
+        id: waveform
+        shell: bash
+        run: |
+          {
+            echo "url=$(node scripts/resolve-model.mjs --field url)"
+            echo "sha256=$(node scripts/resolve-model.mjs --field sha256)"
+            echo "file=$(node scripts/resolve-model.mjs --field filename)"
+            echo "file_sha256=$(node scripts/resolve-model.mjs --field file_sha256)"
+            echo "archived=$(node scripts/resolve-model.mjs --field archived)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Resolve spectral candidate from the ${{ inputs.channel }} channel
+        id: spectral
+        shell: bash
+        run: |
+          {
+            echo "url=$(node scripts/fetch-candidate-model.mjs --channel "${{ inputs.channel }}" --field url)"
+            echo "sha256=$(node scripts/fetch-candidate-model.mjs --channel "${{ inputs.channel }}" --field sha256)"
+            echo "file=$(node scripts/fetch-candidate-model.mjs --channel "${{ inputs.channel }}" --field filename)"
+            echo "release=$(node scripts/fetch-candidate-model.mjs --channel "${{ inputs.channel }}" --field release_id)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Restore model cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            src-tauri/models/${{ steps.waveform.outputs.file }}
+            src-tauri/models/${{ steps.spectral.outputs.file }}
+          key: spectral-candidate-models-${{ steps.waveform.outputs.file_sha256 }}-${{ steps.spectral.outputs.sha256 }}
+          enableCrossOsArchive: true
+
+      - name: Download and verify models
+        shell: bash
+        env:
+          WAVEFORM_URL: ${{ steps.waveform.outputs.url }}
+          WAVEFORM_SHA256: ${{ steps.waveform.outputs.sha256 }}
+          WAVEFORM_FILE: ${{ steps.waveform.outputs.file }}
+          WAVEFORM_FILE_SHA256: ${{ steps.waveform.outputs.file_sha256 }}
+          WAVEFORM_ARCHIVED: ${{ steps.waveform.outputs.archived }}
+          SPECTRAL_URL: ${{ steps.spectral.outputs.url }}
+          SPECTRAL_SHA256: ${{ steps.spectral.outputs.sha256 }}
+          SPECTRAL_FILE: ${{ steps.spectral.outputs.file }}
+        run: |
+          mkdir -p src-tauri/models
+          if ! echo "$WAVEFORM_FILE_SHA256  src-tauri/models/$WAVEFORM_FILE" | sha256sum -c --status 2>/dev/null; then
+            curl -L --fail "$WAVEFORM_URL" -o /tmp/waveform-download
+            echo "$WAVEFORM_SHA256  /tmp/waveform-download" | sha256sum -c
+            if [ "$WAVEFORM_ARCHIVED" = "true" ]; then
+              tar -xzf /tmp/waveform-download -C src-tauri/models "$WAVEFORM_FILE"
+            else
+              mv /tmp/waveform-download "src-tauri/models/$WAVEFORM_FILE"
+            fi
+          fi
+          echo "$WAVEFORM_FILE_SHA256  src-tauri/models/$WAVEFORM_FILE" | sha256sum -c
+          if ! echo "$SPECTRAL_SHA256  src-tauri/models/$SPECTRAL_FILE" | sha256sum -c --status 2>/dev/null; then
+            curl -L --fail "$SPECTRAL_URL" -o "src-tauri/models/$SPECTRAL_FILE"
+          fi
+          echo "$SPECTRAL_SHA256  src-tauri/models/$SPECTRAL_FILE" | sha256sum -c
+
+      - name: Restore ONNX Runtime cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: src-tauri/generated/onnxruntime
+          key: onnxruntime-${{ matrix.ort_target }}-${{ hashFiles('scripts/prepare-onnx-runtime.mjs', 'src-tauri/catalog/release-manifest.json') }}
+
+      - name: Prepare ONNX Runtime
+        env:
+          ORT_TARGET: ${{ matrix.ort_target }}
+        shell: bash
+        run: node scripts/prepare-onnx-runtime.mjs --target "${ORT_TARGET}"
+
+      - name: Install nextest
+        uses: taiki-e/install-action@7a562dfa955aa2e4d5b0fd6ebd57ff9715c07b0b # v2.73.0
+        with:
+          tool: nextest
+
+      - name: Golden stages + spectral unit suite
+        working-directory: src-tauri
+        shell: bash
+        run: cargo nextest run --no-fail-fast -E 'binary(phase7_spectral) or test(spectral)'
+
+      - name: Candidate equivalence + streaming + cancellation
+        working-directory: src-tauri
+        shell: bash
+        env:
+          OPENKARA_SPECTRAL_MODEL: ${{ github.workspace }}/src-tauri/models/${{ steps.spectral.outputs.file }}
+        run: |
+          cargo nextest run --no-fail-fast -E 'binary(phase7_spectral_session) or test(spectral_core_matches_waveform_model_on_one_window)'
+
+      - name: Measurement harness
+        working-directory: src-tauri
+        shell: bash
+        env:
+          OPENKARA_SPECTRAL_MODEL: ${{ github.workspace }}/src-tauri/models/${{ steps.spectral.outputs.file }}
+          OPENKARA_BENCH_OUT: ${{ github.workspace }}/spectral-bench-${{ matrix.ort_target }}.json
+        run: |
+          cargo test -q --release --test phase7_spectral_bench -- --nocapture
+          {
+            echo '### Spectral candidate bench (${{ matrix.ort_target }}, release ${{ steps.spectral.outputs.release }})'
+            echo '```json'
+            cat "$OPENKARA_BENCH_OUT"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload bench report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: spectral-bench-${{ matrix.ort_target }}
+          path: spectral-bench-${{ matrix.ort_target }}.json
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/fetch-candidate-model.mjs
+++ b/scripts/fetch-candidate-model.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+// Resolve a spectral-core model artifact from an openkara-models catalog
+// CHANNEL pointer (candidate by default) instead of the embedded snapshot.
+//
+// The candidate channel carries pre-promotion generations (openkara-models
+// issue #23 PR 3): cross-target validation (issue #172 PR 4) runs against
+// it BEFORE the stable pointer — and therefore the embedded snapshot every
+// consumer trusts — ever references a spectral-core artifact. The manifest
+// bytes are verified against the pointer's SHA-256 and size before parsing,
+// mirroring the Rust catalog client.
+//
+// Usage:
+//   node scripts/fetch-candidate-model.mjs                        # htdemucs, JSON
+//   node scripts/fetch-candidate-model.mjs --variant htdemucs_ft
+//   node scripts/fetch-candidate-model.mjs --channel stable
+//   node scripts/fetch-candidate-model.mjs --field url            # single field
+
+import { createHash } from "node:crypto";
+import { pathToFileURL } from "node:url";
+
+const POINTER_BASE =
+  "https://raw.githubusercontent.com/thedavidweng/openkara-models/main/catalog/channels";
+
+function parseArgs(argv) {
+  const args = {
+    variant: "htdemucs",
+    field: null,
+    channel: "candidate",
+    interface: "spectral-core",
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === "--variant") {
+      args.variant = argv[index + 1];
+      index += 1;
+    } else if (argv[index] === "--field") {
+      args.field = argv[index + 1];
+      index += 1;
+    } else if (argv[index] === "--channel") {
+      args.channel = argv[index + 1];
+      index += 1;
+    } else if (argv[index] === "--interface") {
+      args.interface = argv[index + 1];
+      index += 1;
+    } else {
+      throw new Error(`unknown argument: ${argv[index]}`);
+    }
+  }
+  if (!["candidate", "stable"].includes(args.channel)) {
+    throw new Error(`unknown channel: ${args.channel}`);
+  }
+  return args;
+}
+
+/**
+ * Pick the artifact for (variant, tensor interface) from a verified release
+ * manifest: smallest non-deprecated download wins, mirroring the Rust
+ * resolver. Exported for tests.
+ */
+export function selectModel(manifest, variant, tensorInterface) {
+  if (manifest.schema_version !== "openkara.catalog/release-v1") {
+    throw new Error(
+      `unsupported release manifest schema: ${manifest.schema_version}`,
+    );
+  }
+  const matches = manifest.artifacts.models.filter(
+    (model) =>
+      model.variant === variant &&
+      model.model?.tensor_interface === tensorInterface &&
+      !model.deprecation?.deprecated,
+  );
+  if (matches.length === 0) {
+    throw new Error(
+      `manifest ${manifest.release_id} lists no ${tensorInterface} model for variant ${variant}`,
+    );
+  }
+  return matches.reduce((smallest, candidate) =>
+    candidate.byte_size < smallest.byte_size ? candidate : smallest,
+  );
+}
+
+/** Verify manifest bytes against the channel pointer before parsing. */
+export function verifyManifestBytes(pointer, bytes) {
+  if (pointer.schema_version !== "openkara.catalog/channel-v1") {
+    throw new Error(`unsupported channel schema: ${pointer.schema_version}`);
+  }
+  if (bytes.byteLength !== pointer.release_manifest_size) {
+    throw new Error(
+      `manifest size ${bytes.byteLength} does not match the pointer's ${pointer.release_manifest_size}`,
+    );
+  }
+  const digest = createHash("sha256").update(bytes).digest("hex");
+  if (digest !== pointer.release_manifest_sha256) {
+    throw new Error(
+      `manifest sha256 ${digest} does not match the pointer's ${pointer.release_manifest_sha256}`,
+    );
+  }
+  return JSON.parse(new TextDecoder().decode(bytes));
+}
+
+async function fetchBytes(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`fetch failed (${response.status}): ${url}`);
+  }
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  const pointerBytes = await fetchBytes(`${POINTER_BASE}/${args.channel}.json`);
+  const pointer = JSON.parse(new TextDecoder().decode(pointerBytes));
+  const manifest = verifyManifestBytes(
+    pointer,
+    await fetchBytes(pointer.release_manifest_url),
+  );
+
+  const model = selectModel(manifest, args.variant, args.interface);
+  const onnxEntries = Object.entries(model.extracted_file_digests).filter(
+    ([path]) => path.endsWith(".onnx"),
+  );
+  if (onnxEntries.length !== 1) {
+    throw new Error(
+      `model ${model.artifact_id} must declare exactly one .onnx file, found ${onnxEntries.length}`,
+    );
+  }
+  const [modelFile, modelDigest] = onnxEntries[0];
+
+  const resolved = {
+    channel: args.channel,
+    variant: model.variant,
+    tensor_interface: model.model.tensor_interface,
+    artifact_id: model.artifact_id,
+    filename: modelFile,
+    file_sha256: modelDigest.sha256,
+    file_size: modelDigest.size,
+    download_filename: model.filename,
+    url: model.download_url,
+    sha256: model.archive_digest,
+    size: model.byte_size,
+    archived: /\.(tar\.gz|tgz|zip)$/.test(model.filename),
+    tag: model.upstream.tag,
+    generation: manifest.generation,
+    release_id: manifest.release_id,
+  };
+
+  if (args.field !== null) {
+    if (!(args.field in resolved)) {
+      throw new Error(`unknown field: ${args.field}`);
+    }
+    process.stdout.write(`${resolved[args.field]}\n`);
+  } else {
+    process.stdout.write(`${JSON.stringify(resolved, null, 2)}\n`);
+  }
+}
+
+const invokedDirectly =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  await main();
+}

--- a/src-tauri/tests/phase7_spectral_bench.rs
+++ b/src-tauri/tests/phase7_spectral_bench.rs
@@ -1,0 +1,221 @@
+//! Cross-target measurement harness for the spectral-core candidate
+//! (issue #172 PR 4).
+//!
+//! Records, per target: artifact size, cold session load, first-window
+//! latency, warm median/p95 latency, real-time factor, and peak RSS (unix;
+//! reported as null on Windows). Emits one JSON object to stdout (marked
+//! with a `SPECTRAL_BENCH_JSON:` prefix) and, when `OPENKARA_BENCH_OUT` is
+//! set, writes it to that path for CI artifact upload.
+//!
+//! Gated on `OPENKARA_SPECTRAL_MODEL`; runs the full streaming path in both
+//! stem modes on a synthetic two-window program so the numbers include the
+//! app-side transforms, composition, and OLA — the product path, not a bare
+//! session benchmark.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::atomic::AtomicBool,
+    time::Instant,
+};
+
+mod support;
+
+use openkara_lib::audio::decode::DecodedAudio;
+use openkara_lib::audio::encode::StreamingOggWriter;
+use openkara_lib::{
+    config::{ExecutionProviderPreference, StemMode},
+    separator::{
+        inference::{self, StemWriters},
+        model::{self, TensorInterface},
+        preprocess,
+        workspace::SeparationWorkspace,
+    },
+};
+
+fn initialize_test_runtime() {
+    let runtime_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("generated")
+        .join("onnxruntime")
+        .join(model::ORT_RUNTIME_FILENAME);
+    model::ensure_runtime_loaded_from_path(&runtime_path)
+        .expect("dev runtime should initialize for the spectral bench");
+}
+
+/// Peak resident set size in kilobytes, when the platform exposes it.
+fn peak_rss_kb() -> Option<u64> {
+    #[cfg(unix)]
+    {
+        let mut usage = std::mem::MaybeUninit::<libc::rusage>::zeroed();
+        // SAFETY: getrusage writes a plain struct for the calling process.
+        let rc = unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) };
+        if rc == 0 {
+            let usage = unsafe { usage.assume_init() };
+            // macOS reports bytes, Linux kilobytes.
+            let raw = usage.ru_maxrss as u64;
+            #[cfg(target_os = "macos")]
+            return Some(raw / 1024);
+            #[cfg(not(target_os = "macos"))]
+            return Some(raw);
+        }
+        None
+    }
+    #[cfg(not(unix))]
+    {
+        None
+    }
+}
+
+fn synthetic_audio(frames: usize) -> DecodedAudio {
+    // Deterministic band-limited-ish program material.
+    let channels = 2usize;
+    let mut samples = vec![0.0f32; frames * channels];
+    for (i, s) in samples.iter_mut().enumerate() {
+        let t = (i / channels) as f32 / 44_100.0;
+        let ch = (i % channels) as f32;
+        *s = 0.15 * (2.0 * std::f32::consts::PI * (220.0 + 55.0 * ch) * t).sin()
+            + 0.05 * (2.0 * std::f32::consts::PI * 3_520.0 * t).sin();
+    }
+    DecodedAudio {
+        sample_rate: 44_100,
+        channels,
+        duration_ms: ((frames as f64 / 44_100.0) * 1000.0).round() as u64,
+        samples,
+    }
+}
+
+fn median_and_p95(mut values: Vec<f64>) -> (f64, f64) {
+    values.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let median = values[values.len() / 2];
+    let p95_index = ((values.len() as f64 * 0.95).ceil() as usize).clamp(1, values.len()) - 1;
+    (median, values[p95_index])
+}
+
+fn run_mode(
+    model: &openkara_lib::separator::model::LoadedModel,
+    audio: &DecodedAudio,
+    stem_mode: StemMode,
+    out_dir: &Path,
+) -> (usize, Vec<f64>) {
+    let channels = audio.channels;
+    let input_frame_count = audio.samples.len() / channels;
+    let chunk_size = preprocess::target_frame_count(model, input_frame_count).expect("chunk size");
+    let hop_size = chunk_size / 2;
+
+    fs::create_dir_all(out_dir).expect("bench output dir");
+    let writer = |name: &str| {
+        StreamingOggWriter::new(&out_dir.join(name), audio.sample_rate, channels, None, None)
+            .expect("bench writer")
+    };
+    let mut writers = match stem_mode {
+        StemMode::TwoStem => StemWriters {
+            mode: StemMode::TwoStem,
+            vocals: writer("vocals.ogg"),
+            accompaniment: Some(writer("accompaniment.ogg")),
+            drums: None,
+            bass: None,
+            other: None,
+        },
+        StemMode::FourStem => StemWriters {
+            mode: StemMode::FourStem,
+            vocals: writer("vocals.ogg"),
+            accompaniment: None,
+            drums: Some(writer("drums.ogg")),
+            bass: Some(writer("bass.ogg")),
+            other: Some(writer("other.ogg")),
+        },
+    };
+    let mut workspace =
+        SeparationWorkspace::new(stem_mode, channels, chunk_size, hop_size, input_frame_count);
+
+    let mut chunk_times = Vec::new();
+    let mut last = Instant::now();
+    let outcome = inference::separate_streaming(
+        model,
+        audio,
+        stem_mode,
+        &mut writers,
+        &mut workspace,
+        &AtomicBool::new(false),
+        |_, _| {
+            chunk_times.push(last.elapsed().as_secs_f64());
+            last = Instant::now();
+        },
+    )
+    .expect("bench separation should succeed");
+    writers.finish_all().expect("bench writers finalize");
+
+    (outcome.frames_written, chunk_times)
+}
+
+#[test]
+fn spectral_candidate_bench() {
+    let Some(model_path) = std::env::var_os("OPENKARA_SPECTRAL_MODEL") else {
+        eprintln!("skipping spectral bench: OPENKARA_SPECTRAL_MODEL is not set");
+        return;
+    };
+    let model_path = PathBuf::from(model_path);
+    initialize_test_runtime();
+
+    let artifact_bytes = fs::metadata(&model_path).expect("model metadata").len();
+
+    let cold_start = Instant::now();
+    let model = model::load_from_path(&model_path, ExecutionProviderPreference::Cpu)
+        .expect("spectral model should load");
+    let cold_load_s = cold_start.elapsed().as_secs_f64();
+    assert_eq!(model.tensor_interface, TensorInterface::SpectralCore);
+    let segment = model
+        .spectral
+        .as_ref()
+        .expect("verified interface")
+        .segment_frames;
+
+    // Two full windows (three chunks at 50% overlap) of program material.
+    let audio = synthetic_audio(segment * 2);
+    let audio_seconds = (segment * 2) as f64 / 44_100.0;
+
+    let four_dir = support::unique_temp_path("phase7-bench-four");
+    let four_start = Instant::now();
+    let (_, four_chunks) = run_mode(&model, &audio, StemMode::FourStem, &four_dir);
+    let four_wall = four_start.elapsed().as_secs_f64();
+    fs::remove_dir_all(&four_dir).ok();
+
+    let two_dir = support::unique_temp_path("phase7-bench-two");
+    let two_start = Instant::now();
+    let (_, two_chunks) = run_mode(&model, &audio, StemMode::TwoStem, &two_dir);
+    let two_wall = two_start.elapsed().as_secs_f64();
+    fs::remove_dir_all(&two_dir).ok();
+
+    let first_window_s = four_chunks.first().copied().unwrap_or(f64::NAN);
+    let warm: Vec<f64> = four_chunks
+        .iter()
+        .skip(1)
+        .chain(two_chunks.iter().skip(1))
+        .copied()
+        .collect();
+    let (warm_median_s, warm_p95_s) = if warm.is_empty() {
+        (f64::NAN, f64::NAN)
+    } else {
+        median_and_p95(warm)
+    };
+
+    let report = serde_json::json!({
+        "schema_version": "openkara.spectral-bench/v1",
+        "target": format!("{}-{}", std::env::consts::ARCH, std::env::consts::OS),
+        "model_path": model_path.display().to_string(),
+        "artifact_bytes": artifact_bytes,
+        "segment_frames": segment,
+        "cold_load_s": cold_load_s,
+        "first_window_s": first_window_s,
+        "warm_median_s": warm_median_s,
+        "warm_p95_s": warm_p95_s,
+        "rtf_four_stem": four_wall / audio_seconds,
+        "rtf_two_stem": two_wall / audio_seconds,
+        "peak_rss_kb": peak_rss_kb(),
+    });
+    let line = serde_json::to_string(&report).expect("bench json");
+    println!("SPECTRAL_BENCH_JSON: {line}");
+    if let Some(out) = std::env::var_os("OPENKARA_BENCH_OUT") {
+        fs::write(&out, format!("{line}\n")).expect("bench report write");
+    }
+}

--- a/src-tauri/tests/phase7_spectral_session.rs
+++ b/src-tauri/tests/phase7_spectral_session.rs
@@ -233,3 +233,107 @@ fn spectral_streaming_end_to_end_two_stem() {
     }
     fs::remove_dir_all(&out_dir).ok();
 }
+
+/// Interruption contract (issue #172 PR 4): a cancelled spectral run
+/// publishes nothing and a fresh run restarts from chunk 0 successfully.
+/// No checkpoint state exists by design (#171).
+#[test]
+fn spectral_cancellation_publishes_nothing_and_restarts_from_zero() {
+    use openkara_lib::audio::decode::DecodedAudio;
+    use std::sync::atomic::Ordering;
+
+    let Some(model_path) = spectral_model_path() else {
+        eprintln!("skipping: OPENKARA_SPECTRAL_MODEL is not set");
+        return;
+    };
+    initialize_test_runtime();
+
+    let loaded = model::load_from_path(&model_path, ExecutionProviderPreference::Cpu)
+        .expect("spectral model should load");
+    let segment = loaded
+        .spectral
+        .as_ref()
+        .expect("verified interface")
+        .segment_frames;
+
+    // 1.5 windows -> two chunks at 50% overlap.
+    let channels = 2usize;
+    let frames = segment + segment / 2;
+    let samples: Vec<f32> = (0..frames * channels)
+        .map(|i| 0.1 * ((i as f32) * 0.001).sin())
+        .collect();
+    let audio = DecodedAudio {
+        sample_rate: 44_100,
+        channels,
+        duration_ms: ((frames as f64 / 44_100.0) * 1000.0).round() as u64,
+        samples,
+    };
+
+    let chunk_size = preprocess::target_frame_count(&loaded, frames).expect("chunk size");
+    let hop_size = chunk_size / 2;
+    let out_dir = support::unique_temp_path("phase7-spectral-cancel");
+    fs::create_dir_all(&out_dir).expect("output dir");
+
+    let make_writers = |dir: &Path| StemWriters {
+        mode: StemMode::TwoStem,
+        vocals: StreamingOggWriter::new(&dir.join("vocals.ogg"), 44_100, channels, None, None)
+            .expect("vocals writer"),
+        accompaniment: Some(
+            StreamingOggWriter::new(&dir.join("accompaniment.ogg"), 44_100, channels, None, None)
+                .expect("accompaniment writer"),
+        ),
+        drums: None,
+        bass: None,
+        other: None,
+    };
+
+    // First run: cancel after the first chunk completes.
+    let cancel = AtomicBool::new(false);
+    let mut writers = make_writers(&out_dir);
+    let mut workspace =
+        SeparationWorkspace::new(StemMode::TwoStem, channels, chunk_size, hop_size, frames);
+    let error = inference::separate_streaming(
+        &loaded,
+        &audio,
+        StemMode::TwoStem,
+        &mut writers,
+        &mut workspace,
+        &cancel,
+        |done, _| {
+            if done >= 1 {
+                cancel.store(true, Ordering::Relaxed);
+            }
+        },
+    )
+    .expect_err("cancelled run must not complete");
+    assert!(
+        openkara_lib::separator::error::is_cancelled(&error),
+        "error must be the cancellation sentinel, got {error:#}"
+    );
+    drop(writers); // writers drop without finish_all -> temp files cleaned up
+
+    assert!(
+        !out_dir.join("vocals.ogg").exists() && !out_dir.join("accompaniment.ogg").exists(),
+        "a cancelled run must publish no stem files"
+    );
+
+    // Second run: from zero, to completion, same directory.
+    let mut writers = make_writers(&out_dir);
+    let mut workspace =
+        SeparationWorkspace::new(StemMode::TwoStem, channels, chunk_size, hop_size, frames);
+    let outcome = inference::separate_streaming(
+        &loaded,
+        &audio,
+        StemMode::TwoStem,
+        &mut writers,
+        &mut workspace,
+        &AtomicBool::new(false),
+        |_, _| {},
+    )
+    .expect("restarted run must succeed");
+    writers.finish_all().expect("writers finalize");
+    assert_eq!(outcome.frames_written, frames);
+    assert_sane_stem(&out_dir.join("vocals.ogg"));
+    assert_sane_stem(&out_dir.join("accompaniment.ogg"));
+    fs::remove_dir_all(&out_dir).ok();
+}


### PR DESCRIPTION
Implements issue #172 **PR 4 — Cross-target candidate**. Serial on PR 3 (#194, merged). Consumes the generation-8 candidate channel published by openkara-models#67/#69.

## What

- **`scripts/fetch-candidate-model.mjs`** — resolves a spectral-core artifact from an openkara-models *channel pointer* (candidate by default): the release manifest's bytes are verified against the pointer's SHA-256 + size **before parsing** (mirroring the Rust catalog client), then the smallest non-deprecated artifact of the variant+interface wins. Verified live against the published candidate (resolves `htdemucs.spectral.fp32.onnx`, generation 8, digest-checked).
- **`.github/workflows/spectral-candidate.yml`** (workflow_dispatch) — five-target matrix: `macos-15` (arm64), `macos-15-intel`, `ubuntu-latest` (x64), `ubuntu-24.04-arm`, `windows-2022`. Per target: digest-verified model provisioning (waveform reference + spectral candidate), catalog runtime via the existing `prepare-onnx-runtime.mjs`, then:
  1. golden-stage suite (`phase7_spectral`) + all spectral unit tests,
  2. real-model equivalence vs the waveform model + end-to-end streaming (both stem modes),
  3. the interruption contract (below),
  4. the measurement harness — bench JSON in the job summary + uploaded artifact per target.
- **`tests/phase7_spectral_bench.rs`** — env-gated harness measuring through the full product path (native transforms + composition + OLA + writers), both stem modes: artifact size, cold session load, first-window latency, warm median/p95, RTF, peak RSS (unix; null on Windows).
- **`tests/phase7_spectral_session.rs`** — new interruption test: a cancelled spectral run returns the cancellation sentinel, publishes no stem files, and a fresh run restarts from chunk 0 to completion (no checkpoint state exists by design, per #171).

## Acceptance mapping

| issue item | where |
|---|---|
| golden stages + e2e quality on all five targets | workflow matrix steps 1–2 |
| record size / cold load / warm latency / RTF / peak memory | bench harness + artifacts |
| cache/session identity invalidation by contract version | `model` unit tests (run per target): spectral cache keys carry `openkara.spectral-contract/v1`; unknown versions fail before session creation |
| interruption cleanup + restart-from-zero, no checkpoint resume | new cancellation test |

## Local baseline (published candidate, aarch64 macOS, CPU EP, release)

cold load **0.22 s** · first window 3.99 s · warm median **3.59 s**/7.8 s window · RTF **0.80** (TwoStem premix) / **1.03** (FourStem; 50% overlap doubles compute) · peak RSS **3.0 GB** · artifact **209.5 MB** (vs 355 MB waveform installed).

Provider selection is deliberately pinned to the CPU EP for cross-target determinism — per-target provider/threads tuning is #170's scope and never changes StemMode or overlap (#173).

After merge: dispatch the workflow against the candidate channel; the five green reports + bench artifacts gate the stable switch (#172 PR 5 + models#23 PR 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)