### PR TITLE
fix(lyrics): stop auto-upgrade from overwriting user-authored lyrics (#203)

### DIFF
--- a/src-tauri/src/commands/lyrics.rs
+++ b/src-tauri/src/commands/lyrics.rs
@@ -659,6 +659,10 @@ pub async fn fetch_lyrics_online(
     state: State<'_, AppState>,
     app_handle: AppHandle,
     song_id: String,
+    // True only for the explicit "fetch lyrics online" action. The silent
+    // auto-upgrade fired on song open passes false so it cannot clobber
+    // user-authored lyrics (issue #203).
+    user_initiated: bool,
 ) -> CommandResult<LyricsPayload> {
     let background_state = state.inner().clone();
     let song_id_for_phase1 = song_id.clone();
@@ -691,6 +695,7 @@ pub async fn fetch_lyrics_online(
                     &handle_for_phase3,
                     &song_hash,
                     online_result,
+                    user_initiated,
                 )
             })
             .await
@@ -735,56 +740,95 @@ fn fetch_lyrics_online_phase3(
     app_handle: &AppHandle,
     song_hash: &str,
     online_result: Result<Option<LyricsFetchResult>, LyricsError>,
+    user_initiated: bool,
 ) -> CommandResult<LyricsPayload> {
     remote::run_song_database_mutation_with_result(
         state,
         app_handle,
         |connection| {
-            let result: Result<LyricsPayload, LyricsError> = match online_result {
-                Ok(Some(fetched)) => {
-                    let lines = lyrics::fetch::parse_lyrics_auto(&fetched.raw_lrc)
-                        .map_err(|e| LyricsError::LyricsNotReady(e.to_string()))?;
-                    let raw_lrc = fetched.raw_lrc.clone();
-                    let source = fetched.source.clone();
-                    let offset_ms = lyrics::parser::parse_lrc_metadata(&raw_lrc)
-                        .offset_ms
-                        .unwrap_or(0);
-                    let fetched_at = current_unix_timestamp()
-                        .map_err(|e| LyricsError::Internal(e.to_string()))?;
-
-                    cache::lyrics::upsert_lyrics_cache_entry(
-                        connection,
-                        &LyricsCacheEntry {
-                            song_hash: song_hash.to_owned(),
-                            lrc: fetched.raw_lrc,
-                            source: source.clone(),
-                            offset_ms,
-                            fetched_at,
-                        },
-                    )
-                    .map_err(|e| LyricsError::DatabaseUnavailable(e.to_string()))?;
-
-                    Ok(LyricsPayload {
-                        song_id: song_hash.to_owned(),
-                        lines,
-                        source: Some(source),
-                        offset_ms,
-                        raw_lrc,
-                    })
-                }
-                Ok(None) => Ok(LyricsPayload {
-                    song_id: song_hash.to_owned(),
-                    lines: Vec::new(),
-                    source: None,
-                    offset_ms: 0,
-                    raw_lrc: String::new(),
-                }),
-                Err(e) => Err(e),
-            };
-            result.map_err(Into::into)
+            apply_online_lyrics_result(connection, song_hash, online_result, user_initiated)
+                .map_err(Into::into)
         },
         |payload| payload.source.as_ref().map(|_| payload.song_id.clone()),
     )
+}
+
+/// Cache sources that a silent auto-upgrade (non-user-initiated online fetch)
+/// is allowed to overwrite. Embedded lyrics and the negative-cache marker are
+/// derived, not user-authored, so upgrading them to online synced lyrics is
+/// safe. Every other source — `Manual*`, `Sidecar*`, and already-online
+/// results — is user-authored or user-provided and must never be clobbered by
+/// a background upgrade (issue #203).
+fn is_auto_upgradable_source(source: &LyricsSource) -> bool {
+    matches!(source, LyricsSource::Embedded | LyricsSource::Absent)
+}
+
+/// Applies an online lyrics fetch result to the cache and returns the payload.
+///
+/// When `user_initiated` is false (the silent auto-upgrade fired on song open),
+/// an existing cache entry whose source is not auto-upgradable is preserved and
+/// returned unchanged instead of being overwritten — this is the belt-and-
+/// suspenders guard that keeps a wrong online match from destroying hand-entered
+/// or user-provided lyrics. When `user_initiated` is true (the explicit "fetch
+/// lyrics online" action), the online result always replaces the cache entry.
+fn apply_online_lyrics_result(
+    connection: &Connection,
+    song_hash: &str,
+    online_result: Result<Option<LyricsFetchResult>, LyricsError>,
+    user_initiated: bool,
+) -> Result<LyricsPayload, LyricsError> {
+    match online_result {
+        Ok(Some(fetched)) => {
+            if !user_initiated {
+                if let Some(existing) = cache::lyrics::get_lyrics_cache_entry(connection, song_hash)
+                    .map_err(|e| LyricsError::DatabaseUnavailable(e.to_string()))?
+                {
+                    if !is_auto_upgradable_source(&existing.source) {
+                        // Preserve the user-authored/provided entry untouched.
+                        return payload_from_cached_entry(song_hash.to_owned(), existing);
+                    }
+                }
+            }
+
+            let lines = lyrics::fetch::parse_lyrics_auto(&fetched.raw_lrc)
+                .map_err(|e| LyricsError::LyricsNotReady(e.to_string()))?;
+            let raw_lrc = fetched.raw_lrc.clone();
+            let source = fetched.source.clone();
+            let offset_ms = lyrics::parser::parse_lrc_metadata(&raw_lrc)
+                .offset_ms
+                .unwrap_or(0);
+            let fetched_at =
+                current_unix_timestamp().map_err(|e| LyricsError::Internal(e.to_string()))?;
+
+            cache::lyrics::upsert_lyrics_cache_entry(
+                connection,
+                &LyricsCacheEntry {
+                    song_hash: song_hash.to_owned(),
+                    lrc: fetched.raw_lrc,
+                    source: source.clone(),
+                    offset_ms,
+                    fetched_at,
+                },
+            )
+            .map_err(|e| LyricsError::DatabaseUnavailable(e.to_string()))?;
+
+            Ok(LyricsPayload {
+                song_id: song_hash.to_owned(),
+                lines,
+                source: Some(source),
+                offset_ms,
+                raw_lrc,
+            })
+        }
+        Ok(None) => Ok(LyricsPayload {
+            song_id: song_hash.to_owned(),
+            lines: Vec::new(),
+            source: None,
+            offset_ms: 0,
+            raw_lrc: String::new(),
+        }),
+        Err(e) => Err(e),
+    }
 }
 
 fn plain_text_to_lines(text: &str) -> Vec<LyricLine> {
@@ -877,5 +921,146 @@ mod tests {
         let now = current_unix_timestamp().unwrap();
         let entry = absent_entry(now);
         assert!(!is_negative_cache_expired(&entry));
+    }
+
+    fn test_db() -> Connection {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        cache::apply_migrations(&conn).expect("migrations");
+        conn
+    }
+
+    fn insert_song(conn: &Connection, hash: &str) {
+        let song = crate::library::Song {
+            hash: hash.to_owned(),
+            file_path: Some(format!("media/{hash}.mp3")),
+            cdg_path: None,
+            media_g_container: None,
+            instrumental: false,
+            language: None,
+            audio_source_kind: "original".to_owned(),
+            title: Some("Title".to_owned()),
+            artist: Some("Artist".to_owned()),
+            album: None,
+            duration_ms: 0,
+            cover_art: None,
+            has_cover_art: false,
+            imported_at: 0,
+            original_ext: None,
+        };
+        cache::upsert_song(conn, &song).expect("insert song");
+    }
+
+    fn seed_entry(conn: &Connection, hash: &str, source: LyricsSource, lrc: &str) {
+        cache::lyrics::upsert_lyrics_cache_entry(
+            conn,
+            &LyricsCacheEntry {
+                song_hash: hash.to_owned(),
+                lrc: lrc.to_owned(),
+                source,
+                offset_ms: 0,
+                fetched_at: 1_000_000,
+            },
+        )
+        .expect("seed lyrics entry");
+    }
+
+    fn synced_online_result() -> Result<Option<LyricsFetchResult>, LyricsError> {
+        Ok(Some(LyricsFetchResult {
+            source: LyricsSource::LrcLib,
+            raw_lrc: "[00:01.00]Online line one\n[00:02.00]Online line two\n".to_owned(),
+        }))
+    }
+
+    // Issue #203: the silent auto-upgrade must never overwrite hand-entered
+    // lyrics with an online match (which may be a wrong match for a mistagged
+    // song).
+    #[test]
+    fn auto_upgrade_does_not_clobber_manual_entry() {
+        let conn = test_db();
+        insert_song(&conn, "song-manual");
+        let manual_lrc = "Hand written line one\nHand written line two\n";
+        seed_entry(&conn, "song-manual", LyricsSource::Manual, manual_lrc);
+
+        let payload =
+            apply_online_lyrics_result(&conn, "song-manual", synced_online_result(), false)
+                .expect("apply should succeed");
+
+        // The returned payload and the cache entry both stay Manual.
+        assert_eq!(payload.source, Some(LyricsSource::Manual));
+        assert_eq!(payload.raw_lrc, manual_lrc);
+
+        let stored = cache::lyrics::get_lyrics_cache_entry(&conn, "song-manual")
+            .expect("get")
+            .expect("entry exists");
+        assert_eq!(stored.source, LyricsSource::Manual);
+        assert_eq!(stored.lrc, manual_lrc);
+    }
+
+    #[test]
+    fn auto_upgrade_preserves_manual_ttml_and_lys_and_sidecar() {
+        for (hash, source) in [
+            ("h-manual-ttml", LyricsSource::ManualTtml),
+            ("h-manual-lys", LyricsSource::ManualLys),
+            ("h-sidecar", LyricsSource::Sidecar),
+            ("h-sidecar-ttml", LyricsSource::SidecarTtml),
+            ("h-sidecar-lys", LyricsSource::SidecarLys),
+        ] {
+            let conn = test_db();
+            insert_song(&conn, hash);
+            seed_entry(&conn, hash, source.clone(), "user provided lyric\n");
+
+            let payload = apply_online_lyrics_result(&conn, hash, synced_online_result(), false)
+                .expect("apply should succeed");
+            assert_eq!(payload.source, Some(source.clone()), "source {source:?}");
+
+            let stored = cache::lyrics::get_lyrics_cache_entry(&conn, hash)
+                .expect("get")
+                .expect("entry exists");
+            assert_eq!(stored.source, source, "cache source {source:?}");
+        }
+    }
+
+    #[test]
+    fn user_initiated_fetch_replaces_manual_entry() {
+        let conn = test_db();
+        insert_song(&conn, "song-manual");
+        seed_entry(&conn, "song-manual", LyricsSource::Manual, "Hand written\n");
+
+        // The explicit "fetch lyrics online" action overwrites the manual entry.
+        let payload =
+            apply_online_lyrics_result(&conn, "song-manual", synced_online_result(), true)
+                .expect("apply should succeed");
+
+        assert_eq!(payload.source, Some(LyricsSource::LrcLib));
+
+        let stored = cache::lyrics::get_lyrics_cache_entry(&conn, "song-manual")
+            .expect("get")
+            .expect("entry exists");
+        assert_eq!(stored.source, LyricsSource::LrcLib);
+        assert!(stored.lrc.contains("Online line one"));
+    }
+
+    #[test]
+    fn auto_upgrade_replaces_embedded_entry() {
+        let conn = test_db();
+        insert_song(&conn, "song-embedded");
+        seed_entry(
+            &conn,
+            "song-embedded",
+            LyricsSource::Embedded,
+            "Embedded plain line\n",
+        );
+
+        // Embedded lyrics are derived, not user-authored — auto-upgrade applies.
+        let payload =
+            apply_online_lyrics_result(&conn, "song-embedded", synced_online_result(), false)
+                .expect("apply should succeed");
+
+        assert_eq!(payload.source, Some(LyricsSource::LrcLib));
+
+        let stored = cache::lyrics::get_lyrics_cache_entry(&conn, "song-embedded")
+            .expect("get")
+            .expect("entry exists");
+        assert_eq!(stored.source, LyricsSource::LrcLib);
     }
 }

--- a/src/components/Library/song-list-item-context-menu-build.test.ts
+++ b/src/components/Library/song-list-item-context-menu-build.test.ts
@@ -856,7 +856,7 @@ describe("buildSongListContextMenuForSong – action callbacks", () => {
     const args = mockBuildSongListContextMenuItems.mock.calls[0][0];
     await args.fetchLyricsOnline();
 
-    expect(mockFetchLyricsOnline).toHaveBeenCalledWith("song-abc");
+    expect(mockFetchLyricsOnline).toHaveBeenCalledWith("song-abc", true);
     expect(mockClear).toHaveBeenCalled();
     expect(mockFetchLyrics).toHaveBeenCalledWith("song-abc");
   });

--- a/src/components/Library/song-list-item-context-menu-build.ts
+++ b/src/components/Library/song-list-item-context-menu-build.ts
@@ -161,7 +161,7 @@ export function buildSongListContextMenuForSong(
     },
     fetchLyricsOnline: () => {
       api
-        .fetchLyricsOnline(song.hash)
+        .fetchLyricsOnline(song.hash, true)
         .then((payload) => {
           const currentSongId = usePlayerStore.getState().snapshot?.song_id;
           if (currentSongId === song.hash && payload.lines.length > 0) {

--- a/src/lib/tauri/lyrics.ts
+++ b/src/lib/tauri/lyrics.ts
@@ -26,6 +26,15 @@ export function extractEmbeddedLyrics(songId: string): Promise<LyricsPayload> {
   return invoke<LyricsPayload>("extract_embedded_lyrics", { songId });
 }
 
-export function fetchLyricsOnline(songId: string): Promise<LyricsPayload> {
-  return invoke<LyricsPayload>("fetch_lyrics_online", { songId });
+// `userInitiated` is true only for the explicit "fetch lyrics online" action.
+// The silent auto-upgrade fired on song open passes false so the backend will
+// not overwrite user-authored lyrics (issue #203).
+export function fetchLyricsOnline(
+  songId: string,
+  userInitiated: boolean,
+): Promise<LyricsPayload> {
+  return invoke<LyricsPayload>("fetch_lyrics_online", {
+    songId,
+    userInitiated,
+  });
 }

--- a/src/lib/tauri/tauri-wrappers.test.ts
+++ b/src/lib/tauri/tauri-wrappers.test.ts
@@ -720,11 +720,12 @@ describe("lyrics", () => {
     expect(returned).toBe(lyricsPayload);
   });
 
-  test("fetchLyricsOnline invokes fetch_lyrics_online", async () => {
+  test("fetchLyricsOnline invokes fetch_lyrics_online with userInitiated", async () => {
     mockInvoke.mockResolvedValueOnce(lyricsPayload);
-    const returned = await lyrics.fetchLyricsOnline("song-1");
+    const returned = await lyrics.fetchLyricsOnline("song-1", true);
     expect(mockInvoke).toHaveBeenCalledWith("fetch_lyrics_online", {
       songId: "song-1",
+      userInitiated: true,
     });
     expect(returned).toBe(lyricsPayload);
   });

--- a/src/stores/lyrics-store.test.ts
+++ b/src/stores/lyrics-store.test.ts
@@ -181,10 +181,45 @@ describe("lyrics-store fetchLyrics", () => {
 
     await useLyricsStore.getState().fetchLyrics("song-1");
 
-    expect(mockFetchLyricsOnline).toHaveBeenCalledWith("song-1");
+    expect(mockFetchLyricsOnline).toHaveBeenCalledWith("song-1", false);
     const state = useLyricsStore.getState();
     expect(state.lines).toEqual(synced.lines);
     expect(state.source).toBe("lrc_lib");
+  });
+
+  // Issue #203: user-authored/user-provided sources must never trigger the
+  // silent auto-upgrade, which could overwrite them with a wrong online match.
+  test.each([
+    "manual",
+    "manual_ttml",
+    "manual_lys",
+    "sidecar",
+    "sidecar_ttml",
+    "sidecar_lys",
+  ] as const)("does not auto-upgrade when source is %s", async (source) => {
+    const unsynced = {
+      song_id: "song-1",
+      lines: [
+        {
+          time_ms: 0,
+          text: "Hand written",
+          words: [],
+          bg_words: null,
+          section: null,
+        },
+      ],
+      source,
+      offset_ms: 0,
+      raw_lrc: "Hand written",
+    };
+    mockFetchLyrics.mockResolvedValue(unsynced);
+
+    await useLyricsStore.getState().fetchLyrics("song-1");
+
+    expect(mockFetchLyricsOnline).not.toHaveBeenCalled();
+    const state = useLyricsStore.getState();
+    expect(state.lines).toEqual(unsynced.lines);
+    expect(state.source).toBe(source);
   });
 
   test("does not auto-upgrade when source is lrc_lib", async () => {

--- a/src/stores/lyrics-store.ts
+++ b/src/stores/lyrics-store.ts
@@ -16,6 +16,21 @@ import type { LyricLine, LyricsSource } from "@/types/ipc";
 // Generation counter to prevent stale fetch results from overwriting current lyrics.
 let fetchGeneration = 0;
 
+// Sources that hold user-authored or user-provided lyrics. The silent
+// auto-upgrade must never replace these with an online match (issue #203): a
+// wrong match for a mistagged song would destroy hand-entered or bundled
+// lyrics with no prompt and no undo. Only embedded (and absent) origins are
+// silently upgraded; the explicit "fetch lyrics online" action still works.
+const AUTO_UPGRADE_PROTECTED_SOURCES: ReadonlySet<LyricsSource> =
+  new Set<LyricsSource>([
+    "manual",
+    "manual_ttml",
+    "manual_lys",
+    "sidecar",
+    "sidecar_ttml",
+    "sidecar_lys",
+  ]);
+
 function getSongLanguage(songId: string | null): SongLanguage | null {
   if (!songId) return null;
   const song = useLibraryStore.getState().songs.find((s) => s.hash === songId);
@@ -97,15 +112,22 @@ export const useLyricsStore = create<LyricsState>((set, get) => ({
         isLoading: false,
       });
 
-      // Auto-upgrade: if lyrics are unsynced (all time_ms === 0) and not
-      // from LrcLib, try fetching synced lyrics from the network silently.
+      // Auto-upgrade: if lyrics are unsynced (all time_ms === 0), not from
+      // LrcLib, and not user-authored/user-provided, try fetching synced
+      // lyrics from the network silently. User-authored sources are excluded
+      // so the upgrade cannot silently overwrite manual/sidecar lyrics
+      // (issue #203).
       if (
         payload.lines.length > 0 &&
         payload.source !== "lrc_lib" &&
+        !(
+          payload.source !== null &&
+          AUTO_UPGRADE_PROTECTED_SOURCES.has(payload.source)
+        ) &&
         payload.lines.every((l) => l.time_ms === 0)
       ) {
         try {
-          const online = await api.fetchLyricsOnline(songId);
+          const online = await api.fetchLyricsOnline(songId, false);
           if (
             gen === fetchGeneration &&
             get().songId === songId &&

--- a/src/types/ipc-contract.test.ts
+++ b/src/types/ipc-contract.test.ts
@@ -246,7 +246,7 @@ const LYRICS_COMMANDS: CommandContract[] = [
     frontendFile: "src/lib/tauri/lyrics.ts",
     frontendFn: "fetchLyricsOnline",
     hasArgs: true,
-    rustParams: ["song_id"],
+    rustParams: ["song_id", "user_initiated"],
   },
   {
     command: "save_manual_lyrics",


### PR DESCRIPTION
Fixes #203.

## Problem

The silent lyrics auto-upgrade fired on song open replaced hand-entered manual lyrics (and user-provided sidecar files) with an online synced match whenever the local lyrics were unsynced. The store guard only excluded `lrc_lib`, so `manual`/`manual_ttml`/`manual_lys` (and `sidecar*`) entries qualified, and the backend unconditionally upserted the online result over the user's cache entry. For a mistagged song the online providers can return a WRONG match, permanently overwriting correct manual lyrics with no prompt and no undo.

## Fix

**Frontend (`src/stores/lyrics-store.ts`)** — the auto-upgrade now skips any user-authored/provided source (`manual`, `manual_ttml`, `manual_lys`, `sidecar`, `sidecar_ttml`, `sidecar_lys`). Only embedded (and absent) origins are silently upgraded. The auto-upgrade call now passes `userInitiated: false`.

**Backend (belt-and-suspenders, `src-tauri/src/commands/lyrics.rs`)** — `fetch_lyrics_online` gains a `user_initiated` flag threaded into a new `apply_online_lyrics_result` helper. During auto-upgrade (`user_initiated = false`) an existing cache entry whose source is not `Embedded`/`Absent` is preserved and returned unchanged instead of being clobbered. The explicit "fetch lyrics online" context-menu action passes `user_initiated = true` and still replaces the entry.

## Acceptance criteria

- [x] After saving manual plain-text lyrics for a song that also has an online synced match, reopening keeps the manual lyrics and the cache entry source stays `Manual` — covered by the Rust test `auto_upgrade_does_not_clobber_manual_entry` (and the `manual_ttml`/`manual_lys`/`sidecar*` variants).
- [x] Rust test asserts `fetch_lyrics_online_phase3`'s cache logic does not clobber a `Manual` entry during auto-upgrade (`apply_online_lyrics_result` with `user_initiated = false`); complementary tests confirm embedded IS upgraded and a user-initiated fetch DOES replace.
- [x] Store test asserts `fetchLyricsOnline` is not called when `payload.source` is a manual variant (parameterized over all manual and sidecar variants).

## Testing

- `cargo nextest run -p openkara commands::lyrics cache::lyrics` — 15 passed (4 new)
- `cargo clippy -p openkara --lib --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `pnpm vitest run` on the affected files — 278 passed
- `pnpm lint` + `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)