### PR TITLE
test(separator): platform-default EP stability gate + dual-preference bench (#170, models#19)

### DIFF
--- a/src-tauri/tests/phase7_spectral_bench.rs
+++ b/src-tauri/tests/phase7_spectral_bench.rs
@@ -147,20 +147,14 @@ fn run_mode(
     (outcome.frames_written, chunk_times)
 }
 
-#[test]
-fn spectral_candidate_bench() {
-    let Some(model_path) = std::env::var_os("OPENKARA_SPECTRAL_MODEL") else {
-        eprintln!("skipping spectral bench: OPENKARA_SPECTRAL_MODEL is not set");
-        return;
-    };
-    let model_path = PathBuf::from(model_path);
-    initialize_test_runtime();
-
-    let artifact_bytes = fs::metadata(&model_path).expect("model metadata").len();
-
+/// Bench one execution-provider preference end to end.
+fn bench_preference(
+    model_path: &Path,
+    preference: ExecutionProviderPreference,
+) -> serde_json::Value {
     let cold_start = Instant::now();
-    let model = model::load_from_path(&model_path, ExecutionProviderPreference::Cpu)
-        .expect("spectral model should load");
+    let model = model::load_from_path(model_path, preference)
+        .expect("spectral model should load via the preference's fallback chain");
     let cold_load_s = cold_start.elapsed().as_secs_f64();
     // A loaded model always carries a verified spectral interface.
     let segment = model.spectral.segment_frames;
@@ -194,11 +188,8 @@ fn spectral_candidate_bench() {
         median_and_p95(warm)
     };
 
-    let report = serde_json::json!({
-        "schema_version": "openkara.spectral-bench/v1",
-        "target": format!("{}-{}", std::env::consts::ARCH, std::env::consts::OS),
-        "model_path": model_path.display().to_string(),
-        "artifact_bytes": artifact_bytes,
+    serde_json::json!({
+        "preference": preference.as_str(),
         "segment_frames": segment,
         "cold_load_s": cold_load_s,
         "first_window_s": first_window_s,
@@ -206,7 +197,42 @@ fn spectral_candidate_bench() {
         "warm_p95_s": warm_p95_s,
         "rtf_four_stem": four_wall / audio_seconds,
         "rtf_two_stem": two_wall / audio_seconds,
+    })
+}
+
+#[test]
+fn spectral_candidate_bench() {
+    let Some(model_path) = std::env::var_os("OPENKARA_SPECTRAL_MODEL") else {
+        eprintln!("skipping spectral bench: OPENKARA_SPECTRAL_MODEL is not set");
+        return;
+    };
+    let model_path = PathBuf::from(model_path);
+    initialize_test_runtime();
+
+    let artifact_bytes = fs::metadata(&model_path).expect("model metadata").len();
+
+    // Baseline (CPU EP) plus the product's platform default (XNNPACK on
+    // unix, DirectML on Windows) — measured side by side so per-target
+    // provider selection (#170) is data-driven from every dispatch of the
+    // cross-target workflow, with no manual experiments. On machines
+    // without the accelerator the default preference measures its fallback
+    // chain, which is exactly what users on that hardware experience.
+    let cpu = bench_preference(&model_path, ExecutionProviderPreference::Cpu);
+    let platform_default = ExecutionProviderPreference::default_for_current_platform();
+    let accelerated = if platform_default == ExecutionProviderPreference::Cpu {
+        serde_json::Value::Null
+    } else {
+        bench_preference(&model_path, platform_default)
+    };
+
+    let report = serde_json::json!({
+        "schema_version": "openkara.spectral-bench/v2",
+        "target": format!("{}-{}", std::env::consts::ARCH, std::env::consts::OS),
+        "model_path": model_path.display().to_string(),
+        "artifact_bytes": artifact_bytes,
         "peak_rss_kb": peak_rss_kb(),
+        "cpu": cpu,
+        "platform_default": accelerated,
     });
     let line = serde_json::to_string(&report).expect("bench json");
     println!("SPECTRAL_BENCH_JSON: {line}");

--- a/src-tauri/tests/phase7_spectral_session.rs
+++ b/src-tauri/tests/phase7_spectral_session.rs
@@ -61,8 +61,22 @@ fn separate_to_dir(
     stem_mode: StemMode,
     output_dir: &Path,
 ) -> openkara_lib::separator::inference::SeparationOutcome {
-    let loaded_model = model::load_from_path(model_path, ExecutionProviderPreference::Cpu)
-        .expect("model should load");
+    separate_to_dir_with_preference(
+        model_path,
+        stem_mode,
+        output_dir,
+        ExecutionProviderPreference::Cpu,
+    )
+}
+
+/// Run streaming separation with an explicit execution-provider preference.
+fn separate_to_dir_with_preference(
+    model_path: &Path,
+    stem_mode: StemMode,
+    output_dir: &Path,
+    preference: ExecutionProviderPreference,
+) -> openkara_lib::separator::inference::SeparationOutcome {
+    let loaded_model = model::load_from_path(model_path, preference).expect("model should load");
 
     let decoded = decode::decode_file(&fixture_path("audio", "fixture.wav"))
         .expect("fixture audio should decode");
@@ -280,6 +294,39 @@ fn spectral_cancellation_publishes_nothing_and_restarts_from_zero() {
     .expect("restarted run must succeed");
     writers.finish_all().expect("writers finalize");
     assert_eq!(outcome.frames_written, frames);
+    assert_sane_stem(&out_dir.join("vocals.ogg"));
+    assert_sane_stem(&out_dir.join("accompaniment.ogg"));
+    fs::remove_dir_all(&out_dir).ok();
+}
+
+/// The product's platform-default execution-provider preference must always
+/// yield a working session and a sane separation — on machines WITHOUT the
+/// accelerator (e.g. GPU-less Windows attempting DirectML) the provider
+/// chain has to fall back gracefully rather than fail or corrupt output.
+/// On accelerator-equipped machines the same test exercises the real EP.
+#[test]
+fn spectral_separation_with_default_platform_preference_is_stable() {
+    let Some(model_path) = spectral_model_path() else {
+        eprintln!("skipping: OPENKARA_SPECTRAL_MODEL is not set");
+        return;
+    };
+    initialize_test_runtime();
+
+    let preference =
+        openkara_lib::config::ExecutionProviderPreference::default_for_current_platform();
+    eprintln!(
+        "platform-default provider preference: {}",
+        preference.as_str()
+    );
+
+    let loaded = model::load_from_path(&model_path, preference)
+        .expect("platform-default preference must load via its fallback chain");
+    drop(loaded);
+
+    let out_dir = support::unique_temp_path("phase7-spectral-default-ep");
+    let outcome =
+        separate_to_dir_with_preference(&model_path, StemMode::TwoStem, &out_dir, preference);
+    assert_eq!(outcome.stem_mode, StemMode::TwoStem);
     assert_sane_stem(&out_dir.join("vocals.ogg"));
     assert_sane_stem(&out_dir.join("accompaniment.ogg"));
     fs::remove_dir_all(&out_dir).ok();


### PR DESCRIPTION
Follow-through on two maintainer directions: make GPU acceleration/fallback **deterministic** (no user-side experiments) and make provider tuning **data-driven from CI**.

## What

1. **Platform-default preference stability test** (gated, runs on every leg of the cross-target workflow): loads the model and runs a full separation under `ExecutionProviderPreference::default_for_current_platform()` — DirectML on Windows, XNNPACK elsewhere. On GPU-less Windows CI this exercises exactly the DML-attempt → fallback path that every user without a discrete GPU hits by default; on a GPU machine the identical test exercises real DirectML. Research grounding (archived on models#19): ORT v1.27.1 auto-corrects the documented DML session requirements at EP registration (`inference_session.cc:953-970`), our session is mutex-serialized (DML's single-`Run` constraint), shapes are fixed, opset 17 ≤ DML's ceiling, `DirectML.dll` is preloaded — the setup matches the official docs and UVR-style practice, so the only remaining item on models#19 is a one-off confirmation on real GPU hardware.
2. **Dual-preference bench** (`spectral-bench/v2`): every cross-target dispatch now measures the CPU EP and the platform default side by side, making #170's provider selection reviewable from job summaries instead of manual experiments. Local sample (aarch64 macOS, release): XNNPACK warm **2.67 s/window** vs CPU **5.08 s** — RTF two-stem **0.64 vs 1.31**.

No production code changes — tests and bench only. `cargo clippy -D warnings` / fmt clean; the new gated test passes locally against the stable catalog artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)