### PR TITLE
test(e2e): deflake webkit lyrics-follow and muted-stem assertions (#218)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1083,6 +1083,51 @@ jobs:
       - name: Run Playwright UI smoke tests
         run: node --run test:ui-smoke
 
+      # Count flaky tests (passed only after a retry) from the JSON report and
+      # surface them in the job summary. retries:1 keeps the job green when a
+      # test flakes, so without this a flaking test would degrade silently.
+      # Runs on always() so failures still get a flaky breakdown.
+      - name: Report flaky tests
+        if: always()
+        run: |
+          set -euo pipefail
+          report="playwright-report/results.json"
+          if [ ! -f "$report" ]; then
+            {
+              echo "## Playwright UI smoke — flaky tests"
+              echo ""
+              echo "_No JSON report at ${report}; skipping flaky analysis._"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          flaky=$(jq '.stats.flaky // 0' "$report")
+          unexpected=$(jq '.stats.unexpected // 0' "$report")
+          flaky_list=$(jq -r '
+            [ .. | .specs? // empty | .[] ]
+            | map(select(.tests | any(.status == "flaky")))
+            | .[] | "- `\(.title)`"
+          ' "$report")
+
+          {
+            echo "## Playwright UI smoke — flaky tests"
+            echo ""
+            echo "**Flaky (passed on retry):** ${flaky}"
+            echo "**Failed:** ${unexpected}"
+            echo ""
+            if [ "$flaky" -gt 0 ]; then
+              echo "These passed only after a retry — retries:1 masked them, so investigate:"
+              echo ""
+              echo "$flaky_list"
+            else
+              echo "No flaky tests detected."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$flaky" -gt 0 ]; then
+            echo "::warning::${flaky} flaky Playwright test(s) detected — passed only on retry (retries:1)."
+          fi
+
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ public/dict/
 # Playwright
 test-results/
 blob-report/
+playwright-report/
 
 # CommandCode / Taste (auto-managed by CommandCode)
 .commandcode/

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,11 +19,19 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   workers: 1,
-  // Generate both the list reporter (for live CI logs) and the HTML report
-  // (for the playwright-report/ artifact upload). The CI workflow uploads
-  // playwright-report/ with if-no-files-found: error, so the config and
-  // workflow must agree on HTML report generation.
-  reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
+  // Generate the list reporter (for live CI logs), the HTML report (for the
+  // playwright-report/ artifact upload), and a machine-readable JSON report.
+  // The CI workflow uploads playwright-report/ with if-no-files-found: error,
+  // so the config and workflow must agree on HTML report generation. The JSON
+  // report feeds the "Report flaky tests" step, which counts status=flaky
+  // results so retries:1 can no longer silently absorb flakes.
+  reporter: process.env.CI
+    ? [
+        ["list"],
+        ["html", { open: "never" }],
+        ["json", { outputFile: "playwright-report/results.json" }],
+      ]
+    : "list",
   timeout: 30_000,
 
   use: {

--- a/tests/e2e/lyrics-follow.spec.ts
+++ b/tests/e2e/lyrics-follow.spec.ts
@@ -45,30 +45,6 @@ async function readScrollTop(page: import("@playwright/test").Page) {
   return page.locator(VIEWPORT).evaluate((el) => el.scrollTop);
 }
 
-/**
- * Wait until wheel/trackpad inertia finishes. Each wheel event re-arms the
- * follow idle timer, so measuring the pause from mid-inertia falsely fails.
- * Require three consecutive stable readings (300ms) to avoid false positives
- * when WebKit's smooth-scroll animation briefly pauses between frames.
- */
-async function waitForScrollSettle(
-  page: import("@playwright/test").Page,
-): Promise<number> {
-  let last = -1;
-  let stable = 0;
-  for (let i = 0; i < 60; i++) {
-    const top = await readScrollTop(page);
-    if (last >= 0 && Math.abs(top - last) < 1) {
-      if (++stable >= 3) return top;
-    } else {
-      stable = 0;
-    }
-    last = top;
-    await page.waitForTimeout(100);
-  }
-  return last;
-}
-
 async function emitLayoutDrivenScroll(page: import("@playwright/test").Page) {
   await page.locator(VIEWPORT).evaluate((el) => {
     // Model the bare scroll event WKWebView can emit when active-line layout
@@ -234,35 +210,55 @@ test.describe("Lyrics auto-follow", () => {
   test("user wheel unlocks follow and Follow button re-locks", async ({
     page,
   }) => {
-    await page.waitForTimeout(2500);
+    // Plain advance wait so the engine has locked onto the playing line before
+    // we take over scrollTop. This is NOT a race against the 4s re-lock — the
+    // idle timer only starts once the user scroll below unlocks follow.
+    await page.waitForTimeout(1000);
 
-    const viewport = page.locator(VIEWPORT);
-    const box = await viewport.boundingBox();
-    if (!box) throw new Error("viewport not visible");
-    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
-    // Scroll far below the playing line so the re-lock target differs clearly.
-    await page.mouse.wheel(0, 800);
-    await page.waitForTimeout(200);
-    await page.mouse.wheel(0, 800);
-
-    // Follow button pins visible (data-visible) once the user unlocks follow.
     const followButton = page.locator("[data-testid='lyrics-follow-playing']");
-    await expect(followButton).toHaveAttribute("data-visible", "true");
 
-    // Wait for wheel momentum to finish before sampling the resting position.
-    const unlockedTop = await waitForScrollSettle(page);
+    // Deterministic user scroll: write scrollTop far below the playing line and
+    // dispatch a real WheelEvent in the same synchronous frame. This exercises
+    // the follow guard's wheel path directly — no page.mouse.wheel (WebKit
+    // silently drops synthetic wheel deltas) and no smooth-scroll inertia
+    // stream that would keep re-arming USER_SCROLL_PAUSE_MS mid-test. A
+    // synthetic (untrusted) WheelEvent performs no native scroll, so scrollTop
+    // stays exactly where we wrote it.
+    await page.locator(VIEWPORT).evaluate((el) => {
+      el.scrollTop = 900;
+      el.dispatchEvent(
+        new WheelEvent("wheel", {
+          deltaY: 240,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+
+    // State assertion (built-in retry): unlocking pins the Follow button.
+    await expect(followButton).toHaveAttribute("data-visible", "true");
+    const unlockedTop = await readScrollTop(page);
     expect(unlockedTop).toBeGreaterThan(400);
-    await page.waitForTimeout(800);
+
+    // While unlocked the engine tracks the user's viewport and never writes
+    // scrollTop. Confirm auto-scroll stays released: sampled well inside the 4s
+    // idle window, the view holds its browse position and follow is still
+    // unlocked (no fixed sleep that races the re-lock).
+    await expect
+      .poll(async () => Math.abs((await readScrollTop(page)) - unlockedTop) < 2)
+      .toBe(true);
+    await expect(followButton).toHaveAttribute("data-visible", "true");
     const stillTop = await readScrollTop(page);
-    expect(Math.abs(stillTop - unlockedTop)).toBeLessThan(2);
 
     // Clicking Follow re-locks to the playing line (far above) and unpins it.
     // Requires pointer-events-auto on the control (parent overlay is none).
     await followButton.click();
     await expect(followButton).toHaveAttribute("data-visible", "false");
-    await page.waitForTimeout(300);
-    const relockedTop = await readScrollTop(page);
-    expect(relockedTop).toBeLessThan(stillTop - 200);
+    // Re-lock snaps scrollTop back to the playing line on the next rAF; poll
+    // the resting position instead of a fixed post-click sleep.
+    await expect
+      .poll(async () => (await readScrollTop(page)) < stillTop - 200)
+      .toBe(true);
   });
 
   test("idle timeout re-locks follow and returns scrollTop to the playing line", async ({

--- a/tests/e2e/playback-controls.spec.ts
+++ b/tests/e2e/playback-controls.spec.ts
@@ -246,24 +246,42 @@ test.describe("Playback controls geometry and pressed state", () => {
       const sel = '[data-playback-action="vocals-mute"]';
       const btn = page.locator(sel);
       await btn.click();
+
+      // Semantic terminal state: muted (aria-pressed) with no selected chrome.
+      // The absence of data-active is exactly what keeps the background fill
+      // transparent — assert the attribute contract instead of sampling the
+      // computed backgroundColor, which reads the :hover / transition value
+      // right after a mouse click (the WebKit flake source).
       await expect(btn).toHaveAttribute("aria-pressed", "true");
       await expect(btn).not.toHaveAttribute("data-active", "true");
 
-      const info = await page.evaluate((s) => {
-        const el = document.querySelector(s) as HTMLElement;
-        const cs = window.getComputedStyle(el);
-        const rootCs = window.getComputedStyle(document.documentElement);
-        return {
-          color: cs.color,
-          backgroundColor: cs.backgroundColor,
-          dimmerToken: rootCs.getPropertyValue("--color-text-dimmer").trim(),
-        };
-      }, sel);
-      // No selected fill — background stays transparent.
-      expect(info.backgroundColor).toMatch(
-        /rgba?\(0,\s*0,\s*0,\s*0\)|transparent/,
-      );
-      expect(info.dimmerToken).not.toBe("");
+      // The muted icon settles to the --color-text-dimmer token. color
+      // transitions on click, so poll for the resolved terminal value (built-in
+      // retry) rather than sampling once mid-transition. Resolve the token via
+      // a probe injected into the button's OWN cascade scope: the token is
+      // re-defined for the [data-window-chrome-platform="desktop"] subtree the
+      // app renders inside, so a document.body probe would resolve a different
+      // value. Comparing rgb-to-rgb in-scope keeps this theme-agnostic.
+      await expect
+        .poll(async () =>
+          page.evaluate((s) => {
+            const el = document.querySelector(s) as HTMLElement;
+            const scopedDimmer = window
+              .getComputedStyle(el)
+              .getPropertyValue("--color-text-dimmer")
+              .trim();
+            if (scopedDimmer === "") {
+              return false;
+            }
+            const probe = document.createElement("span");
+            probe.style.color = "var(--color-text-dimmer)";
+            (el.parentElement ?? el).appendChild(probe);
+            const dimmerRgb = window.getComputedStyle(probe).color;
+            probe.remove();
+            return window.getComputedStyle(el).color === dimmerRgb;
+          }, sel),
+        )
+        .toBe(true);
     });
 
     test("queue button geometry does not change when panel opens", async ({


### PR DESCRIPTION
Fixes #218

Two Playwright e2e tests flaked on WebKit and CI `retries:1` absorbed the flakes silently, eroding CI trust. This reworks both assertions to be deterministic and makes flaky results visible in CI.

## Changes

### 1. `lyrics-follow.spec.ts` — "user wheel unlocks follow and Follow button re-locks"
- Replaced `page.mouse.wheel(0, 800)` (WebKit silently drops synthetic wheel deltas) with a deterministic `scrollTop` write + dispatched `WheelEvent` in one synchronous frame — this drives the follow guard's wheel path directly, with no smooth-scroll inertia stream that would keep re-arming `USER_SCROLL_PAUSE_MS`. A synthetic (untrusted) `WheelEvent` performs no native scroll, so `scrollTop` stays exactly where written.
- Removed the racing waits: the up-to-6s `waitForScrollSettle` poll and the `waitForTimeout(800)` that raced the 4s re-lock window. Unlock/re-lock is now asserted via the `data-visible` state attribute (built-in retry) and `expect.poll` on the resting / re-locked `scrollTop`.
- Deleted the now-unused `waitForScrollSettle` helper.

### 2. `playback-controls.spec.ts` — "muted stem button uses dimmer color without selected background"
- Stopped sampling `getComputedStyle().backgroundColor` right after a mouse click, which read the `:hover` / mid-transition value (the flake). Now asserts the semantic terminal state (`aria-pressed="true"`, no `data-active`) — the absence of `data-active` is exactly what keeps the background transparent.
- The "dimmer color" claim is verified by polling until the icon `color` settles to the `--color-text-dimmer` token (built-in retry handles the color transition). The token is resolved via a probe injected into the button's own cascade scope, because the token is re-defined for the `[data-window-chrome-platform="desktop"]` subtree the app renders inside.

### 3. CI — flaky visibility
- Added a `json` reporter (alongside the existing `list` + `html`) writing `playwright-report/results.json`.
- Added a `Report flaky tests` step to the `playwright-ui-smoke` job that counts `status=flaky` results and prints the count to the job summary (even when 0), lists the flaky test titles, and emits a `::warning::` when > 0. `retries:1` stays but can no longer mask flakes silently.
- The step's `run:` block uses no `${{ }}` interpolation (env-free file parse), satisfying the workflow-security hygiene test. `playwright-report/` added to `.gitignore`.

## Acceptance criteria

| Criterion | Status |
|---|---|
| Both tests green on webkit `--repeat-each=20` | Met — 40/40 passed (20 each) on webkit with `retries:0` |
| Assertions no longer depend on fixed sleep + transient-state sampling | Met — deterministic event injection, `data-visible`/`aria-pressed`/`data-active` state assertions, and `expect.poll` on terminal values |
| CI job summary shows a flaky count (printed even when 0), retries kept but no longer silent | Met — new `Report flaky tests` step; JSON-reporter parse validated locally, including nested describe blocks |

## Verification
- `pnpm exec playwright test tests/e2e/lyrics-follow.spec.ts tests/e2e/playback-controls.spec.ts --project webkit --repeat-each=20 --grep "user wheel unlocks follow and Follow button re-locks|muted stem button uses dimmer color"` → **40 passed** (webkit, retries:0).
- Full both-spec run across chromium + webkit → **86 passed**.
- `pnpm lint` (oxlint), `pnpm format` (oxfmt), `pnpm tsc --noEmit`, and the `workflow-security` + `ci-workflow-contract` vitests all pass.
- New CI step shellchecked clean and its jq validated against a nested-suite fixture.

## Note on plan deviation
The wheel test keeps a single `waitForTimeout(1000)` at the start as a plain playback-advance wait. This is not the flaky mechanism the issue targets — the 4s idle re-lock timer only starts once the user scroll unlocks follow, so this wait does not race it. It mirrors the established pattern in the sibling "idle timeout re-locks" test. The flake sources (the 6s settle poll, the 800ms post-unlock sleep, and the mid-transition background sampling) are fully removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)