### PR TITLE
fix(lyrics): stabilize scroll follow across ambience, layout, and resize

### DIFF
--- a/src/components/Playback/PlaybackStage.test.tsx
+++ b/src/components/Playback/PlaybackStage.test.tsx
@@ -66,7 +66,11 @@ vi.mock("@/components/Cdg/CdgCanvas", () => ({
 }));
 
 vi.mock("@/components/Lyrics/LyricsPanel", () => ({
-  LyricsPanel: () => <div data-testid="lyrics-panel">Lyrics</div>,
+  LyricsPanel: () => (
+    <div data-testid="lyrics-panel">
+      <div data-testid="lyrics-scroll-viewport">Lyrics</div>
+    </div>
+  ),
 }));
 
 vi.mock("@/lib/tauri/library", () => ({
@@ -176,5 +180,82 @@ describe("PlaybackStage", () => {
     await act(async () => {
       root.unmount();
     });
+  });
+
+  test("keeps the lyrics scroll viewport mounted when the ambience backdrop resolves mid-song (#200)", async () => {
+    mockCdgState.hasCdg = false;
+    mockLibraryState.songs = [
+      {
+        hash: "song-async-cover",
+        file_path: "song.mp3",
+        audio_source_kind: "original",
+        cdg_path: null,
+        media_g_container: null,
+        instrumental: false,
+        title: "Async Cover",
+        artist: null,
+        album: null,
+        duration_ms: 1000,
+        // No inlined cover_art: the backdrop is fetched on-demand and flips
+        // stageAmbience false→true a second into playback.
+        cover_art: null,
+        has_cover_art: true,
+        imported_at: 0,
+        original_ext: "mp3",
+      },
+    ] as Song[];
+    mockPlayerState.snapshot = { song_id: "song-async-cover" };
+
+    let resolveFetch: (bytes: number[]) => void = () => {};
+    mockGetCoverArtPreview.mockReturnValue(
+      new Promise<number[]>((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(<PlaybackStage />);
+    });
+
+    // Before the backdrop resolves the stage is the plain (non-ambience) lyric
+    // stage, and the scroll viewport is mounted.
+    const stage = container.querySelector("[data-stage-visual-variant]");
+    expect(stage?.getAttribute("data-stage-visual-variant")).toBe("default");
+    const viewportBefore = container.querySelector(
+      "[data-testid='lyrics-scroll-viewport']",
+    ) as HTMLDivElement;
+    expect(viewportBefore).toBeTruthy();
+    // Simulate mid-song follow position: the user is a few lines in.
+    viewportBefore.scrollTop = 240;
+
+    // The async cover-art preview lands mid-playback → ambience flips on.
+    await act(async () => {
+      resolveFetch([0xff, 0xd8, 0x00]);
+      await Promise.resolve();
+    });
+
+    const stageAfter = container.querySelector("[data-stage-visual-variant]");
+    expect(stageAfter?.getAttribute("data-stage-visual-variant")).toBe(
+      "ambience",
+    );
+    expect(
+      container.querySelector("[data-native-stage-backdrop='true']"),
+    ).toBeTruthy();
+
+    const viewportAfter = container.querySelector(
+      "[data-testid='lyrics-scroll-viewport']",
+    ) as HTMLDivElement;
+    // Same DOM node instance: the panel was not remounted, so the line-runtime
+    // springs are intact (no gather replay) and scrollTop is preserved.
+    expect(viewportAfter).toBe(viewportBefore);
+    expect(viewportAfter.scrollTop).toBe(240);
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
   });
 });

--- a/src/components/Playback/PlaybackStage.tsx
+++ b/src/components/Playback/PlaybackStage.tsx
@@ -61,6 +61,7 @@ export function PlaybackStage({
     !hasCdg &&
     !currentSongHasCdg &&
     nativeBackdropUrl != null;
+  const showCdg = hasCdg || currentSongHasCdg;
 
   return (
     <div
@@ -72,29 +73,41 @@ export function PlaybackStage({
           : undefined
       }
     >
-      {stageAmbience ? (
+      {showCdg ? (
+        <CdgCanvas />
+      ) : (
+        // RATIONALE (#200): The ambience backdrop resolves mid-song (async
+        // getCoverArtPreview flips nativeBackdropUrl → stageAmbience false→true).
+        // Rendering LyricsPanel inside the ambience-conditional subtree changed
+        // the element type at its slot, remounting it — which cleared the line
+        // springs (gather replay) and forced scrollTop=0 a second into playback.
+        // Keep LyricsPanel in one stable, keyed slot and toggle the backdrop as
+        // an absolutely-positioned sibling behind it so ambience never remounts
+        // the scroll viewport. CdgCanvas↔LyricsPanel is a genuine media switch
+        // (hasCdg / song metadata), not driven by async cover load.
         <>
-          <div className="absolute inset-0" data-native-stage-backdrop="true">
-            <div
-              className="absolute inset-[-6%] scale-[1.06] bg-center bg-cover"
-              style={{
-                ...(nativeBackdropUrl
-                  ? { backgroundImage: `url(${nativeBackdropUrl})` }
-                  : {}),
-                opacity: "var(--ambience-backdrop-opacity)",
-                filter: "var(--ambience-backdrop-filter)",
-              }}
-            />
-            <div className="absolute inset-0 bg-[var(--ambience-scrim)]" />
-          </div>
-          <div className="relative z-10 flex min-h-0 flex-1 overflow-hidden">
+          {stageAmbience ? (
+            <div className="absolute inset-0" data-native-stage-backdrop="true">
+              <div
+                className="absolute inset-[-6%] scale-[1.06] bg-center bg-cover"
+                style={{
+                  ...(nativeBackdropUrl
+                    ? { backgroundImage: `url(${nativeBackdropUrl})` }
+                    : {}),
+                  opacity: "var(--ambience-backdrop-opacity)",
+                  filter: "var(--ambience-backdrop-filter)",
+                }}
+              />
+              <div className="absolute inset-0 bg-[var(--ambience-scrim)]" />
+            </div>
+          ) : null}
+          <div
+            key="lyrics-stage-slot"
+            className="relative z-10 flex min-h-0 flex-1 overflow-hidden"
+          >
             <LyricsPanel presentation={presentation} />
           </div>
         </>
-      ) : hasCdg || currentSongHasCdg ? (
-        <CdgCanvas />
-      ) : (
-        <LyricsPanel presentation={presentation} />
       )}
     </div>
   );

--- a/src/hooks/use-lyrics-engine.test.tsx
+++ b/src/hooks/use-lyrics-engine.test.tsx
@@ -133,6 +133,46 @@ function Harness(props: {
   );
 }
 
+function defineNumber(el: Element, prop: string, value: number) {
+  Object.defineProperty(el, prop, { value, configurable: true });
+}
+
+// Harness with real line elements so the scroll engine can measure geometry
+// (offsetTop / clientHeight) for the re-anchor tests (#201 / #202). jsdom does
+// not lay out, so the test defines geometry on the mounted nodes directly.
+function ScrollHarness(props: { lyricsFontStep: number; songId?: string }) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [domReady, setDomReady] = useState(false);
+  useLayoutEffect(() => {
+    setDomReady(true);
+  }, []);
+
+  useLyricsEngine({
+    containerRef,
+    isPlainText: false,
+    lyricsFontStep: props.lyricsFontStep,
+    presentation: "standard",
+    songId: props.songId ?? "song-1",
+    viewportActive: domReady,
+    lineRuntime: mockLineRuntime,
+  });
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="scroll-viewport"
+      style={{ height: 100, overflow: "auto" }}
+    >
+      <div data-lyrics-line-index="0" className="w-full">
+        a
+      </div>
+      <div data-lyrics-line-index="1" className="w-full">
+        b
+      </div>
+    </div>
+  );
+}
+
 describe("useLyricsEngine", () => {
   let root: Root;
   let host: HTMLDivElement;
@@ -354,5 +394,152 @@ describe("useLyricsEngine", () => {
     });
 
     expect(mockLyricsState.setActiveLineIndex).toHaveBeenCalled();
+  });
+
+  test("changing the font size re-anchors in place instead of resetting scrollTop to 0 (#201)", () => {
+    // Held on line index 1 (adjustedMs 6000 ≥ the line-1 time of 5000).
+    mockPlayerState.positionMs = 6000;
+
+    act(() => {
+      root.render(<ScrollHarness lyricsFontStep={0} />);
+    });
+
+    const viewport = host.querySelector(
+      "[data-testid='scroll-viewport']",
+    ) as HTMLDivElement;
+    defineNumber(viewport, "clientHeight", 100);
+    defineNumber(viewport, "scrollHeight", 500);
+    const line0 = viewport.querySelector("[data-lyrics-line-index='0']")!;
+    const line1 = viewport.querySelector("[data-lyrics-line-index='1']")!;
+    defineNumber(line0, "offsetTop", 0);
+    defineNumber(line0, "clientHeight", 40);
+    defineNumber(line1, "offsetTop", 200);
+    defineNumber(line1, "clientHeight", 40);
+
+    // Settle onto the held active line: centered target = 200 + 20 - 50 = 170.
+    act(() => {
+      rafCb?.(1000);
+    });
+    expect(viewport.scrollTop).toBe(170);
+
+    // Font size changes mid-song; the active line grows and shifts down.
+    defineNumber(line1, "offsetTop", 260);
+    act(() => {
+      root.render(<ScrollHarness lyricsFontStep={2} />);
+    });
+
+    // The engine effect re-ran, but a layout/font change (same song) must NOT
+    // reset the viewport to the top.
+    expect(viewport.scrollTop).toBe(170);
+    expect(viewport.scrollTop).not.toBe(0);
+
+    // The next frame snaps directly to the recomputed centered target for the
+    // current active line (260 + 20 - 50 = 230) — no animate-from-zero.
+    act(() => {
+      rafCb?.(1100);
+    });
+    expect(viewport.scrollTop).toBe(230);
+    expect(viewport.scrollTop).not.toBe(0);
+  });
+
+  test("re-centers the held active line when the viewport is resized (#202)", () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    let resizeCb: ResizeObserverCallback | null = null;
+    class MockResizeObserver {
+      constructor(cb: ResizeObserverCallback) {
+        resizeCb = cb;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal("ResizeObserver", MockResizeObserver);
+
+    mockLyricsState.activeLineIndex = 1;
+    mockPlayerState.positionMs = 6000;
+
+    act(() => {
+      root.render(<ScrollHarness lyricsFontStep={0} />);
+    });
+
+    const viewport = host.querySelector(
+      "[data-testid='scroll-viewport']",
+    ) as HTMLDivElement;
+    defineNumber(viewport, "clientWidth", 300);
+    defineNumber(viewport, "clientHeight", 100);
+    defineNumber(viewport, "scrollHeight", 500);
+    const line0 = viewport.querySelector("[data-lyrics-line-index='0']")!;
+    const line1 = viewport.querySelector("[data-lyrics-line-index='1']")!;
+    defineNumber(line0, "offsetTop", 0);
+    defineNumber(line0, "clientHeight", 40);
+    defineNumber(line1, "offsetTop", 200);
+    defineNumber(line1, "clientHeight", 40);
+
+    // Held line 1 sits at the target for the current (100px) viewport height.
+    act(() => {
+      rafCb?.(1000);
+    });
+    expect(viewport.scrollTop).toBe(170);
+
+    // Window grows taller (100 → 200). Without a resize observer the engine
+    // would pin scrollTop at the stale 170 until the next line change.
+    defineNumber(viewport, "clientHeight", 200);
+    act(() => {
+      resizeCb?.([], {} as ResizeObserver);
+      vi.advanceTimersByTime(200);
+    });
+
+    // Re-centered for the SAME active line at the new size: 200 + 20 - 100 = 120.
+    expect(viewport.scrollTop).toBe(120);
+
+    vi.useRealTimers();
+  });
+
+  test("does not re-center on resize while the user is browsing (#202)", () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    let resizeCb: ResizeObserverCallback | null = null;
+    class MockResizeObserver {
+      constructor(cb: ResizeObserverCallback) {
+        resizeCb = cb;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal("ResizeObserver", MockResizeObserver);
+
+    mockLyricsState.activeLineIndex = 1;
+    mockPlayerState.positionMs = 6000;
+
+    act(() => {
+      root.render(<ScrollHarness lyricsFontStep={0} />);
+    });
+
+    const viewport = host.querySelector(
+      "[data-testid='scroll-viewport']",
+    ) as HTMLDivElement;
+    defineNumber(viewport, "clientWidth", 300);
+    defineNumber(viewport, "clientHeight", 100);
+    defineNumber(viewport, "scrollHeight", 500);
+    const line1 = viewport.querySelector("[data-lyrics-line-index='1']")!;
+    defineNumber(line1, "offsetTop", 200);
+    defineNumber(line1, "clientHeight", 40);
+
+    // User scrolls away to browse (guard unlocks) and parks at 400.
+    act(() => {
+      viewport.dispatchEvent(new WheelEvent("wheel", { deltaY: 80 }));
+    });
+    viewport.scrollTop = 400;
+
+    // A resize while browsing must not yank the user back to the active line.
+    defineNumber(viewport, "clientHeight", 200);
+    act(() => {
+      resizeCb?.([], {} as ResizeObserver);
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(viewport.scrollTop).toBe(400);
+
+    vi.useRealTimers();
   });
 });

--- a/src/hooks/use-lyrics-engine.ts
+++ b/src/hooks/use-lyrics-engine.ts
@@ -1,4 +1,5 @@
 import { useEffect, useLayoutEffect, useRef, type RefObject } from "react";
+import { getScrollTopForLineIndex } from "@/components/Lyrics/lyrics-scroll";
 import { Spring } from "@/lib/spring";
 import {
   createUserScrollGuard,
@@ -24,6 +25,10 @@ import { useLyricsStore } from "@/stores/lyrics-store";
 import { usePlayerStore } from "@/stores/player-store";
 
 const SCROLL_SPRING = { stiffness: 170, damping: 28, mass: 1 };
+
+// Coalesce continuous resize (drag-resizing the window, sidebar animation)
+// into a single re-anchor snap once the viewport settles (#202).
+const RESIZE_REANCHOR_DEBOUNCE_MS = 120;
 
 /**
  * Unified lyrics runtime (AMLL LyricPlayer shape):
@@ -70,6 +75,11 @@ export function useLyricsEngine(input: {
   const prevActiveLineRef = useRef(-1);
   const prevActiveWordIndexRef = useRef(-1);
   const lastSeekRevisionRef = useRef(usePlayerStore.getState().seekRevision);
+  // Distinguishes a song change (reset to top + replay gather is correct) from
+  // a live layout/font/romanize change (must re-anchor in place, never reset to
+  // 0). Undefined sentinel forces the first real run to be treated as a song
+  // change. See the engine effect below (#201).
+  const engineSongIdRef = useRef<string | null | undefined>(undefined);
 
   // RATIONALE: LyricsPanel early-returns a loading/empty state before the scroll
   // viewport mounts. An effect keyed only on songId would run while
@@ -131,26 +141,46 @@ export function useLyricsEngine(input: {
       typeof window.matchMedia === "function" &&
       window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
+    // RATIONALE (#201): This effect re-runs on lyricsFontStep / layoutVersion /
+    // presentation changes as well as songId. Resetting scrollTop to 0 and
+    // replaying the entrance gather is only correct for a *song change*. A live
+    // font-size / Romanize / layout change must keep the active line put and
+    // re-anchor in place. So gate the reset-to-top on a genuine song change and
+    // otherwise force the next frame to snap to the recomputed centered target
+    // for the current active line (shouldResetScroll-style, no animate-from-0).
+    const isSongChange = engineSongIdRef.current !== songId;
+    engineSongIdRef.current = songId;
+
     const scrollState = scrollStateRef.current;
     const scrollSpring = scrollState.scrollSpring;
-    scrollSpring.jumpTo(0);
-    scrollState.targetScrollTopRef.current = null;
     scrollState.prevActiveIndexRef.current = -1;
     scrollState.prevAdjustedMsRef.current = null;
-    scrollState.lastResumeGenerationRef.current =
-      peekLyricsAutoScrollResumeGeneration();
     lastSeekRevisionRef.current = usePlayerStore.getState().seekRevision;
 
-    const container = containerRef.current;
-    if (container) {
-      const write = () => {
-        container.scrollTop = 0;
-      };
-      if (guardRef.current) {
-        guardRef.current.withProgrammatic(write);
-      } else {
-        write();
+    if (isSongChange) {
+      scrollSpring.jumpTo(0);
+      scrollState.targetScrollTopRef.current = null;
+      scrollState.lastResumeGenerationRef.current =
+        peekLyricsAutoScrollResumeGeneration();
+
+      const container = containerRef.current;
+      if (container) {
+        const write = () => {
+          container.scrollTop = 0;
+        };
+        if (guardRef.current) {
+          guardRef.current.withProgrammatic(write);
+        } else {
+          write();
+        }
       }
+    } else {
+      // Same song, layout/font/romanize changed: leave the spring and scrollTop
+      // where they are and request an explicit resume so the next frame snaps
+      // (jumpTo, not spring-from-0) to the freshly measured centered target for
+      // the current active line. lastResumeGenerationRef is intentionally left
+      // stale so the next tick observes the bump as an explicit resume.
+      requestLyricsAutoScrollResume();
     }
 
     let rafId = 0;
@@ -209,4 +239,99 @@ export function useLyricsEngine(input: {
     layoutVersion,
     lineRuntime,
   ]);
+
+  // RATIONALE (#202): The rAF loop only recomputes the scroll target when the
+  // active line index changes; between line changes it re-asserts the settled
+  // spring pixel position every frame. So resizing the window / maximizing /
+  // toggling the sidebar while a line is held (slow ballads, long instrumental
+  // holds) reflows the content but leaves the spring parked at a stale pixel
+  // target — the active line drifts off-center and stays there until the next
+  // line change. Mirror the audience paging hook and observe the scroll
+  // container; on a real viewport resize, re-center the current active line and
+  // snap the container to it. Skip while the user is browsing (guard active) so
+  // a resize never yanks them, and debounce to coalesce continuous resizes.
+  useLayoutEffect(() => {
+    if (isPlainText || !viewportActive) {
+      return;
+    }
+    const container = containerRef.current;
+    if (!container || typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    // Observe only the viewport box (not the content wrapper): mid-line
+    // per-character emphasis / weight swaps reflow content height while the line
+    // index is unchanged, and re-anchoring on that would reintroduce the exact
+    // jitter tickLyricsEngineScroll deliberately avoids. Content-driven layout
+    // changes (Romanize, font step) are already re-anchored by the engine
+    // effect above via layoutVersion / lyricsFontStep.
+    let lastWidth = container.clientWidth;
+    let lastHeight = container.clientHeight;
+    let debounceId: ReturnType<typeof setTimeout> | null = null;
+
+    const reanchorToActiveLine = () => {
+      debounceId = null;
+      const currentContainer = containerRef.current;
+      if (!currentContainer) {
+        return;
+      }
+      // Never yank a user who has scrolled away to browse the lyrics.
+      if (guardRef.current?.isActive()) {
+        return;
+      }
+      const { lines, activeLineIndex } = useLyricsStore.getState();
+      if (lines.length === 0 || activeLineIndex < 0) {
+        return;
+      }
+      const target = getScrollTopForLineIndex(
+        currentContainer,
+        activeLineIndex,
+      );
+      if (target === null) {
+        return;
+      }
+      const scrollState = scrollStateRef.current;
+      scrollState.scrollSpring.jumpTo(target);
+      scrollState.targetScrollTopRef.current = target;
+      const write = () => {
+        currentContainer.scrollTop = target;
+      };
+      if (guardRef.current) {
+        guardRef.current.withProgrammatic(write);
+      } else {
+        write();
+      }
+    };
+
+    const observer = new ResizeObserver(() => {
+      const currentContainer = containerRef.current;
+      if (!currentContainer) {
+        return;
+      }
+      const width = currentContainer.clientWidth;
+      const height = currentContainer.clientHeight;
+      // ResizeObserver fires an initial callback on observe() and can fire for
+      // sub-pixel/no-op churn; only re-anchor when the viewport box changed.
+      if (width === lastWidth && height === lastHeight) {
+        return;
+      }
+      lastWidth = width;
+      lastHeight = height;
+      if (debounceId !== null) {
+        clearTimeout(debounceId);
+      }
+      debounceId = setTimeout(
+        reanchorToActiveLine,
+        RESIZE_REANCHOR_DEBOUNCE_MS,
+      );
+    });
+    observer.observe(container);
+
+    return () => {
+      if (debounceId !== null) {
+        clearTimeout(debounceId);
+      }
+      observer.disconnect();
+    };
+  }, [containerRef, isPlainText, viewportActive, songId]);
 }


### PR DESCRIPTION
## Summary

Fixes the cluster of "recurring scrolling problems" in the standard lyrics follow path. All three live in `use-lyrics-engine.ts` / `lyrics-engine.ts` / `LyricsPanel.tsx` / `PlaybackStage.tsx`, so they are fixed together on one branch to avoid conflicts.

Fixes #200
Fixes #201
Fixes #202

## Changes

### #200 — Ambience backdrop remounts LyricsPanel mid-song
`PlaybackStage` rendered `<LyricsPanel>` in two structurally different slots of a ternary (inside a Fragment in the ambience branch vs. bare in the fallback). When the on-demand cover-art preview resolved mid-song, `stageAmbience` flipped `false→true`, the top-level child type changed, and React unmounted/remounted `LyricsPanel` — clearing the line-runtime springs (gather replay) and forcing `scrollTop=0` a second into playback.

- `LyricsPanel` now lives in a single stable, keyed slot; the ambience backdrop is rendered as an absolutely-positioned sibling behind it that toggles visibility.
- `CdgCanvas ↔ LyricsPanel` remains a genuine media switch (driven by `hasCdg` / song metadata), never by async cover load.

### #201 — Font-size / Romanize toggle resets scroll to the top
The rAF engine effect depends on `lyricsFontStep` / `presentation` / `layoutVersion` and re-ran on any of them, unconditionally doing `scrollSpring.jumpTo(0)` + `scrollTop=0`. Using the font control or Romanize toggle mid-song flew the lyrics to the top and scrolled back down (twice for Romanize).

- The reset-to-top + gather replay is now gated on a genuine **song change** (tracked via `engineSongIdRef`).
- On a live **layout / font / romanize** change (same song), the viewport is left in place and an explicit resume is requested so the next frame **snaps** (jumpTo, no animate-from-zero) directly to the recomputed centered target for the current active line.

### #202 — Follow never re-centers on viewport resize
Standard mode had no `ResizeObserver`; resizing the window, maximizing, or toggling the sidebar while a line was held left the active line mis-centered until the next line change.

- Added a `ResizeObserver` on the scroll viewport (mirroring `use-audience-plain-text-paging.ts`). On a real viewport-box change it re-centers the current active line and snaps the container to it.
- Skips while the user-scroll guard is active (a resize never yanks a browsing user) and debounces continuous resizes.
- **Deviation from the issue plan** (noted on #202): observes only the viewport box, not the content wrapper — observing the wrapper would re-anchor on mid-line per-character emphasis reflow, reintroducing the exact jitter `tickLyricsEngineScroll` deliberately avoids. Content-driven layout changes (Romanize / font step) are already re-anchored by the #201 path.

## Acceptance criteria

- **#200**: RTL test flips ambience after mount (async cover-art preview resolves) and asserts the scroll viewport DOM node instance is preserved (no remount) and `scrollTop` is unchanged.
- **#201**: test mounts with active line index > 0 and `scrollTop > 0`, changes `lyricsFontStep` without changing `songId`, asserts `scrollTop` never becomes 0 and transitions directly to the recomputed centered target for the current active line.
- **#202**: test drives a held active line, simulates a container size change via a `ResizeObserver` mock, and asserts `scrollTop` is recomputed to the new centered target for that same line; a companion test asserts no re-center while the user is browsing.

## Testing

- `pnpm exec vitest run` — 173 files, 1926 tests pass (includes 5 new tests).
- `pnpm lint` (oxlint `--deny-warnings`), `pnpm format` (oxfmt), `tsc --noEmit` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)