### PR TITLE
fix(i18n): translate remote-library flow strings for zh-CN (#209)

### DIFF
--- a/src/components/Layout/GlobalProgressBar.tsx
+++ b/src/components/Layout/GlobalProgressBar.tsx
@@ -192,7 +192,6 @@ function useActiveTasks(modelDownloadCompleteFlash: boolean): ActiveTask[] {
       key: `upload-${upload.song_id}`,
       label: t("progress.uploadingToRemote", {
         title,
-        defaultValue: `Publishing to remote repository: ${title}`,
       }),
       percent: upload.percent,
     });

--- a/src/components/Library/SongListItem.tsx
+++ b/src/components/Library/SongListItem.tsx
@@ -305,9 +305,6 @@ export function SongListItem({ song, orderedHashes }: SongListItemProps) {
               <TaskProgressBar
                 label={t("progress.uploadingToRemote", {
                   title: getSongDisplayName(song),
-                  defaultValue: `Publishing to remote repository: ${getSongDisplayName(
-                    song,
-                  )}`,
                 })}
                 percent={uploadStatus.percent}
               />

--- a/src/components/Settings/LibrarySetup.tsx
+++ b/src/components/Settings/LibrarySetup.tsx
@@ -444,9 +444,7 @@ export function LibrarySetup({ onComplete }: LibrarySetupProps) {
                 />
               </div>
               <h1 className="text-2xl font-bold text-[var(--color-text)]">
-                {t("setup.openRemoteLibrary", {
-                  defaultValue: "Choose a remote provider",
-                })}
+                {t("setup.openRemoteLibrary")}
               </h1>
               <p className="text-[14px] leading-relaxed text-[var(--color-text-dim)]">
                 {t("setup.openRemoteLibraryDescription", {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -27,6 +27,7 @@
     "dialogTitleCreate": "Choose a location for your Karaoke Library",
     "dialogTitleOpen": "Open an existing Karaoke Library",
     "chooseLanguage": "Choose a language",
+    "openRemoteLibrary": "Choose a remote provider",
     "openRemoteLibraryDescription": "Connect Google Drive, Dropbox, or WebDAV to your remote repository.",
     "remoteProvider": {
       "googleDrive": {
@@ -183,6 +184,7 @@
   },
   "progress": {
     "separating": "Separating: {{title}}",
+    "uploadingToRemote": "Publishing to remote repository: {{title}}",
     "modelDownloadComplete": "Model download complete"
   },
   "queue": {

--- a/src/locales/locales.test.ts
+++ b/src/locales/locales.test.ts
@@ -1,6 +1,35 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
 import { describe, expect, test } from "vitest";
 import en from "./en.json";
 import zh from "./zh-CN.json";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const srcRoot = resolve(here, "..");
+
+// i18next resolves count-aware keys through plural suffixes, so treat a key as
+// present when either the literal key or any of its plural variants exists.
+const PLURAL_SUFFIXES = ["_zero", "_one", "_two", "_few", "_many", "_other"];
+
+function lookup(locale: unknown, key: string): unknown {
+  return key
+    .split(".")
+    .reduce<unknown>(
+      (node, part) =>
+        node && typeof node === "object"
+          ? (node as Record<string, unknown>)[part]
+          : undefined,
+      locale,
+    );
+}
+
+function isPresent(locale: unknown, key: string): boolean {
+  if (lookup(locale, key) !== undefined) return true;
+  return PLURAL_SUFFIXES.some(
+    (suffix) => lookup(locale, `${key}${suffix}`) !== undefined,
+  );
+}
 
 describe("locale copy", () => {
   test("uses the approved hide separate-all copy", () => {
@@ -19,5 +48,76 @@ describe("locale copy", () => {
       "Mark as Instrumental ({{count}})",
     );
     expect(zh.library.markInstrumentalSelected).toBe("标记为伴奏 ({{count}})");
+  });
+
+  test("translates the remote-library setup title and upload progress label", () => {
+    expect(en.setup.openRemoteLibrary).toBe("Choose a remote provider");
+    expect(zh.setup.openRemoteLibrary).toBe("选择远程服务商");
+    expect(en.progress.uploadingToRemote).toBe(
+      "Publishing to remote repository: {{title}}",
+    );
+    expect(zh.progress.uploadingToRemote).toBe(
+      "正在发布到远程资料库：{{title}}",
+    );
+  });
+});
+
+// The parity test in this suite only compares en↔zh key sets, so a key missing
+// from BOTH locales passes silently while an inline `defaultValue` masks the gap
+// in dev. This guard scans the remote-library flow for static `t("literal")`
+// calls and fails when a referenced key (with or without a `defaultValue`) is
+// absent from either locale — the exact footgun that shipped English strings to
+// zh-CN users (issue #209).
+describe("remote-library flow i18n completeness", () => {
+  // Files that make up the remote-repository setup, wizard, progress, and
+  // diagnostics flow flagged in issue #209.
+  const REMOTE_FLOW_FILES = [
+    "components/Settings/SettingsLibrarySection.tsx",
+    "components/Settings/SettingsRemoteCacheSection.tsx",
+    "components/Settings/SettingsRemoteDiagnosticsSection.tsx",
+    "components/Settings/LibrarySetup.tsx",
+    "components/Settings/RemoteLibraryWizard.tsx",
+    "components/Settings/remote-library-copy.ts",
+    "components/Settings/remote-library-flow.ts",
+    "components/Library/SongListItem.tsx",
+    "components/Layout/GlobalProgressBar.tsx",
+    "components/Player/RemoteReconnectIndicator.tsx",
+  ];
+
+  // Matches `t("literal"` / `t('literal'` (allowing whitespace/newlines after
+  // the paren). Dynamically built keys — `t(variable)` — are intentionally
+  // skipped because their key is not statically knowable.
+  const T_CALL = /\bt\(\s*["']([^"']+)["']/g;
+
+  function collectKeys(): string[] {
+    const keys = new Set<string>();
+    for (const relative of REMOTE_FLOW_FILES) {
+      const source = readFileSync(resolve(srcRoot, relative), "utf8");
+      for (const match of source.matchAll(T_CALL)) {
+        keys.add(match[1]);
+      }
+    }
+    return [...keys].sort();
+  }
+
+  test("every referenced key resolves in en.json and zh-CN.json", () => {
+    const keys = collectKeys();
+    // Guard against the regex silently matching nothing (e.g. a moved file).
+    expect(keys.length).toBeGreaterThan(0);
+
+    const missing = keys
+      .map((key) => ({
+        key,
+        en: isPresent(en, key),
+        zh: isPresent(zh, key),
+      }))
+      .filter((entry) => !entry.en || !entry.zh);
+
+    expect(
+      missing,
+      `Missing locale keys referenced in the remote-library flow: ${missing
+        .map((m) => `${m.key} (en=${m.en}, zh=${m.zh})`)
+        .join(", ")}`,
+    ).toEqual([]);
   });
 });

--- a/src/locales/locales.test.ts
+++ b/src/locales/locales.test.ts
@@ -1,12 +1,6 @@
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, resolve } from "node:path";
 import { describe, expect, test } from "vitest";
 import en from "./en.json";
 import zh from "./zh-CN.json";
-
-const here = dirname(fileURLToPath(import.meta.url));
-const srcRoot = resolve(here, "..");
 
 // i18next resolves count-aware keys through plural suffixes, so treat a key as
 // present when either the literal key or any of its plural variants exists.
@@ -62,27 +56,35 @@ describe("locale copy", () => {
   });
 });
 
-// The parity test in this suite only compares en↔zh key sets, so a key missing
-// from BOTH locales passes silently while an inline `defaultValue` masks the gap
-// in dev. This guard scans the remote-library flow for static `t("literal")`
-// calls and fails when a referenced key (with or without a `defaultValue`) is
-// absent from either locale — the exact footgun that shipped English strings to
-// zh-CN users (issue #209).
+// Load the remote-library flow source files as raw strings at build time via
+// Vite's import.meta.glob. This intentionally avoids Node's fs/path modules,
+// which are not part of the app's DOM/bundler tsconfig (`tsconfig.json`) and
+// would fail the CI `tsc --noEmit` gate. Each pattern is an exact file so the
+// keys of the returned record double as a presence check for the flow.
+const REMOTE_FLOW_SOURCES = import.meta.glob(
+  [
+    "../components/Settings/SettingsLibrarySection.tsx",
+    "../components/Settings/SettingsRemoteCacheSection.tsx",
+    "../components/Settings/SettingsRemoteDiagnosticsSection.tsx",
+    "../components/Settings/LibrarySetup.tsx",
+    "../components/Settings/RemoteLibraryWizard.tsx",
+    "../components/Settings/remote-library-copy.ts",
+    "../components/Settings/remote-library-flow.ts",
+    "../components/Library/SongListItem.tsx",
+    "../components/Layout/GlobalProgressBar.tsx",
+    "../components/Player/RemoteReconnectIndicator.tsx",
+  ],
+  { query: "?raw", import: "default", eager: true },
+) as Record<string, string>;
+
+// The parity test above only compares en↔zh key sets, so a key missing from
+// BOTH locales passes silently while an inline `defaultValue` masks the gap in
+// dev. This guard scans the remote-library flow for static `t("literal")` calls
+// and fails when a referenced key (with or without a `defaultValue`) is absent
+// from either locale — the exact footgun that shipped English strings to zh-CN
+// users (issue #209).
 describe("remote-library flow i18n completeness", () => {
-  // Files that make up the remote-repository setup, wizard, progress, and
-  // diagnostics flow flagged in issue #209.
-  const REMOTE_FLOW_FILES = [
-    "components/Settings/SettingsLibrarySection.tsx",
-    "components/Settings/SettingsRemoteCacheSection.tsx",
-    "components/Settings/SettingsRemoteDiagnosticsSection.tsx",
-    "components/Settings/LibrarySetup.tsx",
-    "components/Settings/RemoteLibraryWizard.tsx",
-    "components/Settings/remote-library-copy.ts",
-    "components/Settings/remote-library-flow.ts",
-    "components/Library/SongListItem.tsx",
-    "components/Layout/GlobalProgressBar.tsx",
-    "components/Player/RemoteReconnectIndicator.tsx",
-  ];
+  const EXPECTED_FILE_COUNT = 10;
 
   // Matches `t("literal"` / `t('literal'` (allowing whitespace/newlines after
   // the paren). Dynamically built keys — `t(variable)` — are intentionally
@@ -91,8 +93,7 @@ describe("remote-library flow i18n completeness", () => {
 
   function collectKeys(): string[] {
     const keys = new Set<string>();
-    for (const relative of REMOTE_FLOW_FILES) {
-      const source = readFileSync(resolve(srcRoot, relative), "utf8");
+    for (const source of Object.values(REMOTE_FLOW_SOURCES)) {
       for (const match of source.matchAll(T_CALL)) {
         keys.add(match[1]);
       }
@@ -100,9 +101,13 @@ describe("remote-library flow i18n completeness", () => {
     return [...keys].sort();
   }
 
+  test("resolves every remote-library flow source file", () => {
+    // Guards against a moved/renamed file silently shrinking the scan surface.
+    expect(Object.keys(REMOTE_FLOW_SOURCES)).toHaveLength(EXPECTED_FILE_COUNT);
+  });
+
   test("every referenced key resolves in en.json and zh-CN.json", () => {
     const keys = collectKeys();
-    // Guard against the regex silently matching nothing (e.g. a moved file).
     expect(keys.length).toBeGreaterThan(0);
 
     const missing = keys

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -27,6 +27,7 @@
     "dialogTitleCreate": "选择卡拉OK曲库的存放位置",
     "dialogTitleOpen": "打开已有的卡拉OK曲库",
     "chooseLanguage": "选择语言",
+    "openRemoteLibrary": "选择远程服务商",
     "openRemoteLibraryDescription": "连接 Google Drive、Dropbox 或 WebDAV 作为你的远程资料库。",
     "remoteProvider": {
       "googleDrive": {
@@ -183,6 +184,7 @@
   },
   "progress": {
     "separating": "正在分离：{{title}}",
+    "uploadingToRemote": "正在发布到远程资料库：{{title}}",
     "modelDownloadComplete": "模型下载完成"
   },
   "queue": {


### PR DESCRIPTION
Fixes #209

## Problem

Two user-facing keys in the remote-library flow were absent from **both** locales and relied on inline English `defaultValue`, so zh-CN users saw raw English:

- `setup.openRemoteLibrary` — the remote setup wizard H1 (English title over an already-translated Chinese subtitle → mixed-language screen)
- `progress.uploadingToRemote` — the upload progress bar label

The `en↔zh` parity test in `locales.test.ts` passed because a key missing from *both* locales still has matching (empty) key sets, and the `defaultValue` masked the gap in dev.

## Fix

- Added both keys to `en.json` and `zh-CN.json` and removed the `defaultValue` fallbacks at all three call sites (`LibrarySetup.tsx`, `GlobalProgressBar.tsx`, `SongListItem.tsx`).
  - `setup.openRemoteLibrary`: `Choose a remote provider` / `选择远程服务商`
  - `progress.uploadingToRemote`: `Publishing to remote repository: {{title}}` / `正在发布到远程资料库：{{title}}`
- Strengthened `locales.test.ts` with a remote-flow completeness guard: it scans static `t("literal")` calls across the remote-library flow files and fails when a referenced key (with or without a `defaultValue`) is missing from either locale. Plural keys are resolved through i18next `_one`/`_other`/… suffixes to avoid false positives (e.g. `library.confirmDeleteTitle`).
- Verified no other remote-flow key was missing: a scan of all 113 static `t()` keys in the flow surfaced only these two genuine gaps (plus the plural false positive, now handled).

## Acceptance criteria

- **(a)** Both keys resolve in `en.json` and `zh-CN.json`; no `defaultValue` at the call sites. ✅
- **(b)** The remote wizard renders a translated H1 in zh-CN (`选择远程服务商`). ✅
- **(c)** `locales.test.ts` now fails when a source `t()` key (with or without `defaultValue`) is absent from a locale — verified by simulating removal of the new keys. ✅
- **(d)** Grep confirms no remaining shipped `t(...)` in the remote flow depends on `defaultValue` for a missing key. ✅

## Testing

- `pnpm vitest run` (locale + remote-flow suites): 296 passed / 31 files
- `pnpm lint` (oxlint `--deny-warnings`): clean, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
