### PR TITLE
fix(library): atomic media import and net downgrade savings (#206, #207)

### DIFF
--- a/src-tauri/src/cache/stems.rs
+++ b/src-tauri/src/cache/stems.rs
@@ -458,9 +458,14 @@ pub fn downgrade_to_two_stem(
     )
     .context("failed to write accompaniment.ogg")?;
 
-    let freed_bytes = file_size_or_zero(&drums_abs)
+    // Net disk reclaimed = bytes of the deleted individual stems minus the bytes
+    // of the accompaniment.ogg we just wrote in their place. Reporting only the
+    // deleted stems over-states the savings by roughly one stem's worth (#207).
+    let deleted_bytes = file_size_or_zero(&drums_abs)
         + file_size_or_zero(&bass_abs)
         + file_size_or_zero(&other_abs);
+    let accompaniment_bytes = file_size_or_zero(&accomp_abs);
+    let freed_bytes = deleted_bytes.saturating_sub(accompaniment_bytes);
 
     fs::remove_file(&drums_abs)
         .with_context(|| format!("failed to remove {}", drums_abs.display()))?;
@@ -516,7 +521,16 @@ pub fn batch_downgrade_to_two_stem(
     Ok((count, total_freed))
 }
 
-/// Estimate the disk space that would be freed by downgrading all 4-stem entries to 2-stem.
+/// Estimate the disk space that would be freed by downgrading all 4-stem entries
+/// to 2-stem.
+///
+/// Downgrading deletes the drums/bass/other stems but writes a new
+/// accompaniment.ogg in their place, so the net reclaimed space is the deleted
+/// bytes minus the accompaniment. The accompaniment does not exist yet at
+/// estimate time, so we approximate its size with the existing vocals stem: it
+/// is a single stem encoded with the same OGG/Vorbis settings, making it a close
+/// proxy for the accompaniment mix. Without this offset the estimate over-reports
+/// by roughly one stem's worth (#207).
 pub fn estimate_downgrade_savings(
     connection: &Connection,
     library_root: &LibraryRoot,
@@ -526,12 +540,19 @@ pub fn estimate_downgrade_savings(
 
     let mut total = 0u64;
     for entry in entries.iter().filter(|e| e.has_individual_stems()) {
+        let mut deleted_bytes = 0u64;
         for rel_path in [&entry.drums_path, &entry.bass_path, &entry.other_path]
             .into_iter()
             .flatten()
         {
-            total += file_size_or_zero(&library_root.resolve(rel_path));
+            deleted_bytes += file_size_or_zero(&library_root.resolve(rel_path));
         }
+
+        // Approximate the accompaniment that would be written using the existing
+        // vocals stem as a same-encoding proxy.
+        let accompaniment_estimate = file_size_or_zero(&library_root.resolve(&entry.vocals_path));
+
+        total += deleted_bytes.saturating_sub(accompaniment_estimate);
     }
 
     Ok(total)

--- a/src-tauri/src/library/import/ingest.rs
+++ b/src-tauri/src/library/import/ingest.rs
@@ -16,8 +16,10 @@ use sha2::{Digest, Sha256};
 use std::{
     collections::{HashMap, HashSet},
     fs::{self, File},
-    io::Read,
+    io::{self, Read},
     path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use crate::lyrics::fetch::LyricsSource;
@@ -87,16 +89,7 @@ pub(super) fn build_and_store_song(
     let ext = source.extension().and_then(|e| e.to_str()).unwrap_or("bin");
 
     let dest = library.media_path(&hash, ext);
-    if !dest.exists() {
-        if let Some(parent) = dest.parent() {
-            fs::create_dir_all(parent).with_context(|| {
-                format!("failed to create media directory {}", parent.display())
-            })?;
-        }
-        fs::copy(source, &dest).with_context(|| {
-            format!("failed to copy {} to {}", source.display(), dest.display())
-        })?;
-    }
+    import_media_file(source, &dest)?;
 
     let relative_path = format!("media/{}.{}", hash, ext);
     let title = metadata.title.or_else(|| {
@@ -144,9 +137,9 @@ pub(super) fn build_and_store_media_g_pair(
     let ext = source.extension().and_then(|e| e.to_str()).unwrap_or("bin");
 
     let audio_dest = library.media_g_audio_path(&hash, ext);
-    copy_if_missing(source, &audio_dest)?;
+    import_media_file(source, &audio_dest)?;
     let cdg_dest = library.media_g_cdg_path(&hash);
-    copy_if_missing(cdg_source, &cdg_dest)?;
+    import_media_file(cdg_source, &cdg_dest)?;
 
     let title = metadata.title.or_else(|| {
         source
@@ -179,7 +172,7 @@ pub(super) fn build_and_store_media_g_zip(source: &Path, library: &LibraryRoot) 
     let hash = media_g::media_g_hash(&asset.audio_bytes, &asset.cdg_bytes);
     let imported_at = current_unix_timestamp()?;
     let dest = library.media_g_zip_path(&hash);
-    copy_if_missing(source, &dest)?;
+    import_media_file(source, &dest)?;
 
     let title = metadata.title.or(Some(asset.display_stem));
 
@@ -202,23 +195,109 @@ pub(super) fn build_and_store_media_g_zip(source: &Path, library: &LibraryRoot) 
     })
 }
 
-pub(super) fn copy_if_missing(source: &Path, destination: &Path) -> Result<()> {
-    if destination.exists() {
+/// Import a media asset into the content-addressed library store.
+///
+/// The destination is content-addressed, so a valid prior copy is a byte-for-byte
+/// duplicate of `source` and therefore shares its size. When a file already exists
+/// at `destination` and its size matches the source, it is trusted and left in
+/// place. Otherwise — the file is missing, or is a truncated/partial leftover from
+/// an interrupted copy (ENOSPC, crash, cancel) — the source is re-copied
+/// atomically. Guarding only on existence (the previous behaviour) let a truncated
+/// file at the canonical path be silently accepted as complete on re-import.
+pub(super) fn import_media_file(source: &Path, destination: &Path) -> Result<()> {
+    if existing_copy_is_intact(source, destination) {
         return Ok(());
     }
+    copy_atomic(source, destination)
+}
 
+/// Returns true when `destination` already holds a complete copy of `source`,
+/// judged by byte length. A content-addressed copy is byte-identical to its
+/// source, so a size match is sufficient to trust it; a shorter (or otherwise
+/// mismatched) file signals a partial write that must be re-copied.
+fn existing_copy_is_intact(source: &Path, destination: &Path) -> bool {
+    let Ok(dest_meta) = fs::metadata(destination) else {
+        return false;
+    };
+    if !dest_meta.is_file() {
+        return false;
+    }
+    match fs::metadata(source) {
+        Ok(source_meta) => source_meta.len() == dest_meta.len(),
+        Err(_) => false,
+    }
+}
+
+/// Copy `source` to `destination` atomically: stream into a uniquely named temp
+/// file in the destination directory (same filesystem), fsync it, then rename it
+/// into place. On any failure the temp file is removed, so an interrupted copy
+/// never leaves a partial file at the canonical content-addressed path. Mirrors
+/// the temp+fsync+rename discipline of `StreamingOggWriter` and the model
+/// download promotion.
+fn copy_atomic(source: &Path, destination: &Path) -> Result<()> {
     if let Some(parent) = destination.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("failed to create media directory {}", parent.display()))?;
     }
-    fs::copy(source, destination).with_context(|| {
-        format!(
-            "failed to copy {} to {}",
-            source.display(),
-            destination.display()
-        )
-    })?;
+
+    let temp_path = temp_sibling_path(destination);
+
+    // Stream the full payload into the temp file and fsync it before promotion.
+    // Scope the handles so they are closed before the rename.
+    let staged = (|| -> Result<()> {
+        let mut reader = File::open(source)
+            .with_context(|| format!("failed to open source file {}", source.display()))?;
+        let mut writer = File::create(&temp_path)
+            .with_context(|| format!("failed to create temp media file {}", temp_path.display()))?;
+        io::copy(&mut reader, &mut writer).with_context(|| {
+            format!(
+                "failed to copy {} to {}",
+                source.display(),
+                temp_path.display()
+            )
+        })?;
+        writer
+            .sync_all()
+            .with_context(|| format!("failed to fsync {}", temp_path.display()))?;
+        Ok(())
+    })();
+
+    if let Err(error) = staged {
+        let _ = fs::remove_file(&temp_path);
+        return Err(error);
+    }
+
+    if let Err(error) = fs::rename(&temp_path, destination) {
+        let _ = fs::remove_file(&temp_path);
+        return Err(error).with_context(|| {
+            format!(
+                "failed to promote temp media file from {} to {}",
+                temp_path.display(),
+                destination.display()
+            )
+        });
+    }
+
     Ok(())
+}
+
+/// Build a unique temp path in the same directory as `destination` so the final
+/// rename stays on one filesystem (and is therefore atomic). Uniqueness across
+/// concurrent imports comes from the process id, a monotonic counter, and a
+/// nanosecond timestamp.
+fn temp_sibling_path(destination: &Path) -> PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_nanos())
+        .unwrap_or(0);
+    let pid = std::process::id();
+    let file_name = destination
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "media".to_owned());
+    destination.with_file_name(format!("{file_name}.import.{pid}.{counter}.{nanos}.tmp"))
 }
 
 pub(super) fn sha256_for_file(path: &Path) -> Result<String> {
@@ -346,5 +425,160 @@ mod tests {
         try_extract_embedded_lyrics(&connection, &song, &library);
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    fn scratch_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "ingest_{label}_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("scratch dir should create");
+        dir
+    }
+
+    /// #206 acceptance: when the copy is aborted after the temp file is created
+    /// (here the promotion rename fails because a directory occupies the
+    /// canonical path), the temp is cleaned up and the canonical path is never
+    /// replaced by a partial file.
+    #[test]
+    fn copy_atomic_cleans_temp_and_never_writes_partial_dest_on_promotion_failure() {
+        let dir = scratch_dir("copyatomic_promote_fail");
+        let media = dir.join("media");
+        fs::create_dir_all(&media).expect("media dir");
+
+        let source = dir.join("source.bin");
+        fs::write(&source, b"the complete source payload").expect("source write");
+
+        // A directory at the canonical path forces `fs::rename` to fail after the
+        // temp file has been fully written and fsynced.
+        let dest = media.join("deadbeef.bin");
+        fs::create_dir_all(&dest).expect("dest directory stand-in");
+
+        let result = copy_atomic(&source, &dest);
+        assert!(result.is_err(), "promotion onto a directory must fail");
+        assert!(dest.is_dir(), "canonical path must be left untouched");
+
+        // The temp file must have been removed: only the `dest` directory remains.
+        let remaining: Vec<_> = fs::read_dir(&media)
+            .expect("read media dir")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name())
+            .collect();
+        assert_eq!(
+            remaining.len(),
+            1,
+            "only the canonical path should remain, found: {remaining:?}"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// #206 acceptance (unix): when the copy fails while reading the source
+    /// (a directory used as a source yields EISDIR partway), no file is left at
+    /// the canonical destination and any temp file is cleaned up.
+    #[cfg(unix)]
+    #[test]
+    fn copy_atomic_leaves_no_dest_and_cleans_temp_on_read_failure() {
+        let dir = scratch_dir("copyatomic_read_fail");
+        let media = dir.join("media");
+        fs::create_dir_all(&media).expect("media dir");
+
+        // Using a directory as the copy source: opening it may succeed but the
+        // read fails, aborting the copy after the temp file exists.
+        let source = dir.join("unreadable_source");
+        fs::create_dir_all(&source).expect("source directory");
+        let dest = media.join("deadbeef.bin");
+
+        let result = copy_atomic(&source, &dest);
+        assert!(result.is_err(), "copy from an unreadable source must fail");
+        assert!(
+            !dest.exists(),
+            "canonical path must not exist after a failed copy"
+        );
+
+        let remaining: Vec<_> = fs::read_dir(&media)
+            .expect("read media dir")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name())
+            .collect();
+        assert!(
+            remaining.is_empty(),
+            "temp files must be cleaned up, found: {remaining:?}"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// #206 acceptance: a truncated file already at the content-addressed path is
+    /// not trusted; `import_media_file` re-copies so the destination ends up
+    /// byte-identical (hence equal size and sha256) to the source.
+    #[test]
+    fn import_media_file_repairs_truncated_existing_destination() {
+        let dir = scratch_dir("import_repair_truncated");
+        let media = dir.join("media");
+        fs::create_dir_all(&media).expect("media dir");
+
+        let source = dir.join("source.bin");
+        let payload: Vec<u8> = (0..4096_u32).map(|i| (i % 251) as u8).collect();
+        fs::write(&source, &payload).expect("source write");
+
+        // Simulate a truncated leftover at the canonical path.
+        let dest = media.join("deadbeef.bin");
+        fs::write(&dest, &payload[..128]).expect("truncated dest write");
+        assert!(fs::metadata(&dest).unwrap().len() < payload.len() as u64);
+
+        import_media_file(&source, &dest).expect("import should repair the truncated file");
+
+        let repaired = fs::read(&dest).expect("dest read");
+        assert_eq!(
+            repaired.len(),
+            payload.len(),
+            "repaired size must equal source size"
+        );
+        assert_eq!(
+            sha256_for_file(&dest).unwrap(),
+            sha256_for_file(&source).unwrap(),
+            "repaired sha256 must equal source sha256"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// A complete existing copy (same size) is trusted and left untouched.
+    #[test]
+    fn import_media_file_trusts_intact_existing_destination() {
+        let dir = scratch_dir("import_trust_intact");
+        let media = dir.join("media");
+        fs::create_dir_all(&media).expect("media dir");
+
+        let source = dir.join("source.bin");
+        let payload = b"identical bytes on both sides".to_vec();
+        fs::write(&source, &payload).expect("source write");
+
+        let dest = media.join("deadbeef.bin");
+        fs::write(&dest, &payload).expect("dest write");
+        let mtime_before = fs::metadata(&dest).unwrap().modified().ok();
+
+        import_media_file(&source, &dest).expect("import of an intact copy should succeed");
+
+        assert_eq!(fs::read(&dest).unwrap(), payload);
+        // No temp files should have been created for a trusted copy.
+        let extra_files = fs::read_dir(&media)
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.path() != dest)
+            .count();
+        assert_eq!(extra_files, 0, "no temp files for a trusted copy");
+        if let Some(before) = mtime_before {
+            assert_eq!(
+                fs::metadata(&dest).unwrap().modified().ok(),
+                Some(before),
+                "an intact destination should not be rewritten"
+            );
+        }
+
+        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/src-tauri/tests/phase1_import.rs
+++ b/src-tauri/tests/phase1_import.rs
@@ -76,6 +76,53 @@ fn imports_fixture_audio_and_persists_library_rows() {
     assert_eq!(library.len(), 2);
 }
 
+/// #206: a truncated/partial file left at the content-addressed media path from
+/// an interrupted copy must not be silently accepted on re-import. The import
+/// must re-copy so the on-disk media ends up byte-identical (equal size and
+/// sha256) to the source.
+#[test]
+fn reimport_repairs_truncated_content_addressed_media() {
+    let connection = Connection::open_in_memory().expect("in-memory database should open");
+    cache::apply_migrations(&connection).expect("migrations should succeed");
+    let (_tmp, library) = temp_library();
+
+    let source = fixture_path("fixture.mp3");
+    let source_bytes = fs::read(&source).expect("fixture bytes should read");
+
+    // First import lands a complete copy at the canonical path.
+    let first = import_songs_from_paths(&connection, &library, std::slice::from_ref(&source));
+    assert_eq!(first.imported.len(), 1);
+    let media_rel = first.imported[0]
+        .file_path
+        .clone()
+        .expect("imported song should have a file path");
+    let media_abs = library.resolve(&media_rel);
+    assert_eq!(
+        fs::read(&media_abs).expect("media bytes should read"),
+        source_bytes,
+        "first import should copy the source verbatim"
+    );
+
+    // Simulate a truncated leftover from a crash/ENOSPC mid-copy: the file
+    // "exists" at the canonical path but holds fewer bytes than the source.
+    fs::write(&media_abs, &source_bytes[..source_bytes.len() / 2])
+        .expect("truncation should write");
+    assert!(
+        fs::metadata(&media_abs).unwrap().len() < source_bytes.len() as u64,
+        "media file should now be truncated"
+    );
+
+    // Re-importing the same source must repair the truncated file.
+    let second = import_songs_from_paths(&connection, &library, std::slice::from_ref(&source));
+    assert_eq!(second.imported.len(), 1);
+    assert!(second.failed.is_empty());
+    assert_eq!(
+        fs::read(&media_abs).expect("repaired media bytes should read"),
+        source_bytes,
+        "re-import must repair the truncated media to match the source exactly"
+    );
+}
+
 #[test]
 fn reports_failures_without_aborting_other_imports() {
     let connection = Connection::open_in_memory().expect("in-memory database should open");

--- a/src-tauri/tests/phase3_stems_cache.rs
+++ b/src-tauri/tests/phase3_stems_cache.rs
@@ -380,6 +380,109 @@ fn downgrade_to_two_stem_rewrites_accompaniment_metadata() {
     cleanup_dir(&library_root_path);
 }
 
+/// #207: `downgrade_to_two_stem` must report the NET disk reclaimed, i.e. the
+/// deleted drums+bass+other bytes minus the newly written accompaniment.ogg —
+/// not the gross sum of the deleted stems.
+#[test]
+fn downgrade_freed_bytes_nets_out_written_accompaniment() {
+    let connection = Connection::open_in_memory().expect("in-memory database should open");
+    cache::apply_migrations(&connection).expect("migrations should succeed");
+    let library = unique_library_root();
+    let library_root_path = library.root().to_owned();
+    let song = tagged_song_in_library(&library, "song-downgrade-net");
+    cache::upsert_song(&connection, &song).expect("song insert should succeed");
+
+    let cached = populate_stem_cache(
+        &connection,
+        &library,
+        &song,
+        "song-downgrade-net",
+        StemMode::FourStem,
+        "htdemucs",
+    );
+
+    // Sizes of the individual stems on disk, captured before they are deleted.
+    let file_len = |rel: &str| {
+        fs::metadata(library.resolve(rel))
+            .expect("stem metadata")
+            .len()
+    };
+    let deleted_bytes = file_len(cached.entry.drums_path.as_ref().unwrap())
+        + file_len(cached.entry.bass_path.as_ref().unwrap())
+        + file_len(cached.entry.other_path.as_ref().unwrap());
+
+    let (updated_entry, freed_bytes) =
+        stems::downgrade_to_two_stem(&connection, &library, "song-downgrade-net")
+            .expect("downgrade should succeed");
+
+    let accompaniment_bytes = fs::metadata(library.resolve(&updated_entry.accomp_path))
+        .expect("accompaniment metadata")
+        .len();
+
+    assert!(
+        accompaniment_bytes > 0,
+        "a new accompaniment.ogg should have been written"
+    );
+    assert_eq!(
+        freed_bytes,
+        deleted_bytes.saturating_sub(accompaniment_bytes),
+        "freed bytes must net out the newly written accompaniment"
+    );
+    assert!(
+        freed_bytes < deleted_bytes,
+        "net savings must be less than the gross deleted-stem sum"
+    );
+
+    cleanup_dir(&library_root_path);
+}
+
+/// #207: `estimate_downgrade_savings` must net out an accompaniment estimate
+/// (the existing vocals stem is used as a same-encoding proxy) rather than
+/// returning the raw drums+bass+other sum.
+#[test]
+fn estimate_downgrade_savings_nets_out_accompaniment_proxy() {
+    let connection = Connection::open_in_memory().expect("in-memory database should open");
+    cache::apply_migrations(&connection).expect("migrations should succeed");
+    let library = unique_library_root();
+    let library_root_path = library.root().to_owned();
+    let song = tagged_song_in_library(&library, "song-estimate-net");
+    cache::upsert_song(&connection, &song).expect("song insert should succeed");
+
+    let cached = populate_stem_cache(
+        &connection,
+        &library,
+        &song,
+        "song-estimate-net",
+        StemMode::FourStem,
+        "htdemucs",
+    );
+
+    let file_len = |rel: &str| {
+        fs::metadata(library.resolve(rel))
+            .expect("stem metadata")
+            .len()
+    };
+    let deleted_bytes = file_len(cached.entry.drums_path.as_ref().unwrap())
+        + file_len(cached.entry.bass_path.as_ref().unwrap())
+        + file_len(cached.entry.other_path.as_ref().unwrap());
+    let vocals_proxy = file_len(&cached.entry.vocals_path);
+
+    let estimate =
+        stems::estimate_downgrade_savings(&connection, &library).expect("estimate should succeed");
+
+    assert_eq!(
+        estimate,
+        deleted_bytes.saturating_sub(vocals_proxy),
+        "estimate must net out the vocals-sized accompaniment proxy"
+    );
+    assert!(
+        estimate < deleted_bytes,
+        "estimate must be less than the gross deleted-stem sum"
+    );
+
+    cleanup_dir(&library_root_path);
+}
+
 /// Verify that the streaming OGG writer produces a valid file that can
 /// be decoded back, confirming the streaming path produces correct output.
 #[test]


### PR DESCRIPTION
Fixes #206
Fixes #207

Two library/cache correctness bugs on the `src-tauri` import and downgrade paths, fixed together.

## #206 — Atomic, verified media import

**Problem:** `build_and_store_song` and `copy_if_missing` copied media straight to the final content-addressed path guarded only by `!dest.exists()`. A crash / ENOSPC / cancel mid-copy left a truncated but non-empty file there; on re-import the source hash (and therefore the dest path) was identical, `dest.exists()` was true, the copy was skipped, and the song was registered pointing at the corrupt file. The integrity audit only flags missing or zero-byte files, so the truncation was silent and persistent.

**Fix:** Both copy sites now go through a single `import_media_file`:
- Trust an existing destination only when its size matches the source (a content-addressed copy is byte-identical, so a size mismatch means a partial/truncated leftover) — otherwise re-copy.
- `copy_atomic` streams the source into a uniquely named sibling temp file (same directory → same filesystem), `fsync`s it, then `fs::rename`s it into place. The temp file is removed on any error, so an interrupted copy never leaves a partial file at the canonical path. This mirrors `StreamingOggWriter` and the model-download promotion.
- `copy_if_missing` is removed; its three Media+G call sites now use `import_media_file`.

## #207 — Net downgrade disk-savings figures

**Problem:** `downgrade_to_two_stem` reported `freed_bytes` as only the deleted drums+bass+other bytes, ignoring the new `accompaniment.ogg` it wrote (~one stem's worth). `estimate_downgrade_savings` likewise summed only drums/bass/other. Both figures flow to the maintenance UI and over-reported by roughly 1/3.

**Fix:**
- `downgrade_to_two_stem` returns `(deleted drums+bass+other) − (bytes of the written accompaniment.ogg)` (saturating).
- `estimate_downgrade_savings` nets out an accompaniment estimate, using the existing vocals stem as a same-encoding size proxy (documented in the function).

## Acceptance criteria

#206
- Test `import_media_file_repairs_truncated_existing_destination`: a truncated file pre-placed at the content-addressed path is re-copied so the dest ends byte-identical (equal size and sha256) to the source.
- Test `reimport_repairs_truncated_content_addressed_media` (integration): full import path — import, truncate the on-disk media, re-import, assert the media matches the source exactly.
- Test `copy_atomic_cleans_temp_and_never_writes_partial_dest_on_promotion_failure` and `copy_atomic_leaves_no_dest_and_cleans_temp_on_read_failure` (unix): a copy forced to fail leaves no file at the canonical dest and cleans up the temp.

#207
- Test `downgrade_freed_bytes_nets_out_written_accompaniment`: asserts `freed_bytes == (deleted drums+bass+other) − (written accompaniment.ogg bytes)`.
- Test `estimate_downgrade_savings_nets_out_accompaniment_proxy`: asserts the estimate nets out the documented vocals-sized accompaniment proxy rather than returning the raw sum.

## Local gates

- `cargo nextest run` (scoped to the affected import/stems tests): 24 passed.
- `cargo clippy --all-targets -- -D warnings`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)