### PR TITLE
fix(release): gate tag/version consistency and refresh install docs for 1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,21 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
 
+      - name: Verify package.json version matches release tag
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          package_version="$(node -p "require('./package.json').version")"
+          if [ "${package_version}" != "${EXPECTED_VERSION}" ]; then
+            echo "::error::Release ${RELEASE_TAG} expects version ${EXPECTED_VERSION}, but package.json is ${package_version}."
+            echo "The published bundle takes its version from package.json (scripts/sync-version.mjs), so a tag that disagrees with package.json builds assets named OpenKara_${package_version}_* while the winget/flatpak manifests look for OpenKara_${EXPECTED_VERSION}_* and the release fails."
+            echo "To fix: bump package.json to ${EXPECTED_VERSION}, run 'pnpm version:sync', commit, then re-tag that commit."
+            exit 1
+          fi
+          echo "package.json version ${package_version} matches release ${RELEASE_TAG}."
+
       - name: Generate release notes with git-cliff
         id: notes
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,12 @@ This project follows [Conventional Commits](https://www.conventionalcommits.org/
 - `refactor:` a code change. It does not fix a bug or add a feature.
 - `test:` add or update tests
 
+## Releasing
+
+Maintainers: see [docs/RELEASING.md](docs/RELEASING.md) for the tag-driven
+release process (bump `package.json`, `pnpm version:sync`, tag, verify the draft
+release assets, publish).
+
 ## License
 
 If you contribute, you accept the project license for your contributions.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ winget install thedavidweng.OpenKara
 xattr -rd com.apple.quarantine /Applications/OpenKara.app
 ```
 
+**Windows SmartScreen note:** OpenKara isn't code-signed yet, so Windows may show a "Windows protected your PC" screen on first run. Click **More info**, then **Run anyway** to launch it.
+
 On first launch, OpenKara will prompt you to create a Karaoke Library and start downloading the default AI model in the background.
 
 ### Build from Source
@@ -165,7 +167,7 @@ OpenKara uses custom ONNX builds of [Demucs](https://github.com/adefossez/demucs
 | `htdemucs`    | Standard — Hybrid Transformer Demucs       | Stereo audio at 44.1 kHz (7.8s) | 4 stems: drums, bass, other, vocals | ONNX (opset 17) |
 | `htdemucs_ft` | High Quality — Fine-tuned 4-model ensemble | Stereo audio at 44.1 kHz (7.8s) | 4 stems: drums, bass, other, vocals | ONNX (opset 17) |
 
-On first launch, OpenKara automatically downloads the standard `openkara-models` asset pinned by the app's embedded catalog snapshot (currently v2.1.0) into the app data directory. Settings offers an update check that installs newer catalog generations without waiting for an app release. The current standard model is ~339 MiB on disk, and the optional high quality model is ~1.32 GiB. Both assets are ONNX Runtime-optimized and carry metadata used for cache invalidation. See the [openkara-models README](https://github.com/thedavidweng/openkara-models#readme) for details on the conversion pipeline. For local development and deterministic tests, run `./scripts/setup.sh` to populate `src-tauri/models/`.
+On first launch, OpenKara automatically downloads the standard `openkara-models` asset pinned by the app's embedded catalog snapshot (currently generation 9) into the app data directory. Settings offers an update check that installs newer catalog generations without waiting for an app release. The current standard model is ~199.8 MiB on disk, and the optional high quality model is ~800.1 MiB. Both assets are ONNX Runtime-optimized and carry metadata used for cache invalidation. See the [openkara-models README](https://github.com/thedavidweng/openkara-models#readme) for details on the conversion pipeline. For local development and deterministic tests, run `./scripts/setup.sh` to populate `src-tauri/models/`.
 
 ## Tech Stack
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -90,6 +90,8 @@ winget install thedavidweng.OpenKara
 xattr -rd com.apple.quarantine /Applications/OpenKara.app
 ```
 
+**Windows SmartScreen 提示：** OpenKara 目前还没有代码签名，Windows 首次运行时可能会弹出"Windows 已保护你的电脑"提示。点击**更多信息**，再点击**仍要运行**即可启动。
+
 首次启动时，OpenKara 会引导你创建 Karaoke 曲库，并在后台开始下载默认 AI 模型。
 
 ### 从源码构建
@@ -129,7 +131,7 @@ OpenKara 使用自定义 ONNX 格式的 [Demucs](https://github.com/adefossez/de
 | `htdemucs`    | 标准 — Hybrid Transformer Demucs | 44.1 kHz 立体声音频（7.8 秒） | 4 条音轨：鼓、贝斯、其他、人声 | ONNX（opset 17） |
 | `htdemucs_ft` | 高质量 — 微调 4 模型集成         | 44.1 kHz 立体声音频（7.8 秒） | 4 条音轨：鼓、贝斯、其他、人声 | ONNX（opset 17） |
 
-首次启动时，OpenKara 会将标准 `openkara-models` v2.0.1 资源下载到应用数据目录。当前标准模型磁盘大小约为 339 MiB，可选的高质量模型约为 1.32 GiB。两者都已完成 ONNX Runtime 离线优化，并携带用于缓存失效的 metadata。详见 [openkara-models README](https://github.com/thedavidweng/openkara-models#readme) 了解转换流水线。开发环境和需要稳定输入的测试可运行 `./scripts/setup.sh` 填充 `src-tauri/models/`。
+首次启动时，OpenKara 会将标准 `openkara-models` 资源（当前锁定为 generation 9）下载到应用数据目录。当前标准模型磁盘大小约为 199.8 MiB，可选的高质量模型约为 800.1 MiB。两者都已完成 ONNX Runtime 离线优化，并携带用于缓存失效的 metadata。详见 [openkara-models README](https://github.com/thedavidweng/openkara-models#readme) 了解转换流水线。开发环境和需要稳定输入的测试可运行 `./scripts/setup.sh` 填充 `src-tauri/models/`。
 
 ## 技术栈
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,50 @@
+# Releasing
+
+OpenKara releases are driven by a `v*` git tag. The
+[`Release` workflow](../.github/workflows/release.yml) builds every platform
+bundle, opens a **draft** GitHub Release, attaches `SHA256SUMS`, and renders the
+WinGet and Flatpak manifests.
+
+The published bundle takes its version from `package.json` (see
+[`scripts/sync-version.mjs`](../scripts/sync-version.mjs)), while the tag drives
+asset naming and the distribution manifests. **These two must agree.** If they
+drift, the build produces assets named `OpenKara_<package.json version>_*` while
+the WinGet/Flatpak manifests look for `OpenKara_<tag version>_*`, so the release
+ships misnamed assets and the manifest jobs fail. The `prepare-release` job
+fails fast with this exact guidance when they disagree.
+
+## Cut a release
+
+1. **Bump `package.json`** to the new version (e.g. `1.0.0`).
+2. **Sync the native manifests:** run `pnpm version:sync`. This propagates the
+   version into `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, and
+   `src-tauri/tauri.conf.json`.
+3. **Commit** the version bump (`git commit -am "chore(release): 1.0.0"`) and
+   merge it to `main`.
+4. **Tag that commit** with a leading `v` and push the tag:
+   ```bash
+   git tag v1.0.0
+   git push origin v1.0.0
+   ```
+   The tag version (minus the `v`) must match `package.json`.
+5. **Watch the draft release.** The workflow runs the separation smoke on every
+   target, builds the bundles, and opens a draft GitHub Release.
+6. **Verify the asset names** on the draft release match the tag, e.g.
+   `OpenKara_1.0.0_x64-setup.exe`. Confirm `SHA256SUMS` is attached.
+7. **Publish** the draft release from the GitHub UI. Publishing (or the
+   workflow, when configured) drives the Homebrew tap, WinGet, and Flathub
+   submissions.
+
+## If the version gate fails
+
+The `prepare-release` job errors when the tag and `package.json` disagree. To
+recover: bump `package.json` to the tag version, run `pnpm version:sync`,
+commit, then delete and re-create the tag on the corrected commit:
+
+```bash
+git tag -d v1.0.0
+git push origin :refs/tags/v1.0.0
+# ...bump, sync, commit, merge to main...
+git tag v1.0.0
+git push origin v1.0.0
+```

--- a/packaging/flatpak/io.github.thedavidweng.OpenKara.metainfo.xml
+++ b/packaging/flatpak/io.github.thedavidweng.OpenKara.metainfo.xml
@@ -2,7 +2,7 @@
 <component type="desktop-application">
   <id>io.github.thedavidweng.OpenKara</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>MIT</project_license>
+  <project_license>Apache-2.0</project_license>
   <name>OpenKara</name>
   <summary>Turn your music library into a karaoke stage</summary>
   <developer id="io.github.thedavidweng">
@@ -31,31 +31,33 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
-    <release version="1.0.0" date="2026-06-03">
+    <release version="0.9.0" date="2026-06-14">
       <description>
         <ul>
-          <li>Streaming playback with ring-buffer decode, chunked cache, and bandwidth-aware proxy mode.</li>
+          <li>Streaming playback with ring-buffer decode, chunked cache, and a bandwidth-aware low-bitrate proxy.</li>
           <li>Saved playlists and singer rotation with round-robin queue assignment.</li>
-          <li>Remote repository support for Google Drive, Dropbox, and WebDAV.</li>
-          <li>AirPlay casting with audience streaming and route controls.</li>
-          <li>Lyrics romanization with 13 supported languages.</li>
-          <li>Playback UX improvements and architecture refactoring.</li>
+          <li>Faster startup and render-frame-synced playback position.</li>
+          <li>Stabilized synced lyrics with Spotify-style seekable lines.</li>
+          <li>Hardened Flatpak packaging with CI-generated SHA256SUMS.</li>
         </ul>
       </description>
     </release>
-    <release version="0.8.1" date="2026-05-07">
+    <release version="0.8.0" date="2026-05-07">
       <description>
         <ul>
-          <li>Fix Linux packaging metadata and Flathub source builds.</li>
+          <li>Per-song lyric language selection with romanization for 13 languages.</li>
+          <li>Cantonese romanization via Jyutping.</li>
+          <li>Instant romanization refresh when changing the lyric language during playback.</li>
+          <li>Japanese tokenizer dictionary bundled locally instead of loaded from a CDN.</li>
         </ul>
       </description>
     </release>
-    <release version="0.8.0" date="2026-05-06">
+    <release version="0.7.0" date="2026-04-30">
       <description>
         <ul>
-          <li>Cross-platform desktop karaoke powered by on-device AI stem separation.</li>
-          <li>Portable karaoke library with synced lyrics and CD+G support.</li>
-          <li>Local playback, queueing, and full-screen karaoke presentation.</li>
+          <li>Reduced Dropbox permissions to the scopes required for remote library access.</li>
+          <li>Hardened remote library initialization, upload, sync, and reopen for Dropbox and WebDAV.</li>
+          <li>Fixed packaged macOS app startup and signing for the bundled ONNX Runtime.</li>
         </ul>
       </description>
     </release>

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -31,4 +31,24 @@ describe("release workflow", () => {
     expect(ciWorkflow).not.toContain("Release separation smoke");
     expect(ciWorkflow).not.toContain("./scripts/run-local-smoke.sh");
   });
+
+  test("fails fast when the release tag and package.json version disagree", () => {
+    // The bundle version comes from package.json (scripts/sync-version.mjs),
+    // while the tag drives asset naming and the winget/flatpak manifests. If
+    // they drift, the release ships misnamed assets and the distribution
+    // manifests point at assets that do not exist. This gate must stay in
+    // prepare-release so it fails before any build or publish job runs.
+    const releaseWorkflow = readProjectFile(".github/workflows/release.yml");
+
+    expect(releaseWorkflow).toContain(
+      "name: Verify package.json version matches release tag",
+    );
+    expect(releaseWorkflow).toContain(
+      `node -p "require('./package.json').version"`,
+    );
+    expect(releaseWorkflow).toContain("pnpm version:sync");
+    expect(releaseWorkflow).toMatch(
+      /prepare-release:[\s\S]*Verify package\.json version matches release tag[\s\S]*publish:/,
+    );
+  });
 });

--- a/website/faq.md
+++ b/website/faq.md
@@ -65,6 +65,10 @@ xattr -rd com.apple.quarantine /Applications/OpenKara.app
 
 Then open the app again. This only needs to be done once.
 
+### Windows says "Windows protected your PC". What do I do?
+
+OpenKara isn't code-signed yet, so Windows SmartScreen warns before running it. Click **More info**, then **Run anyway** to launch OpenKara. You only need to do this the first time you run a new build.
+
 ## Need more detail?
 
 - [Project README](https://github.com/thedavidweng/OpenKara/blob/main/README.md)

--- a/website/zh/faq.md
+++ b/website/zh/faq.md
@@ -65,6 +65,10 @@ xattr -rd com.apple.quarantine /Applications/OpenKara.app
 
 然后重新打开应用就行。只需要做一次。
 
+### Windows 提示"Windows 已保护你的电脑"，怎么办？
+
+OpenKara 目前还没有代码签名，Windows SmartScreen 会在运行前弹出提示。点击**更多信息**，再点击**仍要运行**即可启动 OpenKara。每次运行新版本时只需操作一次。
+
 ## 想了解更多？
 
 - [项目 README](https://github.com/thedavidweng/OpenKara/blob/main/README_CN.md)


### PR DESCRIPTION
Closes four 1.0-release-readiness gaps in the release pipeline and install docs.

## S1 — Tag/version consistency gate (highest priority)

The release version came only from the git tag, but the built bundle takes its version from `package.json` (`scripts/sync-version.mjs`). A `v1.0.0` tag against `package.json` 0.9.1 would produce `OpenKara_0.9.1_*` assets while `render-winget-manifests.mjs` looks for `OpenKara_1.0.0_x64-setup.exe`, hard-failing the winget job at `release-metadata.mjs`'s `requireReleaseAsset`.

- Added a fail-fast **"Verify package.json version matches release tag"** step in the `prepare-release` job. It reads `package.json` via `node -p`, compares against the tag version, and errors with remediation guidance ("bump package.json to X, run `pnpm version:sync`, commit, then re-tag"). GitHub expressions go through `env:` (no `${{ }}` in the `run:` block, per the workflow-security hygiene test).
- Added `docs/RELEASING.md` (bump -> `pnpm version:sync` -> commit -> tag -> watch draft -> verify asset names -> publish) and linked it from `CONTRIBUTING.md`.
- Added a `tests/release-workflow.test.ts` assertion so the gate cannot be silently removed.

## S3 — README model figures

README claimed catalog "v2.1.0", ~339 MiB standard, ~1.32 GiB HQ — deprecated waveform-era numbers. Updated to the current spectral catalog read from `release-manifest.json` (generation 9): standard `htdemucs.spectral.fp32.onnx` = 209,469,333 B (~199.8 MiB), HQ `htdemucs_ft.spectral.fp32.onnx` = 839,009,018 B (~800.1 MiB). Fixed in **README.md** and **README_CN.md** (the latter said "v2.0.1" with the same stale sizes).

## S4 — Windows SmartScreen guidance

Installers are unsigned on Windows (only macOS ad-hoc signing in `tauri.conf.json`), so first run shows "Windows protected your PC". Added a "More info -> Run anyway" note next to the existing macOS Gatekeeper guidance in **README.md**, **README_CN.md**, **website/faq.md**, and **website/zh/faq.md**.

## S5 — Flatpak metainfo

- `project_license` MIT -> **Apache-2.0** (matches LICENSE / package.json / Cargo.toml).
- Replaced the fabricated `1.0.0` (dated 2026-06-03) release entry — which skipped all 0.9.x and mis-described 0.8.0 — with the real published history: **0.9.0** (2026-06-14), **0.8.0** (2026-05-07), **0.7.0** (2026-04-30), descriptions distilled from the actual GitHub release notes.
- Screenshot URLs left at `v0.9.0`: verified the PNGs exist at that tag (identical blobs to v0.9.1) and it is the latest published release. The `flatpak-packaging` test requires a `/vX.Y.Z/` path and forbids `/main/`, so a real version tag is mandatory and v0.9.0 resolves.

## Verification

- `pnpm vitest run` — 174 files, 1942 tests pass (incl. release-workflow with the new assertion, workflow-security, ci-workflow-contract, flatpak-packaging).
- `pnpm lint` — exit 0. `pnpm format` — clean.
- `release.yml` and `metainfo.xml` parse (python yaml / ElementTree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
