### PR TITLE
fix(bootstrap): make the model-download failed banner recoverable (#217)

### DIFF
--- a/src/components/Bootstrap/ModelBootstrapBanner.test.tsx
+++ b/src/components/Bootstrap/ModelBootstrapBanner.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { ModelBootstrapBanner } from "./ModelBootstrapBanner";
+import { useBootstrapStore } from "@/stores/bootstrap-store";
+import { useSettingsStore } from "@/stores/settings-store";
+import type { ModelBootstrapStatusSnapshot } from "@/types/ipc";
+
+const { mockDownloadModel, mockNotifyError } = vi.hoisted(() => ({
+  mockDownloadModel: vi.fn(),
+  mockNotifyError: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+  initReactI18next: { type: "3rdParty", init: () => {} },
+}));
+
+vi.mock("@/lib/tauri", () => ({ downloadModel: mockDownloadModel }));
+vi.mock("@/lib/errors", () => ({ notifyError: mockNotifyError }));
+
+function setStatus(
+  state: ModelBootstrapStatusSnapshot["state"],
+  overrides: Partial<ModelBootstrapStatusSnapshot> = {},
+) {
+  const status: ModelBootstrapStatusSnapshot = {
+    state,
+    model_path: "/tmp/model",
+    downloaded_bytes: null,
+    total_bytes: null,
+    error: null,
+    ...overrides,
+  };
+  useBootstrapStore.setState({ status });
+}
+
+describe("ModelBootstrapBanner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useBootstrapStore.setState({ status: null });
+    useSettingsStore.setState({ modelVariant: "htdemucs" });
+  });
+
+  afterEach(cleanup);
+
+  test("renders nothing when there is no model status", () => {
+    const { container } = render(<ModelBootstrapBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders nothing for a ready model", () => {
+    setStatus("ready");
+    const { container } = render(<ModelBootstrapBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("failed state renders the error, an actionable hint, and a Retry control", () => {
+    setStatus("failed", {
+      error: {
+        code: "network_unavailable",
+        message: "network unreachable",
+        retryable: true,
+        fallback: "retry",
+      },
+    });
+    render(<ModelBootstrapBanner />);
+
+    expect(screen.getByText("bootstrap.downloadFailed")).toBeTruthy();
+    // Copy no longer asserts "separation unavailable" when a retry path exists.
+    expect(screen.queryByText("bootstrap.separationUnavailable")).toBeNull();
+    expect(screen.getByText("bootstrap.downloadFailedHint")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "bootstrap.retryDownload" }),
+    ).toBeTruthy();
+  });
+
+  test("Retry invokes the model-download command for the active variant", () => {
+    mockDownloadModel.mockResolvedValue({
+      state: "downloading",
+      model_path: "/tmp/model",
+      downloaded_bytes: 0,
+      total_bytes: null,
+      error: null,
+    });
+    useSettingsStore.setState({ modelVariant: "htdemucs_ft" });
+    setStatus("failed");
+    render(<ModelBootstrapBanner />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "bootstrap.retryDownload" }),
+    );
+
+    expect(mockDownloadModel).toHaveBeenCalledExactlyOnceWith("htdemucs_ft");
+  });
+
+  test("after Retry the banner transitions to the downloading state", async () => {
+    mockDownloadModel.mockResolvedValue({
+      state: "downloading",
+      model_path: "/tmp/model",
+      downloaded_bytes: 0,
+      total_bytes: 209_000_000,
+      error: null,
+    });
+    setStatus("failed");
+    render(<ModelBootstrapBanner />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "bootstrap.retryDownload" }),
+    );
+
+    await waitFor(() => {
+      expect(useBootstrapStore.getState().status?.state).toBe("downloading");
+    });
+    expect(screen.getByText("bootstrap.downloadingModel")).toBeTruthy();
+  });
+
+  test("surfaces a download failure without leaving the failed banner", async () => {
+    mockDownloadModel.mockRejectedValue(new Error("still offline"));
+    setStatus("failed");
+    render(<ModelBootstrapBanner />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "bootstrap.retryDownload" }),
+    );
+
+    await waitFor(() => {
+      expect(mockNotifyError).toHaveBeenCalledOnce();
+    });
+    expect(useBootstrapStore.getState().status?.state).toBe("failed");
+  });
+});

--- a/src/components/Bootstrap/ModelBootstrapBanner.tsx
+++ b/src/components/Bootstrap/ModelBootstrapBanner.tsx
@@ -1,12 +1,36 @@
 import { Loader2 } from "lucide-react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { notifyError } from "@/lib/errors";
+import { downloadModel } from "@/lib/tauri";
 import { useBootstrapStore } from "@/stores/bootstrap-store";
 import { useSettingsStore } from "@/stores/settings-store";
 
 export function ModelBootstrapBanner() {
   const { t } = useTranslation();
   const status = useBootstrapStore((s) => s.status);
+  const updateStatus = useBootstrapStore((s) => s.updateStatus);
   const openSettings = useSettingsStore((s) => s.open);
+  const modelVariant = useSettingsStore((s) => s.modelVariant);
+  const [retrying, setRetrying] = useState(false);
+
+  const retryDownload = async () => {
+    if (retrying) return;
+    setRetrying(true);
+    try {
+      // `download_model` returns a `downloading` snapshot and spawns the
+      // fetch; publishing it flips the banner into the downloading state so
+      // GlobalProgressBar can take over the byte/percent readout. A later
+      // failure re-emits `model-bootstrap-error`, returning to this banner —
+      // the recovery loop stays entirely in the banner.
+      const snapshot = await downloadModel(modelVariant);
+      updateStatus(snapshot);
+    } catch (error) {
+      notifyError(error);
+    } finally {
+      setRetrying(false);
+    }
+  };
 
   if (!status || status.state === "ready") return null;
 
@@ -51,15 +75,26 @@ export function ModelBootstrapBanner() {
       )}
 
       {status.state === "failed" && (
-        <div className="flex items-center justify-between">
-          <span className="text-[12px] text-[var(--color-destructive)]">
-            {t("bootstrap.downloadFailed", {
-              error: status.error?.message || t("bootstrap.unknownError"),
-            })}
-          </span>
-          <span className="text-[11px] text-[var(--color-text-dim)]">
-            {t("bootstrap.separationUnavailable")}
-          </span>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="text-[12px]">
+            <p className="text-[var(--color-destructive)]">
+              {t("bootstrap.downloadFailed", {
+                error: status.error?.message || t("bootstrap.unknownError"),
+              })}
+            </p>
+            <p className="mt-0.5 text-[11px] text-[var(--color-text-dim)]">
+              {t("bootstrap.downloadFailedHint")}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => void retryDownload()}
+            disabled={retrying}
+            className="flex shrink-0 items-center gap-1.5 self-start rounded-md border border-[var(--color-border-light)] bg-[var(--color-surface)] px-3 py-1.5 text-[11px] text-[var(--color-text)] transition-colors hover:bg-[var(--color-hover)] hover:text-[var(--color-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]/50 disabled:cursor-not-allowed disabled:opacity-60 sm:self-center"
+          >
+            {retrying && <Loader2 size={12} className="animate-spin" />}
+            {t("bootstrap.retryDownload")}
+          </button>
         </div>
       )}
     </div>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -553,7 +553,8 @@
     "openSettingsToUpgrade": "Open Settings",
     "downloadFailed": "Model download failed: {{error}}",
     "unknownError": "Unknown error",
-    "separationUnavailable": "Separation unavailable"
+    "downloadFailedHint": "Check your connection, then retry the download.",
+    "retryDownload": "Retry"
   },
   "playlist": {
     "create": "New Playlist",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -553,7 +553,8 @@
     "openSettingsToUpgrade": "打开设置",
     "downloadFailed": "模型下载失败：{{error}}",
     "unknownError": "未知错误",
-    "separationUnavailable": "分离不可用"
+    "downloadFailedHint": "请检查网络连接后重试下载。",
+    "retryDownload": "重试"
   },
   "playlist": {
     "create": "新建播放列表",


### PR DESCRIPTION
Fixes #217

## Problem

The model-download `failed` state of `ModelBootstrapBanner` was a dead end: it rendered `bootstrap.downloadFailed` + "Separation unavailable" with **no control**. The sibling `outdated` state got an "Open Settings" button, but `failed` got nothing — even though the backend marks this error `retryable: true` and a hidden recovery path exists (pressing a song's Separate button, or re-clicking the model tile in Settings, silently restarts the 209MB download). A first-run user who was briefly offline saw a broken-looking app with nothing to click, and the copy actively told them the feature was "unavailable."

## Fix

- **Retry button** added to the `failed` branch of `ModelBootstrapBanner.tsx`, following the existing `outdated`-branch button pattern. It calls the existing `download_model` command for the active model variant (`useSettingsStore(modelVariant)`), then publishes the returned `downloading` snapshot via `useBootstrapStore.updateStatus`, flipping the banner to `downloading` — `GlobalProgressBar` already renders byte/percent from the subsequent `model-bootstrap-progress` events. A repeat failure re-emits `model-bootstrap-error` and returns to the banner, so the entire recover loop stays in the banner (no Settings / song-row detour needed). The button shows a spinner and disables while a retry is in flight; errors surface via `notifyError`.
- **Copy** softened (en + zh-CN): dropped `separationUnavailable` ("Separation unavailable" / "分离不可用") in favour of an actionable `downloadFailedHint` ("Check your connection, then retry the download." / "请检查网络连接后重试下载。") plus a `retryDownload` control ("Retry" / "重试"). The banner no longer asserts the feature is unavailable when a retry path is present.

## Acceptance criteria

- **a) Component test: `failed` renders a Retry control that invokes the model-download command** — `ModelBootstrapBanner.test.tsx` asserts the Retry button renders and `downloadModel` is called with the active variant.
- **b) After Retry, state transitions to `downloading` and progress shows** — test asserts the store transitions to `downloading` and the downloading copy renders (GlobalProgressBar is already wired to that state).
- **c) Offline→online first run recovers entirely from the banner** — retry path lives on the banner; no Settings/song-row interaction required.
- **d) Copy no longer asserts "unavailable" when a retry path is present** — `separationUnavailable` removed; test asserts it is absent.

## Optional item (deferred)

The optional bounded auto-retry-with-backoff in `spawn_model_bootstrap_worker` (Rust) was **not** implemented. It is marked optional in the issue plan and would need care to preserve the one-shot failure semantics that existing worker tests rely on. The explicit user-driven Retry fully satisfies acceptance criteria a–d; auto-retry can follow as a separate, isolated change.

## Testing

- `pnpm vitest run src/components/Bootstrap/ModelBootstrapBanner.test.tsx` — 6 passed (new file)
- `pnpm vitest run src/components/Bootstrap src/stores/bootstrap-store.test.ts src/lib/tauri/tauri-wrappers.test.ts` — 137 passed
- `pnpm lint` (oxlint --deny-warnings), `pnpm exec tsc --noEmit`, `pnpm format` (oxfmt --check) — all clean
- No Rust changes, so no cargo gates required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)