### PR TITLE
fix(remote): bound streaming range fetches and stream downloads to disk (#204, #205)

### DIFF
--- a/src-tauri/src/audio/remote_source.rs
+++ b/src-tauri/src/audio/remote_source.rs
@@ -191,8 +191,50 @@ pub struct ProviderFetcher {
     client: reqwest::blocking::Client,
 }
 
+/// Connect timeout for the streaming range fetcher's HTTP client.
+const STREAMING_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Per-request timeout for the streaming range fetcher's HTTP client.
+///
+/// Because [`ProviderFetcher::execute_request`] and [`ReqwestFetcher`] consume
+/// the body with a streaming `read()` loop rather than `response.bytes()`,
+/// reqwest's blocking `Read` applies this value as a fresh deadline PER READ —
+/// i.e. an idle timeout. A half-open/stalled connection trips it within this
+/// bound and surfaces a normal `FetchError` (so `fetch_range_with_retry` runs
+/// its backoff and `ConsecutiveFailures` can drive mid-song reconnect), while a
+/// slow-but-steady weak-network transfer keeps making progress and is not
+/// killed (issue #204).
+const STREAMING_READ_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Build the blocking HTTP client used for streaming range fetches with an
+/// explicit connect and per-request (idle) timeout. Falls back to a default
+/// client only if the builder fails (e.g. a TLS backend init error); the
+/// timeouts are the whole point, so the fallback is a last resort.
+fn build_streaming_client(
+    connect_timeout: Duration,
+    read_timeout: Duration,
+) -> reqwest::blocking::Client {
+    reqwest::blocking::Client::builder()
+        .connect_timeout(connect_timeout)
+        .timeout(read_timeout)
+        .build()
+        .unwrap_or_else(|_| reqwest::blocking::Client::new())
+}
+
 impl ProviderFetcher {
     pub fn new(url: String, headers: Vec<(String, String)>) -> Self {
+        Self::with_client(
+            url,
+            headers,
+            build_streaming_client(STREAMING_CONNECT_TIMEOUT, STREAMING_READ_TIMEOUT),
+        )
+    }
+
+    fn with_client(
+        url: String,
+        headers: Vec<(String, String)>,
+        client: reqwest::blocking::Client,
+    ) -> Self {
         Self {
             url,
             headers: std::sync::Mutex::new(headers),
@@ -202,8 +244,24 @@ impl ProviderFetcher {
             credential_generation: AtomicU64::new(0),
             refresh_in_flight: std::sync::Mutex::new(None),
             refresh_condvar: std::sync::Condvar::new(),
-            client: reqwest::blocking::Client::new(),
+            client,
         }
+    }
+
+    /// Test-only constructor that injects a short-timeout client so the stall
+    /// path can be exercised without waiting the production timeout.
+    #[cfg(test)]
+    fn with_read_timeout_for_test(
+        url: String,
+        headers: Vec<(String, String)>,
+        connect_timeout: Duration,
+        read_timeout: Duration,
+    ) -> Self {
+        Self::with_client(
+            url,
+            headers,
+            build_streaming_client(connect_timeout, read_timeout),
+        )
     }
 
     pub fn with_post(mut self, api_arg_header: String) -> Self {
@@ -325,7 +383,7 @@ impl ProviderFetcher {
             builder = builder.header("Dropbox-API-Arg", arg.as_str());
         }
 
-        let response = builder.send().map_err(FetchError::Http)?;
+        let mut response = builder.send().map_err(FetchError::Http)?;
         let status = response.status().as_u16();
 
         if status == 416 {
@@ -344,8 +402,9 @@ impl ProviderFetcher {
             return Err(FetchError::HttpStatus(status));
         }
 
-        let bytes = response.bytes().map_err(FetchError::Http)?;
-        Ok(bytes.to_vec())
+        // Stream the body with a per-read idle timeout instead of buffering it
+        // all under a single total-body deadline. See `STREAMING_READ_TIMEOUT`.
+        read_range_body(&mut response, length)
     }
 }
 
@@ -586,7 +645,9 @@ pub fn spawn_fetch_thread(
     Arc<BandwidthMonitor>,
     std::thread::JoinHandle<()>,
 ) {
-    let client = reqwest::blocking::Client::new();
+    // Build the client with explicit connect + per-request (idle) timeouts so a
+    // half-open/stalled connection cannot hang the fetch thread forever (#204).
+    let client = build_streaming_client(STREAMING_CONNECT_TIMEOUT, STREAMING_READ_TIMEOUT);
     spawn_fetch_thread_with_fetcher(
         url,
         cache,
@@ -644,7 +705,7 @@ impl HttpFetcher for ReqwestFetcher {
         let end = offset + length - 1;
         let range_header = format!("bytes={offset}-{end}");
 
-        let response = self
+        let mut response = self
             .client
             .get(url)
             .header("Range", &range_header)
@@ -673,8 +734,9 @@ impl HttpFetcher for ReqwestFetcher {
             return Err(FetchError::RateLimited(retry_after));
         }
 
-        let bytes = response.bytes().map_err(FetchError::Http)?;
-        Ok(bytes.to_vec())
+        // Stream the body with a per-read idle timeout instead of buffering it
+        // all under a single total-body deadline. See `STREAMING_READ_TIMEOUT`.
+        read_range_body(&mut response, length)
     }
 }
 
@@ -905,6 +967,11 @@ pub enum FetchError {
     HttpStatus(u16),
     RateLimited(Option<Duration>),
     Cache(String),
+    /// An IO error while streaming the response body — includes a per-read
+    /// idle-timeout on a stalled/half-open connection (issue #204). Treated as
+    /// a transient failure so `fetch_range_with_retry` retries and, past the
+    /// threshold, emits `ConsecutiveFailures` to drive reconnect.
+    Io(io::Error),
     /// The server does not support Range requests (HTTP 416 or missing Accept-Ranges).
     RangeNotSupported,
 }
@@ -922,9 +989,46 @@ impl std::fmt::Display for FetchError {
                 Ok(())
             }
             FetchError::Cache(msg) => write!(f, "cache error: {msg}"),
+            FetchError::Io(e) => write!(f, "IO error while streaming range: {e}"),
             FetchError::RangeNotSupported => write!(f, "server does not support Range requests"),
         }
     }
+}
+
+/// Maximum bytes buffered for a single streaming range response. Range chunks
+/// are at most `MAX_PREFETCH_BYTES` (512 KiB); this ceiling only guards against
+/// a server that ignores the Range header and streams a huge body, which the
+/// old `response.bytes()` would have buffered without any bound.
+const MAX_RANGE_RESPONSE_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Read a range response body into memory with a per-read idle timeout.
+///
+/// reqwest's blocking `Read` impl applies the client's configured `timeout` as
+/// a fresh deadline for each read once the body is streaming, so a stalled or
+/// half-open connection trips a bounded timeout (surfaced as `FetchError::Io`)
+/// instead of parking the fetch thread forever (issue #204). A slow-but-steady
+/// weak link keeps making progress and is not killed by a single total-body
+/// deadline. `expected_length` sizes the initial buffer.
+fn read_range_body(
+    response: &mut reqwest::blocking::Response,
+    expected_length: u64,
+) -> Result<Vec<u8>, FetchError> {
+    let capacity = expected_length.min(MAX_RANGE_RESPONSE_BYTES) as usize;
+    let mut body = Vec::with_capacity(capacity);
+    let mut chunk = [0u8; 64 * 1024];
+    loop {
+        let read = response.read(&mut chunk).map_err(FetchError::Io)?;
+        if read == 0 {
+            break;
+        }
+        if body.len() as u64 + read as u64 > MAX_RANGE_RESPONSE_BYTES {
+            return Err(FetchError::Io(io::Error::other(
+                "range response exceeded the maximum buffered size",
+            )));
+        }
+        body.extend_from_slice(&chunk[..read]);
+    }
+    Ok(body)
 }
 
 /// Classify a fetch HTTP status into the shared `RemoteErrorKind` taxonomy.
@@ -1745,5 +1849,146 @@ mod tests {
 
         // Suppress unused mock warning.
         m_success.assert();
+    }
+
+    // ---- streaming range fetcher timeout tests (issue #204) ----
+
+    /// A single-connection mock server that accepts the request, sends 206
+    /// headers promising a body, then never writes the body — a half-open /
+    /// stalled peer. Holds the connection open until dropped so the client's
+    /// per-read idle timeout (not an EOF) is what ends the read.
+    struct StallingRangeServer {
+        url: String,
+        stop: Arc<AtomicBool>,
+        handle: Option<std::thread::JoinHandle<()>>,
+    }
+
+    impl StallingRangeServer {
+        fn spawn() -> Self {
+            use std::io::{Read as _, Write as _};
+            use std::net::TcpListener;
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind stalling server");
+            let addr = listener.local_addr().expect("addr");
+            let stop = Arc::new(AtomicBool::new(false));
+            let stop_thread = Arc::clone(&stop);
+            let handle = std::thread::spawn(move || {
+                let Ok((mut stream, _)) = listener.accept() else {
+                    return;
+                };
+                let mut req = [0u8; 2048];
+                let _ = stream.read(&mut req);
+                let _ = stream.write_all(
+                    b"HTTP/1.1 206 Partial Content\r\nContent-Range: bytes 0-999999/1000000\r\n\
+                      Content-Length: 1000000\r\n\r\n",
+                );
+                let _ = stream.flush();
+                // Hold the connection open without a body until told to stop.
+                while !stop_thread.load(Ordering::Relaxed) {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+            });
+            Self {
+                url: format!("http://{addr}/file"),
+                stop,
+                handle: Some(handle),
+            }
+        }
+    }
+
+    impl Drop for StallingRangeServer {
+        fn drop(&mut self) {
+            self.stop.store(true, Ordering::Relaxed);
+            if let Some(handle) = self.handle.take() {
+                let _ = handle.join();
+            }
+        }
+    }
+
+    #[test]
+    fn provider_fetcher_times_out_on_stalled_body_instead_of_hanging() {
+        // Acceptance (#204): a half-open connection that accepts the Range
+        // request then never writes the body must make `fetch_range` return an
+        // error within a bounded time (~ the read timeout), not block forever.
+        let server = StallingRangeServer::spawn();
+        let fetcher = ProviderFetcher::with_read_timeout_for_test(
+            server.url.clone(),
+            Vec::new(),
+            Duration::from_millis(300),
+            Duration::from_millis(300),
+        );
+
+        let started = std::time::Instant::now();
+        let result = fetcher.fetch_range("", 0, 100);
+        let elapsed = started.elapsed();
+
+        assert!(result.is_err(), "a stalled body must error, not hang");
+        assert!(
+            matches!(result, Err(FetchError::Io(_))),
+            "stall surfaces as an IO/timeout error"
+        );
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "fetch must be bounded by the read timeout, took {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn timed_out_fetch_drives_consecutive_failures_and_thread_exits() {
+        // Acceptance (#204): a timed-out range fetch surfaces as a normal
+        // failure, so `fetch_range_with_retry` runs and, past the threshold,
+        // `ConsecutiveFailures` is emitted to drive reconnect — and the fetch
+        // thread exits cleanly on Shutdown (no leaked thread/socket).
+        let dir = temp_dir("io_timeout_consec");
+        let cache = Arc::new(ChunkedCache::open(&dir, "io1", 100).unwrap());
+
+        let timed_out = || {
+            Err(FetchError::Io(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "simulated stalled connection",
+            )))
+        };
+        let mock = MockFetcher::new(vec![
+            timed_out(),
+            timed_out(),
+            timed_out(),
+            timed_out(),
+            timed_out(),
+        ]);
+
+        let (tx, event_rx, _monitor, handle) = spawn_fetch_thread_with_fetcher(
+            "http://example.com/test.mp3".to_string(),
+            Arc::clone(&cache),
+            Box::new(mock),
+            RetryConfig {
+                initial_delay: Duration::from_millis(1),
+                max_delay: Duration::from_millis(5),
+                max_retries: 0,
+                consecutive_failure_threshold: 5,
+            },
+            None,
+        );
+
+        for i in 0..5u64 {
+            tx.send(FetchCommand::Fetch {
+                offset: i * 100,
+                length: 100,
+            })
+            .unwrap();
+        }
+
+        let event = event_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("ConsecutiveFailures must be emitted for repeated timeouts");
+        assert!(matches!(
+            event,
+            FetchEvent::ConsecutiveFailures { count: 5 }
+        ));
+
+        // The thread must join promptly after Shutdown — the timed-out fetches
+        // returned instead of parking the thread, so no thread/socket leaks.
+        tx.send(FetchCommand::Shutdown).unwrap();
+        handle.join().expect("fetch thread exits after Shutdown");
+
+        cleanup(&dir);
     }
 }

--- a/src-tauri/src/remote/atomic_download.rs
+++ b/src-tauri/src/remote/atomic_download.rs
@@ -216,6 +216,21 @@ fn run_atomic_download(
     Ok(())
 }
 
+/// Durable on-disk length of a streaming download's part file, used to persist
+/// sub-chunk resume progress after a `download_range` interruption.
+///
+/// Providers stream range bytes straight to the part file, so its length is the
+/// true count of bytes received so far. It is at least `floor` (the last
+/// confirmed chunk-boundary offset) and never more than `expected_size`. When
+/// the file cannot be stat-ed, `floor` is returned so progress never regresses.
+fn durable_part_len(temp_path: &Path, floor: u64, expected_size: u64) -> u64 {
+    fs::metadata(temp_path)
+        .map(|m| m.len())
+        .unwrap_or(floor)
+        .max(floor)
+        .min(expected_size)
+}
+
 /// Build the temp path `<destination>.part.<operation_id>`.
 fn part_path(destination: &Path, operation_id: &str) -> PathBuf {
     let file_name = destination
@@ -440,6 +455,12 @@ fn download_to_part_resumable(
             .download_range(relative_path, temp_path, offset, length)
             .map_err(|remote_error| {
                 // Persist progress before returning so a restart resumes.
+                // Providers stream range bytes straight to the part file, so a
+                // mid-chunk interruption leaves durable bytes on disk. Persist
+                // the actual on-disk length (not the chunk start) so the resume
+                // continues from within the chunk instead of re-downloading it
+                // (issue #205 sub-chunk resume).
+                let durable = durable_part_len(temp_path, offset, expected_size);
                 let now = crate::remote::types::current_unix_time_ms();
                 let _ = crate::remote::control_db::upsert_transfer_part(
                     control_db,
@@ -451,7 +472,7 @@ fn download_to_part_resumable(
                         expected_digest: expected_digest.map(str::to_owned),
                         provider_revision: None,
                         provider_session_id: None,
-                        transferred_bytes: offset as i64,
+                        transferred_bytes: durable as i64,
                         state: "in_progress".to_owned(),
                         updated_at_ms: now,
                     },
@@ -511,19 +532,51 @@ fn run_resumable_download(
 
     // Open the temp file in append mode for resumed chunks. If the file does
     // not exist (e.g. the temp was cleaned up but the DB row remained), start
-    // from offset 0.
+    // from offset 0. Otherwise clamp the resume point to the file's actual
+    // length: providers stream range bytes straight to the part file, so a
+    // prior interruption may have left MORE durable bytes than the last
+    // chunk-boundary offset (sub-chunk progress). Resuming from the true
+    // on-disk length avoids re-downloading bytes already on disk, and never
+    // leaves a gap (we never resume past what was written).
     if !temp_path.exists() {
         offset = 0;
+    } else {
+        let file_len = fs::metadata(temp_path).map(|m| m.len()).unwrap_or(offset);
+        offset = offset.max(file_len).min(total);
     }
 
     // Download remaining chunks via Range requests.
     while offset < total {
         let length = RESUMABLE_DOWNLOAD_CHUNK_SIZE.min(total - offset);
+        let chunk_start = offset;
         let verified_bytes = provider
             .download_range(opts.relative_path, temp_path, offset, length)
             .map_err(|remote_error| {
+                // Streaming providers leave durable bytes on a mid-chunk
+                // interruption; persist the actual on-disk length so a restart
+                // resumes from within the chunk instead of re-downloading it
+                // (issue #205 sub-chunk resume).
+                let durable = durable_part_len(temp_path, chunk_start, total);
+                if durable > existing.transferred_bytes.max(0) as u64 {
+                    let now = crate::remote::types::current_unix_time_ms();
+                    let _ = crate::remote::control_db::upsert_transfer_part(
+                        opts.control_db,
+                        &crate::remote::control_db::TransferPartRow {
+                            operation_id: opts.operation_id.to_owned(),
+                            relative_path: opts.relative_path.to_owned(),
+                            direction: crate::remote::control_db::TransferDirection::Download,
+                            expected_size: Some(opts.expected_size as i64),
+                            expected_digest: opts.expected_digest.map(str::to_owned),
+                            provider_revision: opts.provider_revision.map(str::to_owned),
+                            provider_session_id: None,
+                            transferred_bytes: durable as i64,
+                            state: "in_progress".to_owned(),
+                            updated_at_ms: now,
+                        },
+                    );
+                }
                 internal_error(format!(
-                    "resumable download range failed at offset {offset}: {}",
+                    "resumable download range failed at offset {chunk_start}: {}",
                     remote_error.detail.as_deref().unwrap_or(&remote_error.code)
                 ))
             })?;
@@ -1988,6 +2041,11 @@ mod tests {
         revisions: Arc<Mutex<HashMap<String, String>>>,
         /// Fail the Nth range request (0-indexed) by returning an error.
         fail_on_range: Arc<Mutex<Option<usize>>>,
+        /// On the Nth range request (0-indexed), stream only the first M bytes
+        /// of the requested chunk to the destination file, then fail — modeling
+        /// a streaming provider interrupted mid-chunk (issue #205 sub-chunk
+        /// resume). `(call_index, partial_bytes)`.
+        partial_then_fail: Arc<Mutex<Option<(usize, u64)>>>,
         range_call_count: Arc<Mutex<usize>>,
     }
 
@@ -1997,6 +2055,7 @@ mod tests {
                 files: Arc::new(Mutex::new(HashMap::new())),
                 revisions: Arc::new(Mutex::new(HashMap::new())),
                 fail_on_range: Arc::new(Mutex::new(None)),
+                partial_then_fail: Arc::new(Mutex::new(None)),
                 range_call_count: Arc::new(Mutex::new(0)),
             }
         }
@@ -2014,6 +2073,10 @@ mod tests {
 
         fn fail_on_range(&self, index: usize) {
             *self.fail_on_range.lock().unwrap() = Some(index);
+        }
+
+        fn partial_then_fail(&self, index: usize, partial_bytes: u64) {
+            *self.partial_then_fail.lock().unwrap() = Some((index, partial_bytes));
         }
 
         fn range_call_count(&self) -> usize {
@@ -2097,7 +2160,18 @@ mod tests {
                 ));
             }
             let chunk = &data[start..end];
-            // Append the chunk to the destination file at the given offset.
+            // A streaming provider interrupted mid-chunk has already written
+            // the bytes received so far. Model that: write only the first
+            // `partial_bytes` to the file, then fail with a transient error.
+            let partial = {
+                let guard = self.partial_then_fail.lock().unwrap();
+                guard.and_then(|(idx, bytes)| (idx == call_index).then_some(bytes))
+            };
+            let to_write: &[u8] = match partial {
+                Some(bytes) => &chunk[..(bytes as usize).min(chunk.len())],
+                None => chunk,
+            };
+            // Append the bytes to the destination file at the given offset.
             use std::io::Seek;
             let mut file = std::fs::OpenOptions::new()
                 .create(true)
@@ -2116,13 +2190,19 @@ mod tests {
                     format!("failed to seek: {e}"),
                 )
             })?;
-            std::io::Write::write_all(&mut file, chunk).map_err(|e| {
+            std::io::Write::write_all(&mut file, to_write).map_err(|e| {
                 crate::remote::errors::RemoteError::new(
                     crate::remote::errors::RemoteErrorKind::NetworkUnavailable,
                     format!("failed to write chunk: {e}"),
                 )
             })?;
-            Ok(chunk.len() as u64)
+            if partial.is_some() {
+                return Err(crate::remote::errors::RemoteError::new(
+                    crate::remote::errors::RemoteErrorKind::NetworkUnavailable,
+                    "simulated mid-chunk interruption after partial write",
+                ));
+            }
+            Ok(to_write.len() as u64)
         }
 
         fn upload_file(&self, _relative_path: &str) -> CommandResult<()> {
@@ -2347,6 +2427,101 @@ mod tests {
         assert!(
             temp_path.exists(),
             "partial must survive transient range failure for cross-restart resume"
+        );
+    }
+
+    #[test]
+    fn resumable_download_resumes_from_sub_chunk_offset_and_verifies_digest() {
+        // Acceptance (#205 criterion 2): a mid-chunk interruption after N bytes
+        // must resume from ~N bytes written (not the chunk start), and the
+        // completed download must verify against the expected digest.
+        let dir = TempDir::new().expect("temp dir");
+        let dest = dir.path().join("media/song.mp3");
+        let provider = ResumableFakeProvider::new();
+        // 20 MiB file → chunked at 8 MiB. Seed one full chunk (8 MiB) done.
+        let data = vec![0x5Au8; 20 * 1024 * 1024];
+        let digest = sha256_bytes(&data);
+        provider.store_file("media/song.mp3", data.clone(), "rev-1");
+
+        let chunk_start = 8 * 1024 * 1024u64;
+        let partial = 3 * 1024 * 1024u64; // 3 MiB into the second chunk.
+                                          // The first range request writes only 3 MiB of its 8 MiB chunk, then
+                                          // fails — modeling a streaming provider dropped mid-chunk.
+        provider.partial_then_fail(0, partial);
+
+        let (_db_dir, conn) = fresh_control_db();
+
+        let temp_path = part_path(&dest, "op-1");
+        std::fs::create_dir_all(temp_path.parent().unwrap()).unwrap();
+        std::fs::write(&temp_path, &data[..chunk_start as usize]).unwrap();
+        crate::remote::control_db::upsert_transfer_part(
+            &conn,
+            &crate::remote::control_db::TransferPartRow {
+                operation_id: "op-1".to_owned(),
+                relative_path: "media/song.mp3".to_owned(),
+                direction: crate::remote::control_db::TransferDirection::Download,
+                expected_size: Some(data.len() as i64),
+                expected_digest: Some(digest.clone()),
+                provider_revision: Some("rev-1".to_owned()),
+                provider_session_id: None,
+                transferred_bytes: chunk_start as i64,
+                state: "in_progress".to_owned(),
+                updated_at_ms: 1000,
+            },
+        )
+        .unwrap();
+
+        // First attempt: interrupted mid-chunk after `partial` bytes.
+        let result = resumable_atomic_download(
+            &provider,
+            ResumableDownloadOptions {
+                relative_path: "media/song.mp3",
+                destination: &dest,
+                expected_size: data.len() as u64,
+                expected_digest: Some(&digest),
+                operation_id: "op-1",
+                control_db: &conn,
+                provider_revision: Some("rev-1"),
+            },
+        );
+        assert!(result.is_err(), "mid-chunk interruption should propagate");
+
+        // Sub-chunk progress persisted: the offset advanced past the chunk
+        // start by the partially-written bytes (not left at the chunk start).
+        let parts = crate::remote::control_db::list_transfer_parts(&conn, "op-1").unwrap();
+        assert_eq!(parts.len(), 1, "transfer part retained after failure");
+        assert_eq!(
+            parts[0].transferred_bytes as u64,
+            chunk_start + partial,
+            "resume offset must reflect the sub-chunk bytes written to disk"
+        );
+        assert_eq!(
+            std::fs::metadata(&temp_path).unwrap().len(),
+            chunk_start + partial,
+            "durable bytes on disk match the persisted offset"
+        );
+
+        // Second attempt: resumes from the sub-chunk offset and completes.
+        resumable_atomic_download(
+            &provider,
+            ResumableDownloadOptions {
+                relative_path: "media/song.mp3",
+                destination: &dest,
+                expected_size: data.len() as u64,
+                expected_digest: Some(&digest),
+                operation_id: "op-1",
+                control_db: &conn,
+                provider_revision: Some("rev-1"),
+            },
+        )
+        .expect("resume completes and verifies the digest");
+
+        assert_eq!(std::fs::read(&dest).unwrap(), data, "final file matches");
+        assert!(
+            crate::remote::control_db::list_transfer_parts(&conn, "op-1")
+                .unwrap()
+                .is_empty(),
+            "transfer part deleted on success"
         );
     }
 }

--- a/src-tauri/src/remote/dropbox.rs
+++ b/src-tauri/src/remote/dropbox.rs
@@ -13,7 +13,6 @@ use std::{
     cell::RefCell,
     collections::HashMap,
     fs,
-    io::Write,
     net::{Ipv4Addr, SocketAddrV4, TcpListener},
     path::Path,
     sync::{Arc, Mutex, OnceLock},
@@ -978,7 +977,7 @@ pub(crate) fn dropbox_download_file(
     let path_owned = path.to_owned();
     // Rebuild the authorized request on every attempt so the shared network
     // policy can retry transport failures and rate-limits.
-    let response = send_with_retry("download Dropbox file", || {
+    let mut response = send_with_retry("download Dropbox file", || {
         let builder = dropbox_authorized_request(app_data_dir, secret, Method::POST, url.clone())
             .map_err(|e| RemoteError::new(RemoteErrorKind::NetworkUnavailable, e.message))?
             .header(
@@ -1002,21 +1001,19 @@ pub(crate) fn dropbox_download_file(
             )))
         })?;
     }
-    let bytes = response.bytes().map_err(|error| {
-        CommandError::from(LibraryError::Internal(format!(
-            "failed to read Dropbox response: {error}"
-        )))
-    })?;
+    // Stream to disk as bytes arrive rather than buffering the whole file with
+    // `response.bytes()`, so the client timeout acts as a per-read idle timeout
+    // and slow links complete instead of failing at a single total-body
+    // deadline (issue #205).
     let mut file = fs::File::create(destination).map_err(|error| {
         CommandError::from(LibraryError::Internal(format!(
             "failed to create {}: {error}",
             destination.display()
         )))
     })?;
-    file.write_all(bytes.as_ref()).map_err(|error| {
+    crate::remote::net_policy::stream_response_body(&mut response, &mut file).map_err(|error| {
         CommandError::from(LibraryError::Internal(format!(
-            "failed to write {}: {error}",
-            destination.display()
+            "failed to stream Dropbox response: {error}"
         )))
     })?;
     Ok(())
@@ -1504,7 +1501,7 @@ impl RemoteProvider for DropboxProvider<'_> {
         // Dropbox's content download endpoint honors a standard HTTP Range
         // header: bytes=<start>-<end> (inclusive end).
         let range_value = format!("bytes={}-{}", offset, offset + length - 1);
-        let response =
+        let mut response =
             dropbox_authorized_request(self.app_data_dir, &mut secret, Method::POST, url)
                 .map_err(|e| RemoteError::new(RemoteErrorKind::NetworkUnavailable, e.message))?
                 .header(
@@ -1561,27 +1558,6 @@ impl RemoteProvider for DropboxProvider<'_> {
                 )
             })?;
         }
-        let bytes = response.bytes().map_err(|error| {
-            RemoteError::new(
-                RemoteErrorKind::NetworkUnavailable,
-                format!("failed to read Dropbox response: {error}"),
-            )
-        })?;
-
-        // Validate body length: must match the requested range length.
-        // A short response would leave gaps; an oversized response would
-        // write beyond the requested range.
-        let actual_len = bytes.len() as u64;
-        if actual_len != length {
-            return Err(RemoteError::new(
-                RemoteErrorKind::RemoteIntegrityFailed,
-                format!(
-                    "Dropbox range download body length mismatch: \
-                     requested {length} bytes at offset {offset}, got {actual_len} bytes"
-                ),
-            ));
-        }
-
         // Open for write at a specific offset. We intentionally do NOT
         // truncate — the file may already contain bytes from a prior range
         // download, and truncating would destroy them.
@@ -1602,13 +1578,46 @@ impl RemoteProvider for DropboxProvider<'_> {
                 format!("failed to seek {}: {error}", destination.display()),
             )
         })?;
-        file.write_all(bytes.as_ref()).map_err(|error| {
-            RemoteError::new(
+
+        // Stream the body straight to disk as it arrives instead of buffering
+        // the whole chunk with `response.bytes()`. The buffered call imposed
+        // one total-body deadline per 8 MiB chunk; streaming makes the client
+        // timeout a per-read idle timeout so slow links make progress, and an
+        // interruption leaves the received bytes durable for sub-chunk resume
+        // (issue #205).
+        let written = crate::remote::net_policy::stream_response_body(&mut response, &mut file)
+            .map_err(|error| {
+                RemoteError::new(
+                    RemoteErrorKind::NetworkUnavailable,
+                    format!("failed to stream Dropbox range response: {error}"),
+                )
+            })?;
+
+        // Validate body length. For a 206 the body must be exactly `length`
+        // bytes; for a 200 full-body fallback (offset == 0 only) it must be at
+        // least `length`. A truncated transfer is a transport failure, not
+        // corruption, so it stays retryable and the partial bytes on disk are
+        // preserved for resume.
+        if status == reqwest::StatusCode::PARTIAL_CONTENT {
+            if written != length {
+                return Err(RemoteError::new(
+                    RemoteErrorKind::NetworkUnavailable,
+                    format!(
+                        "Dropbox range download body length mismatch: \
+                         requested {length} bytes at offset {offset}, got {written} bytes"
+                    ),
+                ));
+            }
+        } else if written < length {
+            return Err(RemoteError::new(
                 RemoteErrorKind::NetworkUnavailable,
-                format!("failed to write {}: {error}", destination.display()),
-            )
-        })?;
-        Ok(actual_len)
+                format!(
+                    "Dropbox full-body response shorter than requested range: \
+                     requested {length} bytes, got {written} bytes"
+                ),
+            ));
+        }
+        Ok(written)
     }
 
     fn get_revision(&self, relative_path: &str) -> CommandResult<Option<String>> {

--- a/src-tauri/src/remote/google_drive.rs
+++ b/src-tauri/src/remote/google_drive.rs
@@ -18,7 +18,7 @@ use std::{
     cell::RefCell,
     collections::HashMap,
     fs,
-    io::{Seek, SeekFrom, Write},
+    io::{Seek, SeekFrom},
     net::{Ipv4Addr, SocketAddrV4, TcpListener},
     path::Path,
     sync::{Arc, Mutex, OnceLock},
@@ -827,7 +827,7 @@ pub(crate) fn google_drive_download_file(
     use crate::remote::send_with_retry;
 
     let url = google_drive_api_url(&format!("/drive/v3/files/{file_id}?alt=media"))?;
-    let response = send_with_retry("download Google Drive file", || {
+    let mut response = send_with_retry("download Google Drive file", || {
         let builder =
             google_drive_authorized_request(app_data_dir, secret, Method::GET, url.clone())
                 .map_err(|e| RemoteError::new(RemoteErrorKind::NetworkUnavailable, e.message))?;
@@ -847,21 +847,19 @@ pub(crate) fn google_drive_download_file(
             )))
         })?;
     }
-    let bytes = response.bytes().map_err(|error| {
-        CommandError::from(LibraryError::Internal(format!(
-            "failed to read Google Drive response: {error}"
-        )))
-    })?;
+    // Stream to disk as bytes arrive rather than buffering the whole file with
+    // `response.bytes()`, so the client timeout acts as a per-read idle timeout
+    // and slow links complete instead of failing at a single total-body
+    // deadline (issue #205).
     let mut file = fs::File::create(destination).map_err(|error| {
         CommandError::from(LibraryError::Internal(format!(
             "failed to create {}: {error}",
             destination.display()
         )))
     })?;
-    file.write_all(bytes.as_ref()).map_err(|error| {
+    crate::remote::net_policy::stream_response_body(&mut response, &mut file).map_err(|error| {
         CommandError::from(LibraryError::Internal(format!(
-            "failed to write {}: {error}",
-            destination.display()
+            "failed to stream Google Drive response: {error}"
         )))
     })?;
     Ok(())
@@ -1810,7 +1808,7 @@ impl RemoteProvider for GoogleDriveProvider<'_> {
         let url = google_drive_api_url(&format!("/drive/v3/files/{}?alt=media", entry.id))
             .map_err(|e| RemoteError::new(RemoteErrorKind::NetworkUnavailable, e.message))?;
         let end = offset + length - 1;
-        let response = google_drive_request_with_access_token(&token, Method::GET, url)
+        let mut response = google_drive_request_with_access_token(&token, Method::GET, url)
             .header("Range", format!("bytes={offset}-{end}"))
             .send_network("download Google Drive file range")
             .map_err(|e| RemoteError::new(RemoteErrorKind::NetworkUnavailable, e.message))?;
@@ -1852,25 +1850,6 @@ impl RemoteProvider for GoogleDriveProvider<'_> {
             crate::remote::errors::verify_content_range(cr_str, offset, length)?;
         }
 
-        let body = response.bytes().map_err(|error| {
-            RemoteError::new(
-                RemoteErrorKind::NetworkUnavailable,
-                format!("failed to read Google Drive range response: {error}"),
-            )
-        })?;
-
-        // Validate body length: must match the requested range length.
-        let actual_len = body.len() as u64;
-        if actual_len != length {
-            return Err(RemoteError::new(
-                RemoteErrorKind::RemoteIntegrityFailed,
-                format!(
-                    "Google Drive range download body length mismatch: \
-                     requested {length} bytes at offset {offset}, got {actual_len} bytes"
-                ),
-            ));
-        }
-
         if let Some(parent) = destination.parent() {
             fs::create_dir_all(parent).map_err(|error| {
                 RemoteError::new(
@@ -1899,13 +1878,46 @@ impl RemoteProvider for GoogleDriveProvider<'_> {
                 format!("failed to seek {}: {}", destination.display(), error),
             )
         })?;
-        file.write_all(&body).map_err(|error| {
-            RemoteError::new(
+
+        // Stream the body straight to disk as it arrives instead of buffering
+        // the whole chunk with `response.bytes()`. The buffered call imposed
+        // one total-body deadline per 8 MiB chunk; streaming makes the client
+        // timeout a per-read idle timeout so slow links make progress, and an
+        // interruption leaves the received bytes durable for sub-chunk resume
+        // (issue #205).
+        let written = crate::remote::net_policy::stream_response_body(&mut response, &mut file)
+            .map_err(|error| {
+                RemoteError::new(
+                    RemoteErrorKind::NetworkUnavailable,
+                    format!("failed to stream Google Drive range response: {error}"),
+                )
+            })?;
+
+        // Validate body length. For a 206 the body must be exactly `length`
+        // bytes; for a 200 full-body fallback (offset == 0 only) it must be at
+        // least `length`. A truncated transfer is a transport failure, not
+        // corruption, so it stays retryable and the partial bytes on disk are
+        // preserved for resume.
+        if status == reqwest::StatusCode::PARTIAL_CONTENT {
+            if written != length {
+                return Err(RemoteError::new(
+                    RemoteErrorKind::NetworkUnavailable,
+                    format!(
+                        "Google Drive range download body length mismatch: \
+                         requested {length} bytes at offset {offset}, got {written} bytes"
+                    ),
+                ));
+            }
+        } else if written < length {
+            return Err(RemoteError::new(
                 RemoteErrorKind::NetworkUnavailable,
-                format!("failed to write {}: {}", destination.display(), error),
-            )
-        })?;
-        Ok(actual_len)
+                format!(
+                    "Google Drive full-body response shorter than requested range: \
+                     requested {length} bytes, got {written} bytes"
+                ),
+            ));
+        }
+        Ok(written)
     }
 }
 

--- a/src-tauri/src/remote/net_policy.rs
+++ b/src-tauri/src/remote/net_policy.rs
@@ -38,9 +38,10 @@
 use crate::remote::errors::{
     kind_from_http_status, kind_from_io_error, RemoteError, RemoteErrorKind,
 };
+use std::io::{Read, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// Maximum `Retry-After` value honored (seconds). Absurd/unbounded values are
 /// ignored so a misbehaving server cannot stall an operation indefinitely.
@@ -369,6 +370,78 @@ pub(crate) fn shared_http_client() -> &'static reqwest::blocking::Client {
     })
 }
 
+/// Read buffer size for streaming downloads. reqwest's blocking `Read` impl
+/// applies the client's configured `timeout` as a fresh deadline for each
+/// read once the response body is streaming, so every 64 KiB read is bounded
+/// individually.
+const DOWNLOAD_STREAM_BUFFER: usize = 64 * 1024;
+
+/// Total wall-clock ceiling for streaming a single download body/chunk. The
+/// per-read idle timeout (the client's `timeout`) bounds a stalled read; this
+/// bounds a pathological trickle that stays just under the idle timeout
+/// forever. It is deliberately generous — a genuinely slow-but-steady link
+/// (2G-class, tens of KB/s) completes well within it — so it never clips a
+/// legitimate weak-network transfer.
+const DOWNLOAD_STREAM_TOTAL_BUDGET: Duration = Duration::from_secs(60 * 60);
+
+/// Stream a blocking HTTP response body into `writer`, returning the number of
+/// bytes written.
+///
+/// This replaces `response.bytes()` for downloads. `response.bytes()` wraps the
+/// ENTIRE body read in one `timeout` deadline (a total-body deadline), so any
+/// body that cannot fully arrive within that single window fails outright —
+/// imports on 2G-class links time out with zero durable progress (issue #205).
+/// Reading in a loop makes reqwest's blocking `Read` apply the client `timeout`
+/// as a fresh per-read deadline, i.e. an idle timeout: a slow-but-steady link
+/// keeps making progress, while a stalled/half-open connection still trips a
+/// bounded timeout. Bytes are written as they arrive, so an interruption leaves
+/// durable partial progress on disk that the resumable path can continue from.
+///
+/// `max_bytes` caps the accepted body length. When the body would exceed it the
+/// stream is rejected with an error (the overflowing chunk is not written), so
+/// a misbehaving server cannot grow the destination without bound. Pass
+/// `u64::MAX` (or [`stream_response_body`]) when the length is validated later.
+pub(crate) fn stream_response_body_capped<W: Write>(
+    response: &mut reqwest::blocking::Response,
+    writer: &mut W,
+    max_bytes: u64,
+) -> std::io::Result<u64> {
+    let started = Instant::now();
+    let mut total: u64 = 0;
+    let mut buffer = [0u8; DOWNLOAD_STREAM_BUFFER];
+    loop {
+        if started.elapsed() > DOWNLOAD_STREAM_TOTAL_BUDGET {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "download exceeded the total time budget",
+            ));
+        }
+        let read = response.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        total = total.saturating_add(read as u64);
+        if total > max_bytes {
+            return Err(std::io::Error::other(format!(
+                "download body exceeded the maximum of {max_bytes} bytes"
+            )));
+        }
+        writer.write_all(&buffer[..read])?;
+    }
+    Ok(total)
+}
+
+/// Stream a blocking HTTP response body into `writer` with no length cap,
+/// returning the number of bytes written. See [`stream_response_body_capped`]
+/// for the per-read idle-timeout rationale. Callers that know the expected
+/// length (range chunks) should prefer the capped variant.
+pub(crate) fn stream_response_body<W: Write>(
+    response: &mut reqwest::blocking::Response,
+    writer: &mut W,
+) -> std::io::Result<u64> {
+    stream_response_body_capped(response, writer, u64::MAX)
+}
+
 /// Run a fallible remote operation with the default production retry policy.
 ///
 /// Callers rebuild the request inside `operation` on every attempt so the
@@ -681,5 +754,182 @@ mod tests {
             classify_status(reqwest::StatusCode::INTERNAL_SERVER_ERROR),
             RemoteErrorKind::NetworkUnavailable
         );
+    }
+
+    // ---- streaming download body tests (issue #205) ----
+
+    use std::net::TcpListener;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::Ordering as AtomicOrdering;
+
+    /// A single-connection mock HTTP server. It sends a `200 OK` with the given
+    /// `content_length`, then writes `first_body` immediately, then trickles
+    /// `trailing_body` in `chunk_size` pieces separated by `gap`. When `stall`
+    /// is set it stops after `first_body` and holds the connection open (no
+    /// further bytes) until `stop` is set — simulating a half-open/stalled peer.
+    struct MockBodyServer {
+        url: String,
+        stop: Arc<AtomicBool>,
+        handle: Option<std::thread::JoinHandle<()>>,
+    }
+
+    impl MockBodyServer {
+        fn spawn(
+            content_length: usize,
+            first_body: Vec<u8>,
+            trailing_body: Vec<u8>,
+            chunk_size: usize,
+            gap: Duration,
+            stall: bool,
+        ) -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock server");
+            let addr = listener.local_addr().expect("addr");
+            let stop = Arc::new(AtomicBool::new(false));
+            let stop_thread = Arc::clone(&stop);
+            let handle = std::thread::spawn(move || {
+                let Ok((mut stream, _)) = listener.accept() else {
+                    return;
+                };
+                // Consume the request headers (best effort).
+                let mut req = [0u8; 2048];
+                let _ = stream.read(&mut req);
+                let headers = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {content_length}\r\nAccept-Ranges: bytes\r\n\r\n"
+                );
+                if stream.write_all(headers.as_bytes()).is_err() {
+                    return;
+                }
+                let _ = stream.write_all(&first_body);
+                let _ = stream.flush();
+                if stall {
+                    // Hold the connection open with no further body so the
+                    // client's per-read idle timeout must fire.
+                    while !stop_thread.load(AtomicOrdering::Relaxed) {
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    return;
+                }
+                for piece in trailing_body.chunks(chunk_size.max(1)) {
+                    std::thread::sleep(gap);
+                    if stream.write_all(piece).is_err() {
+                        return;
+                    }
+                    let _ = stream.flush();
+                }
+                // Keep the socket open briefly so the client can drain the last
+                // bytes before EOF.
+                while !stop_thread.load(AtomicOrdering::Relaxed) {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+            });
+            Self {
+                url: format!("http://{addr}/body"),
+                stop,
+                handle: Some(handle),
+            }
+        }
+    }
+
+    impl Drop for MockBodyServer {
+        fn drop(&mut self) {
+            self.stop.store(true, AtomicOrdering::Relaxed);
+            if let Some(handle) = self.handle.take() {
+                let _ = handle.join();
+            }
+        }
+    }
+
+    fn short_timeout_client(read_timeout: Duration) -> reqwest::blocking::Client {
+        reqwest::blocking::Client::builder()
+            .connect_timeout(Duration::from_secs(2))
+            .timeout(read_timeout)
+            .build()
+            .expect("client builds")
+    }
+
+    #[test]
+    fn stream_response_body_succeeds_on_slow_but_steady_trickle() {
+        // Acceptance (#205 criterion 1 & 3): a body that arrives steadily but
+        // whose TOTAL transfer time exceeds the client timeout must succeed.
+        // `response.bytes()` applies the timeout as a single total-body
+        // deadline (which this transfer would blow); the streaming loop applies
+        // it as a per-read idle timeout, which every gap stays under.
+        let total = 128 * 1024usize;
+        let body: Vec<u8> = (0..total).map(|i| (i % 251) as u8).collect();
+        let read_timeout = Duration::from_millis(300);
+        // 16 KiB chunks, 120 ms apart => ~0.96 s total, each gap < 300 ms.
+        let server = MockBodyServer::spawn(
+            total,
+            Vec::new(),
+            body.clone(),
+            16 * 1024,
+            Duration::from_millis(120),
+            false,
+        );
+        let client = short_timeout_client(read_timeout);
+        let mut response = client.get(&server.url).send().expect("send");
+
+        let started = Instant::now();
+        let mut sink: Vec<u8> = Vec::new();
+        let written = stream_response_body(&mut response, &mut sink).expect("stream succeeds");
+        let elapsed = started.elapsed();
+
+        assert_eq!(written, total as u64);
+        assert_eq!(sink, body);
+        // The transfer genuinely outlasted the client timeout, proving the fix
+        // (a total-body deadline of `read_timeout` would have failed here).
+        assert!(
+            elapsed > read_timeout,
+            "transfer ({elapsed:?}) should exceed the client timeout ({read_timeout:?})"
+        );
+    }
+
+    #[test]
+    fn stream_response_body_times_out_on_stall_and_keeps_partial() {
+        // Acceptance (#205 criterion 2, partial-write half): a stalled peer must
+        // return a bounded error, and the bytes received before the stall must
+        // already be durable in the writer (so the resumable path can continue).
+        let prefix = vec![7u8; 4096];
+        let server = MockBodyServer::spawn(
+            1_000_000,
+            prefix.clone(),
+            Vec::new(),
+            0,
+            Duration::ZERO,
+            true,
+        );
+        let client = short_timeout_client(Duration::from_millis(250));
+        let mut response = client.get(&server.url).send().expect("send");
+
+        let started = Instant::now();
+        let mut sink: Vec<u8> = Vec::new();
+        let result = stream_response_body(&mut response, &mut sink);
+        let elapsed = started.elapsed();
+
+        assert!(result.is_err(), "a stalled body must error, not hang");
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "stall must be bounded, took {elapsed:?}"
+        );
+        assert_eq!(sink, prefix, "bytes received before the stall are durable");
+    }
+
+    #[test]
+    fn stream_response_body_capped_rejects_oversized_body() {
+        let body = vec![1u8; 4096];
+        let server = MockBodyServer::spawn(
+            body.len(),
+            body.clone(),
+            Vec::new(),
+            0,
+            Duration::ZERO,
+            false,
+        );
+        let client = short_timeout_client(Duration::from_secs(2));
+        let mut response = client.get(&server.url).send().expect("send");
+        let mut sink: Vec<u8> = Vec::new();
+        // Cap below the body length: the stream must be rejected.
+        let result = stream_response_body_capped(&mut response, &mut sink, 1024);
+        assert!(result.is_err(), "body over the cap must error");
     }
 }

--- a/src-tauri/src/remote/webdav.rs
+++ b/src-tauri/src/remote/webdav.rs
@@ -16,7 +16,7 @@ use reqwest::{
 };
 use std::{
     fs::{self, OpenOptions},
-    io::{Seek, SeekFrom, Write},
+    io::{Seek, SeekFrom},
     path::Path,
 };
 
@@ -231,7 +231,7 @@ pub(crate) fn download_webdav_file(
     username: &str,
     password: &str,
 ) -> CommandResult<Option<String>> {
-    let response = webdav_send(client, Method::GET, url, username, password, None, None)?;
+    let mut response = webdav_send(client, Method::GET, url, username, password, None, None)?;
     if response.status() == StatusCode::NOT_FOUND {
         return Ok(None);
     }
@@ -254,21 +254,20 @@ pub(crate) fn download_webdav_file(
         .get(ETAG)
         .and_then(|value| value.to_str().ok())
         .map(str::to_owned);
-    let bytes = response.bytes().map_err(|error| {
-        CommandError::from(LibraryError::Internal(format!(
-            "failed to read WebDAV response: {error}"
-        )))
-    })?;
+    // Stream the body to disk as it arrives instead of buffering the whole
+    // file with `response.bytes()`. The buffered call imposed a single
+    // total-body deadline; streaming makes the client timeout a per-read idle
+    // timeout, so slow-but-steady links complete instead of failing at the
+    // deadline (issue #205).
     let mut file = fs::File::create(destination).map_err(|error| {
         CommandError::from(LibraryError::Internal(format!(
             "failed to create {}: {error}",
             destination.display()
         )))
     })?;
-    file.write_all(bytes.as_ref()).map_err(|error| {
+    crate::remote::net_policy::stream_response_body(&mut response, &mut file).map_err(|error| {
         CommandError::from(LibraryError::Internal(format!(
-            "failed to write {}: {error}",
-            destination.display()
+            "failed to stream WebDAV response: {error}"
         )))
     })?;
     Ok(etag)
@@ -1076,7 +1075,7 @@ impl RemoteProvider for WebDAVProvider<'_> {
             })?;
         let range_header = format!("bytes={offset}-{end}");
 
-        let response = client
+        let mut response = client
             .request(Method::GET, &url)
             .basic_auth(&self.secret.username, Some(&self.secret.password))
             .header("Range", &range_header)
@@ -1129,37 +1128,6 @@ impl RemoteProvider for WebDAVProvider<'_> {
             crate::remote::errors::verify_content_range(cr_str, offset, length)?;
         }
 
-        let bytes = response.bytes().map_err(|error| {
-            RemoteError::new(
-                RemoteErrorKind::NetworkUnavailable,
-                format!("failed to read WebDAV range response: {error}"),
-            )
-        })?;
-
-        // Validate body length. For a 206 response, the body must be exactly
-        // `length` bytes. For a 200 full-body response (offset == 0 only),
-        // the body must be at least `length` bytes.
-        let actual_len = bytes.len() as u64;
-        if status == StatusCode::PARTIAL_CONTENT {
-            if actual_len != length {
-                return Err(RemoteError::new(
-                    RemoteErrorKind::RemoteIntegrityFailed,
-                    format!(
-                        "WebDAV range download body length mismatch: \
-                         requested {length} bytes at offset {offset}, got {actual_len} bytes"
-                    ),
-                ));
-            }
-        } else if actual_len < length {
-            return Err(RemoteError::new(
-                RemoteErrorKind::RemoteIntegrityFailed,
-                format!(
-                    "WebDAV full-body response shorter than requested range: \
-                     requested {length} bytes, got {actual_len} bytes"
-                ),
-            ));
-        }
-
         if let Some(parent) = destination.parent() {
             fs::create_dir_all(parent).map_err(|error| {
                 RemoteError::new(
@@ -1190,22 +1158,47 @@ impl RemoteProvider for WebDAVProvider<'_> {
             )
         })?;
 
-        // For a 206 response, write the partial body. For a 200 full-body
-        // response (offset == 0 only), write only the requested `length`
-        // bytes.
-        let to_write: &[u8] = if status == StatusCode::PARTIAL_CONTENT {
-            bytes.as_ref()
-        } else {
-            // Full-body response (offset == 0): slice to the requested length.
-            &bytes[..(length as usize).min(bytes.len())]
-        };
-        let written = to_write.len() as u64;
-        file.write_all(to_write).map_err(|error| {
-            RemoteError::new(
+        // Stream the body straight to the destination as it arrives instead of
+        // buffering the whole chunk with `response.bytes()`. The buffered call
+        // imposed one total-body deadline per chunk (an 8 MiB chunk needed
+        // >= 68 KB/s just to finish); streaming makes the client timeout a
+        // per-read idle timeout, so a slow-but-steady link makes progress and
+        // an interruption leaves the bytes received so far durable on disk for
+        // sub-chunk resume (issue #205). For a 206 the body is exactly
+        // `length` bytes; for a 200 full-body fallback (offset == 0 only) the
+        // whole file arrives and is written from the start.
+        let written = crate::remote::net_policy::stream_response_body(&mut response, &mut file)
+            .map_err(|error| {
+                RemoteError::new(
+                    RemoteErrorKind::NetworkUnavailable,
+                    format!("failed to stream WebDAV range response: {error}"),
+                )
+            })?;
+
+        // Validate body length. For a 206 response, the body must be exactly
+        // `length` bytes. For a 200 full-body response (offset == 0 only),
+        // the body must be at least `length` bytes. A truncated transfer is a
+        // transport failure, not corruption, so it stays retryable and the
+        // partial bytes on disk are preserved for resume.
+        if status == StatusCode::PARTIAL_CONTENT {
+            if written != length {
+                return Err(RemoteError::new(
+                    RemoteErrorKind::NetworkUnavailable,
+                    format!(
+                        "WebDAV range download body length mismatch: \
+                         requested {length} bytes at offset {offset}, got {written} bytes"
+                    ),
+                ));
+            }
+        } else if written < length {
+            return Err(RemoteError::new(
                 RemoteErrorKind::NetworkUnavailable,
-                format!("failed to write {}: {error}", destination.display()),
-            )
-        })?;
+                format!(
+                    "WebDAV full-body response shorter than requested range: \
+                     requested {length} bytes, got {written} bytes"
+                ),
+            ));
+        }
 
         Ok(written)
     }
@@ -1663,5 +1656,32 @@ mod tests {
         assert!(error.message.contains("not an OpenKara remote repository"));
         assert!(!server.directory_exists("/MovedOpenKara/"));
         assert!(server.file("/MovedOpenKara/openkara.db").is_none());
+    }
+
+    #[test]
+    fn download_webdav_file_streams_full_body_to_disk() {
+        // Regression for issue #205: the full-file download now streams the
+        // body to disk instead of buffering it with `response.bytes()`. Verify
+        // the streamed file matches the source byte-for-byte through the real
+        // provider helper.
+        let server = TestWebDavServer::start();
+        let client = webdav_client().unwrap();
+        let url = join_url(&server.base_url, "song.bin").unwrap();
+        let body: Vec<u8> = (0..200_000).map(|i| (i % 256) as u8).collect();
+        upload_webdav_bytes(&client, &url, body.clone(), "openkara", "secret").unwrap();
+
+        let dest_dir = tempdir().unwrap();
+        let dest_path = dest_dir.path().join("nested/out.bin");
+        let etag = download_webdav_file(&client, &url, &dest_path, "openkara", "secret").unwrap();
+
+        assert!(
+            etag.is_some(),
+            "ETag surfaced from headers before streaming"
+        );
+        assert_eq!(
+            std::fs::read(&dest_path).unwrap(),
+            body,
+            "streamed file matches"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Two remote-library HTTP network-robustness fixes in `src-tauri`, on one branch.

### #204 — streaming playback range fetcher had no timeouts
`ProviderFetcher` and `ReqwestFetcher` were built with `reqwest::blocking::Client::new()` — reqwest's default builder sets **no** connect or request timeout. A half-open/stalled connection (captive portal, dead peer after sleep/wake, 2G black-hole) blocked the fetch thread forever: `fetch_range_with_retry` never ran, `ConsecutiveFailures`/`UrlExpired` were never emitted, mid-song reconnect could not fire, and the blocked thread + socket leaked for the process lifetime.

Fix:
- Build both clients with an explicit `connect_timeout` and a per-request `timeout` (30s each).
- Consume the range body with a streaming `read()` loop instead of `response.bytes()`, so reqwest's blocking `Read` applies the `timeout` as a **per-read idle timeout**. A stall now trips a bounded `FetchError::Io` (a new variant) that flows through `fetch_range_with_retry` → `ConsecutiveFailures` → reconnect, and the fetch thread exits; a slow-but-steady weak link keeps making progress and is not killed.

### #205 — downloads buffered the whole body under a single 120s deadline
`download_file` and 8 MiB-chunk `download_range` across WebDAV, Dropbox, and Google Drive all read the entire body with `response.bytes()`, which wraps the whole read in one total-body deadline. On EDGE/2G every attempt timed out with zero durable progress, and any interruption discarded up to 8 MiB (or the whole file).

Fix:
- New `net_policy::stream_response_body` / `stream_response_body_capped` — a per-read idle-timeout streaming loop (mirrors `separator/artifacts.rs`) with a wall-clock budget, writing bytes to the destination/part file as they arrive.
- Route all six provider download paths through it. The per-read timeout becomes the effective idle timeout, so slow-but-steady links succeed.
- The resumable driver now persists the **actual on-disk length** on a mid-chunk failure and clamps the resume point to it, so an interruption resumes sub-chunk instead of re-downloading the whole 8 MiB chunk. Final size/digest validation is unchanged; a truncated transfer is classified as transient (`NetworkUnavailable`) so the partial survives for resume.

## Acceptance criteria

**#204**
- [x] Mock server accepts the Range request then never writes the body → `ProviderFetcher::fetch_range` returns an error within a bounded time (`provider_fetcher_times_out_on_stalled_body_instead_of_hanging`).
- [x] A stalled/timed-out fetch surfaces as a failure that emits `FetchEvent::ConsecutiveFailures`, and the fetch thread's `JoinHandle` completes after `Shutdown` — no leak (`timed_out_fetch_drives_consecutive_failures_and_thread_exits`).

**#205**
- [x] Body trickled steadily but slower than a total-body deadline allows → the download **succeeds** (`stream_response_body_succeeds_on_slow_but_steady_trickle`; asserts total transfer time exceeds the client timeout).
- [x] Connection reset after N bytes mid-chunk, then resume → resumed transfer starts from ~N bytes written (not the chunk start) and completes with a verified digest (`resumable_download_resumes_from_sub_chunk_offset_and_verifies_digest`; partial durability also covered by `stream_response_body_times_out_on_stall_and_keeps_partial`).
- [x] Large body streamed over a duration exceeding the old total-body deadline completes without failure (same trickle test; streaming to disk is fixed-memory regardless of size).
- [x] Full-body download streams correctly through the real provider path (`download_webdav_file_streams_full_body_to_disk`).

## Testing
- `cargo nextest run --lib` for `remote::`, `audio::`, `services::` — 568 passed (incl. the pre-existing `fault_injection` resumable/disconnect test).
- `cargo clippy --lib --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.

Fixes #204
Fixes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)