### PR TITLE
chore(ci): purge waveform-model residue from the candidate validation workflow

### DIFF
--- a/.github/workflows/spectral-candidate.yml
+++ b/.github/workflows/spectral-candidate.yml
@@ -81,18 +81,6 @@ jobs:
             libwebkit2gtk-4.1-dev \
             libxdo-dev
 
-      - name: Resolve waveform model from catalog snapshot
-        id: waveform
-        shell: bash
-        run: |
-          {
-            echo "url=$(node scripts/resolve-model.mjs --field url)"
-            echo "sha256=$(node scripts/resolve-model.mjs --field sha256)"
-            echo "file=$(node scripts/resolve-model.mjs --field filename)"
-            echo "file_sha256=$(node scripts/resolve-model.mjs --field file_sha256)"
-            echo "archived=$(node scripts/resolve-model.mjs --field archived)"
-          } >> "$GITHUB_OUTPUT"
-
       - name: Resolve spectral candidate from the ${{ inputs.channel }} channel
         id: spectral
         shell: bash
@@ -109,20 +97,13 @@ jobs:
       - name: Restore model cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: |
-            src-tauri/models/${{ steps.waveform.outputs.file }}
-            src-tauri/models/${{ steps.spectral.outputs.file }}
-          key: spectral-candidate-models-${{ steps.waveform.outputs.file_sha256 }}-${{ steps.spectral.outputs.sha256 }}
+          path: src-tauri/models/${{ steps.spectral.outputs.file }}
+          key: spectral-candidate-models-${{ steps.spectral.outputs.sha256 }}
           enableCrossOsArchive: true
 
-      - name: Download and verify models
+      - name: Download and verify the candidate model
         shell: bash
         env:
-          WAVEFORM_URL: ${{ steps.waveform.outputs.url }}
-          WAVEFORM_SHA256: ${{ steps.waveform.outputs.sha256 }}
-          WAVEFORM_FILE: ${{ steps.waveform.outputs.file }}
-          WAVEFORM_FILE_SHA256: ${{ steps.waveform.outputs.file_sha256 }}
-          WAVEFORM_ARCHIVED: ${{ steps.waveform.outputs.archived }}
           SPECTRAL_URL: ${{ steps.spectral.outputs.url }}
           SPECTRAL_SHA256: ${{ steps.spectral.outputs.sha256 }}
           SPECTRAL_FILE: ${{ steps.spectral.outputs.file }}
@@ -135,16 +116,6 @@ jobs:
           }
           verified() { [ -f "$1" ] && [ "$(sha256 "$1")" = "$2" ]; }
           mkdir -p src-tauri/models
-          if ! verified "src-tauri/models/$WAVEFORM_FILE" "$WAVEFORM_FILE_SHA256"; then
-            curl -L --fail "$WAVEFORM_URL" -o /tmp/waveform-download
-            verified /tmp/waveform-download "$WAVEFORM_SHA256" || { echo "waveform download digest mismatch"; exit 1; }
-            if [ "$WAVEFORM_ARCHIVED" = "true" ]; then
-              tar -xzf /tmp/waveform-download -C src-tauri/models "$WAVEFORM_FILE"
-            else
-              mv /tmp/waveform-download "src-tauri/models/$WAVEFORM_FILE"
-            fi
-          fi
-          verified "src-tauri/models/$WAVEFORM_FILE" "$WAVEFORM_FILE_SHA256" || { echo "waveform model digest mismatch"; exit 1; }
           if ! verified "src-tauri/models/$SPECTRAL_FILE" "$SPECTRAL_SHA256"; then
             curl -L --fail "$SPECTRAL_URL" -o "src-tauri/models/$SPECTRAL_FILE"
           fi
@@ -172,13 +143,13 @@ jobs:
         shell: bash
         run: cargo nextest run --no-fail-fast -E 'binary(phase7_spectral) or test(spectral)'
 
-      - name: Candidate equivalence + streaming + cancellation
+      - name: Candidate streaming + cancellation suite
         working-directory: src-tauri
         shell: bash
         env:
           OPENKARA_SPECTRAL_MODEL: ${{ github.workspace }}/src-tauri/models/${{ steps.spectral.outputs.file }}
         run: |
-          cargo nextest run --no-fail-fast -E 'binary(phase7_spectral_session) or test(spectral_core_matches_waveform_model_on_one_window)'
+          cargo nextest run --no-fail-fast -E 'binary(phase7_spectral_session)'
 
       - name: Measurement harness
         working-directory: src-tauri

--- a/docs/references/contracts/model-bootstrap.md
+++ b/docs/references/contracts/model-bootstrap.md
@@ -55,12 +55,14 @@
 - 网络刷新时：先按指针声明的字节数与 SHA-256 验证清单原始字节，**验证通过
   后才解析**；拒绝 generation 低于内嵌快照的指针（stable 通道单调递增）。
 - 清单结构校验：artifact ID 唯一、digest 为 64 位十六进制、URL 必须 HTTPS、
-  `tensor_interface` 必须为 `waveform`、每个模型的
+  `tensor_interface` 必须为 `waveform` 或 `spectral-core`、每个模型的
   `compatible_runtime_ids` 非空且指向已知 runtime、兼容性边非空、每个模型
   必须声明恰好一个 `.onnx` 安装文件。
-- **多工件解析**（generation ≥ 5）：同一变体可有多个交付形态（raw 保留给旧
-  消费者、压缩 dual 为首选）。确定性规则：非弃用工件中**下载体积最小者**
-  胜出——与上游偏好序一致（压缩 dual < 去重 raw < raw）。
+- **多工件解析**（generation ≥ 8）：同一变体可有多个交付形态（历史 waveform
+  交付保留在清单中供 provenance）。确定性规则：先过滤到**可加载接口**
+  （`tensor_interface == "spectral-core"`，频谱会话是唯一生产路径）且非弃用的
+  工件，再取**下载体积最小者**——体积规则绝不允许跨接口比较（ft 变体的
+  waveform dual 比 spectral 交付更小，若不过滤会解析出加载器拒绝的工件）。
 - **压缩交付**：下载负载按 `archive_digest` 验证，安全解压后再按
   `extracted_file_digests` 验证安装的 `.onnx`；raw 交付两者为同一字节。
 - **dual 双输出波形模型**（历史工件）：`outputs[0]=[1,4,2,N]` 四轨堆叠 +

--- a/knip.json
+++ b/knip.json
@@ -1,12 +1,7 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
-  "entry": ["src-tauri/**/*.rs", "website/src/main.tsx"],
-  "project": [
-    "src/**/*.{ts,tsx}",
-    "website/src/**/*.{ts,tsx}",
-    "website/vite.config.ts"
-  ],
+  "entry": ["src-tauri/**/*.rs"],
+  "project": ["src/**/*.{ts,tsx}", "website/src/**/*.{ts,tsx}"],
   "exclude": ["exports", "types"],
-  "ignoreDependencies": ["tailwindcss"],
   "ignoreBinaries": ["xcrun", "hdiutil"]
 }


### PR DESCRIPTION
Evidence-based cleanup of the last old-pipeline residue in OpenKara (full scan found the production tree already clean — residue was concentrated here):

- `spectral-candidate.yml`: drop the waveform model resolve/download steps (`steps.waveform`, `WAVEFORM_*` env, cache key parts) — their only consumer was the one-time waveform-equivalence test deleted with the waveform path in #172 PR 5; the nextest filter still named that nonexistent test (inert clause, now removed). Candidate resolution, golden/session suites, and the bench harness are untouched.
- `docs/references/contracts/model-bootstrap.md`: the resolver description predated the loadable-interface filter — now documents the actual rule (spectral-core filter before smallest-size, and why cross-interface size comparison is forbidden).
- `knip.json`: drop redundant entries/ignores (knip now runs fully clean).

Scan also confirmed: no orphan scripts, no unused deps (knip + grep), no dead config/i18n keys, no latest.json consumers, audio seek-bar "waveform" feature is unrelated and live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)