### PR TITLE
fix(runtime): surface the first-install ONNX Runtime download as a named task (#226)

### DIFF
--- a/src-tauri/src/commands/runtime_bootstrap.rs
+++ b/src-tauri/src/commands/runtime_bootstrap.rs
@@ -206,6 +206,25 @@ fn store_snapshot(
     }
 }
 
+/// Store the in-flight download snapshot AND emit it as a progress event so
+/// the UI's runtime-download task tracks bytes live. Mirrors the model
+/// bootstrap progress pattern (`MODEL_BOOTSTRAP_PROGRESS_EVENT`): without the
+/// emit, the separation-triggered first install only ever published its
+/// initial 0% snapshot, so the progress bar showed "0%" with no labeled task
+/// and looked frozen while the runtime downloaded (#226).
+fn report_download_progress(
+    status: &Arc<Mutex<RuntimeBootstrapStatusSnapshot>>,
+    emit: &mut impl FnMut(&'static str, RuntimeBootstrapStatusSnapshot),
+    base: &RuntimeBootstrapStatusSnapshot,
+    state: RuntimeBootstrapState,
+    downloaded_bytes: u64,
+    total_bytes: Option<u64>,
+) {
+    let snapshot = downloading_snapshot(base, state, downloaded_bytes, total_bytes);
+    store_snapshot(status, snapshot.clone());
+    emit(RUNTIME_BOOTSTRAP_PROGRESS_EVENT, snapshot);
+}
+
 /// Resolve the catalog runtime a download should install: the freshest
 /// verified catalog when `check_*_updates` cached one newer than the
 /// embedded snapshot, otherwise the embedded pin.
@@ -239,20 +258,19 @@ pub fn install_and_load_runtime_blocking(
     store_snapshot(status, initial.clone());
     emit(RUNTIME_BOOTSTRAP_PROGRESS_EVENT, initial);
 
-    let progress_status = Arc::clone(status);
-    let progress_base = base.clone();
     let installed = runtime_bootstrap::install_runtime_artifact(
         app_data_dir,
         runtime,
         catalog,
-        move |downloaded_bytes, total_bytes| {
-            let snapshot = downloading_snapshot(
-                &progress_base,
+        |downloaded_bytes, total_bytes| {
+            report_download_progress(
+                status,
+                emit,
+                &base,
                 RuntimeBootstrapState::Downloading,
                 downloaded_bytes,
                 total_bytes,
             );
-            store_snapshot(&progress_status, snapshot);
         },
     )?;
 
@@ -314,20 +332,19 @@ pub fn download_and_stage_candidate_blocking(
     store_snapshot(status, initial.clone());
     emit(RUNTIME_BOOTSTRAP_PROGRESS_EVENT, initial);
 
-    let progress_status = Arc::clone(status);
-    let progress_base = base.clone();
     let installed = runtime_bootstrap::install_runtime_artifact(
         app_data_dir,
         runtime,
         catalog,
-        move |downloaded_bytes, total_bytes| {
-            let snapshot = downloading_snapshot(
-                &progress_base,
+        |downloaded_bytes, total_bytes| {
+            report_download_progress(
+                status,
+                emit,
+                &base,
                 RuntimeBootstrapState::DownloadingCandidate,
                 downloaded_bytes,
                 total_bytes,
             );
-            store_snapshot(&progress_status, snapshot);
         },
     )?;
 
@@ -672,6 +689,44 @@ mod tests {
             let status = Arc::new(Mutex::new(snapshot));
             assert!(ensure_runtime_ready(&status).is_ok());
         }
+    }
+
+    #[test]
+    fn report_download_progress_stores_and_emits_the_snapshot() {
+        // The separation-triggered first install used to only store the
+        // in-flight snapshot without emitting it, leaving the UI stuck at "0%".
+        // This guards that progress now both persists AND reaches the frontend.
+        let base = snapshot_from_inventory(&empty_inventory());
+        let status = Arc::new(Mutex::new(base.clone()));
+        let mut events: Vec<(&'static str, RuntimeBootstrapStatusSnapshot)> = Vec::new();
+        {
+            let mut emit = |event, snapshot| events.push((event, snapshot));
+            report_download_progress(
+                &status,
+                &mut emit,
+                &base,
+                RuntimeBootstrapState::Downloading,
+                2_048,
+                Some(8_192),
+            );
+        }
+
+        let stored = status.lock().expect("status lock should succeed").clone();
+        assert_eq!(stored.state, RuntimeBootstrapState::Downloading);
+        assert_eq!(stored.downloaded_bytes, Some(2_048));
+        assert_eq!(stored.total_bytes, Some(8_192));
+        assert!(stored.error.is_none());
+
+        assert_eq!(
+            events.len(),
+            1,
+            "exactly one progress event must be emitted"
+        );
+        assert_eq!(events[0].0, RUNTIME_BOOTSTRAP_PROGRESS_EVENT);
+        assert_eq!(
+            events[0].1, stored,
+            "the emitted snapshot must match the stored snapshot"
+        );
     }
 
     #[test]

--- a/src/components/Bootstrap/RuntimeUpdateBanner.test.tsx
+++ b/src/components/Bootstrap/RuntimeUpdateBanner.test.tsx
@@ -1,7 +1,13 @@
 // @vitest-environment jsdom
 
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { RuntimeUpdateBanner } from "./RuntimeUpdateBanner";
 import { useRuntimeBootstrapStore } from "@/stores/runtime-bootstrap-store";
 import type {
@@ -9,17 +15,23 @@ import type {
   RuntimeBootstrapStatusSnapshot,
 } from "@/types/ipc";
 
-const { mockRestartApp, mockNotifyError } = vi.hoisted(() => ({
-  mockRestartApp: vi.fn().mockResolvedValue(undefined),
-  mockNotifyError: vi.fn(),
-}));
+const { mockRestartApp, mockDownloadRuntime, mockNotifyError } = vi.hoisted(
+  () => ({
+    mockRestartApp: vi.fn().mockResolvedValue(undefined),
+    mockDownloadRuntime: vi.fn(),
+    mockNotifyError: vi.fn(),
+  }),
+);
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
   initReactI18next: { type: "3rdParty", init: () => {} },
 }));
 
-vi.mock("@/lib/tauri", () => ({ restartApp: mockRestartApp }));
+vi.mock("@/lib/tauri", () => ({
+  restartApp: mockRestartApp,
+  downloadRuntime: mockDownloadRuntime,
+}));
 vi.mock("@/lib/errors", () => ({ notifyError: mockNotifyError }));
 
 function setStatus(
@@ -85,5 +97,77 @@ describe("RuntimeUpdateBanner", () => {
 
     fireEvent.click(screen.getByLabelText("common.close"));
     expect(container.firstChild).toBeNull();
+  });
+
+  test("missing state shows the runtime-required banner with a hint", () => {
+    setStatus("missing", { active_artifact_id: null });
+    render(<RuntimeUpdateBanner />);
+
+    expect(
+      screen.getByText("settings.runtime.banner.runtimeRequired"),
+    ).toBeTruthy();
+    expect(
+      screen.getByText("settings.runtime.banner.runtimeRequiredHint"),
+    ).toBeTruthy();
+  });
+
+  test("downloading state shows the downloading-runtime banner", () => {
+    setStatus("downloading", {
+      active_artifact_id: null,
+      downloaded_bytes: 1_000_000,
+      total_bytes: 6_400_000,
+    });
+    render(<RuntimeUpdateBanner />);
+
+    expect(
+      screen.getByText("settings.runtime.banner.downloadingRuntime"),
+    ).toBeTruthy();
+  });
+
+  test("failed state renders the error, a hint, and a Retry that triggers the runtime download", async () => {
+    mockDownloadRuntime.mockResolvedValue({
+      state: "downloading",
+      runtime_path: "/tmp/runtime",
+      downloaded_bytes: 0,
+      total_bytes: null,
+      version: "v1.27.1",
+      active_artifact_id: null,
+      target_triple: "aarch64-apple-darwin",
+      candidate_version: null,
+      restart_required: false,
+      error: null,
+    });
+    setStatus("failed", {
+      active_artifact_id: null,
+      error: {
+        code: "network_unavailable",
+        message: "network unreachable",
+        retryable: true,
+        fallback: "retry",
+      },
+    });
+    render(<RuntimeUpdateBanner />);
+
+    expect(
+      screen.getByText("settings.runtime.banner.downloadFailed"),
+    ).toBeTruthy();
+    expect(
+      screen.getByText("settings.runtime.banner.downloadFailedHint"),
+    ).toBeTruthy();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "settings.runtime.banner.retryDownload",
+      }),
+    );
+
+    expect(mockDownloadRuntime).toHaveBeenCalledOnce();
+    // Publishing the returned `downloading` snapshot flips the banner so
+    // GlobalProgressBar can take over the byte/percent readout (mirrors #217).
+    await waitFor(() => {
+      expect(useRuntimeBootstrapStore.getState().status?.state).toBe(
+        "downloading",
+      );
+    });
   });
 });

--- a/src/components/Bootstrap/RuntimeUpdateBanner.tsx
+++ b/src/components/Bootstrap/RuntimeUpdateBanner.tsx
@@ -1,15 +1,37 @@
+import { Loader2 } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { restartApp } from "@/lib/tauri";
+import { downloadRuntime, restartApp } from "@/lib/tauri";
 import { notifyError } from "@/lib/errors";
 import { useRuntimeBootstrapStore } from "@/stores/runtime-bootstrap-store";
 
 export function RuntimeUpdateBanner() {
   const { t } = useTranslation();
   const status = useRuntimeBootstrapStore((s) => s.status);
+  const updateStatus = useRuntimeBootstrapStore((s) => s.updateStatus);
   const [activationDismissed, setActivationDismissed] = useState(false);
+  const [retrying, setRetrying] = useState(false);
 
   const state = status?.state;
+
+  const retryDownload = async () => {
+    if (retrying) return;
+    setRetrying(true);
+    try {
+      // `download_runtime` returns a `downloading` snapshot and spawns the
+      // fetch; publishing it flips the banner into the downloading state so
+      // GlobalProgressBar can take over the byte/percent readout. A later
+      // failure re-emits `runtime-bootstrap-error`, returning to this banner —
+      // the recovery loop stays entirely in the banner (mirrors the #217 model
+      // banner).
+      const snapshot = await downloadRuntime();
+      updateStatus(snapshot);
+    } catch (error) {
+      notifyError(error);
+    } finally {
+      setRetrying(false);
+    }
+  };
 
   if (state === "candidate_ready_restart_required") {
     return (
@@ -46,6 +68,60 @@ export function RuntimeUpdateBanner() {
             className="shrink-0 rounded-md border border-[var(--color-border-light)] bg-[var(--color-surface)] px-3 py-1.5 text-[11px] text-[var(--color-text)] transition-colors hover:bg-[var(--color-hover)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]/50"
           >
             {t("common.close")}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (state === "missing") {
+    return (
+      <div className="animate-expand shrink-0 border-b border-[var(--color-border)] bg-[var(--color-sidebar)] px-4 py-3">
+        <div className="flex flex-col gap-0.5">
+          <span className="text-[12px] text-[var(--color-text)]">
+            {t("settings.runtime.banner.runtimeRequired")}
+          </span>
+          <span className="text-[11px] text-[var(--color-text-dim)]">
+            {t("settings.runtime.banner.runtimeRequiredHint")}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  if (state === "downloading") {
+    return (
+      <div className="animate-expand shrink-0 border-b border-[var(--color-border)] bg-[var(--color-sidebar)] px-4 py-3">
+        <div className="flex items-center gap-2 text-[12px] text-[var(--color-text)]">
+          <Loader2 size={12} className="animate-spin" />
+          {t("settings.runtime.banner.downloadingRuntime")}
+        </div>
+      </div>
+    );
+  }
+
+  if (state === "failed") {
+    return (
+      <div className="animate-expand shrink-0 border-b border-[var(--color-border)] bg-[var(--color-sidebar)] px-4 py-3">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="text-[12px]">
+            <p className="text-[var(--color-destructive)]">
+              {t("settings.runtime.banner.downloadFailed", {
+                error: status?.error?.message || t("bootstrap.unknownError"),
+              })}
+            </p>
+            <p className="mt-0.5 text-[11px] text-[var(--color-text-dim)]">
+              {t("settings.runtime.banner.downloadFailedHint")}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => void retryDownload()}
+            disabled={retrying}
+            className="flex shrink-0 items-center gap-1.5 self-start rounded-md border border-[var(--color-border-light)] bg-[var(--color-surface)] px-3 py-1.5 text-[11px] text-[var(--color-text)] transition-colors hover:bg-[var(--color-hover)] hover:text-[var(--color-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]/50 disabled:cursor-not-allowed disabled:opacity-60 sm:self-center"
+          >
+            {retrying && <Loader2 size={12} className="animate-spin" />}
+            {t("settings.runtime.banner.retryDownload")}
           </button>
         </div>
       </div>

--- a/src/components/Layout/GlobalProgressBar.test.tsx
+++ b/src/components/Layout/GlobalProgressBar.test.tsx
@@ -6,22 +6,28 @@ import { cleanup, fireEvent, render } from "@testing-library/react";
 import { GlobalProgressBar } from "./GlobalProgressBar";
 import * as api from "@/lib/tauri";
 import type {
+  RuntimeBootstrapStatusSnapshot,
   SeparationStatusSnapshot,
   Song,
   UploadStatusSnapshot,
 } from "@/types/ipc";
 
-const { mockLibraryState, mockBootstrapState } = vi.hoisted(() => ({
-  mockLibraryState: {
-    separationStatuses: {} as Record<string, SeparationStatusSnapshot>,
-    uploadStatuses: {} as Record<string, UploadStatusSnapshot>,
-    batchSeparation: null as null,
-    songs: [] as Song[],
-  },
-  mockBootstrapState: {
-    status: null as null,
-  },
-}));
+const { mockLibraryState, mockBootstrapState, mockRuntimeState } = vi.hoisted(
+  () => ({
+    mockLibraryState: {
+      separationStatuses: {} as Record<string, SeparationStatusSnapshot>,
+      uploadStatuses: {} as Record<string, UploadStatusSnapshot>,
+      batchSeparation: null as null,
+      songs: [] as Song[],
+    },
+    mockBootstrapState: {
+      status: null as null,
+    },
+    mockRuntimeState: {
+      status: null as RuntimeBootstrapStatusSnapshot | null,
+    },
+  }),
+);
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -39,6 +45,12 @@ vi.mock("@/stores/bootstrap-store", () => ({
   useBootstrapStore: (
     selector: (state: typeof mockBootstrapState) => unknown,
   ) => selector(mockBootstrapState),
+}));
+
+vi.mock("@/stores/runtime-bootstrap-store", () => ({
+  useRuntimeBootstrapStore: (
+    selector: (state: typeof mockRuntimeState) => unknown,
+  ) => selector(mockRuntimeState),
 }));
 
 vi.mock("@/lib/tauri", () => ({
@@ -151,5 +163,34 @@ describe("GlobalProgressBar", () => {
     expect(markup).toContain("progress.separating:Separate Song");
     expect(markup).toContain("progress.uploadingToRemote:Upload Song");
     expect(markup).toContain("motion-surface");
+  });
+
+  test("shows a named runtime download task with live progress while the runtime downloads", () => {
+    mockLibraryState.batchSeparation = null;
+    mockLibraryState.separationStatuses = {};
+    mockLibraryState.uploadStatuses = {};
+    mockLibraryState.songs = [];
+    mockRuntimeState.status = {
+      state: "downloading",
+      runtime_path: "/tmp/runtime",
+      downloaded_bytes: 3_200_000,
+      total_bytes: 6_400_000,
+      version: "v1.27.1",
+      active_artifact_id: null,
+      target_triple: "aarch64-apple-darwin",
+      candidate_version: null,
+      restart_required: false,
+      error: null,
+    };
+
+    const markup = renderToStaticMarkup(<GlobalProgressBar />);
+
+    // A labeled task — not a bare "0%" — is what tells the user the runtime is
+    // downloading rather than the app being frozen (#226).
+    expect(markup).toContain("bootstrap.downloadingRuntime");
+    // 3.2 MB / 6.4 MB → a determinate bar at 50% width.
+    expect(markup).toContain("width:50%");
+
+    mockRuntimeState.status = null;
   });
 });

--- a/src/components/Layout/GlobalProgressBar.tsx
+++ b/src/components/Layout/GlobalProgressBar.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { X } from "lucide-react";
 import { useLibraryStore } from "@/stores/library-store";
 import { useBootstrapStore } from "@/stores/bootstrap-store";
+import { useRuntimeBootstrapStore } from "@/stores/runtime-bootstrap-store";
 import { formatBytes } from "@/lib/format";
 import * as api from "@/lib/tauri";
 import { notifyError } from "@/lib/errors";
@@ -99,6 +100,7 @@ function useModelDownloadCompleteFlash(): boolean {
 function useActiveTasks(modelDownloadCompleteFlash: boolean): ActiveTask[] {
   const { t } = useTranslation();
   const bootstrapStatus = useBootstrapStore((s) => s.status);
+  const runtimeStatus = useRuntimeBootstrapStore((s) => s.status);
   const separationStatuses = useLibraryStore((s) => s.separationStatuses);
   const uploadStatuses = useLibraryStore((s) => s.uploadStatuses);
   const batchSeparation = useLibraryStore((s) => s.batchSeparation);
@@ -111,6 +113,35 @@ function useActiveTasks(modelDownloadCompleteFlash: boolean): ActiveTask[] {
       key: "model-download-complete",
       label: t("progress.modelDownloadComplete"),
       percent: 100,
+    });
+  }
+
+  // Runtime download — the ONNX Runtime is fetched before the model on a
+  // fresh install (and again as a candidate on updates). Surfacing it as a
+  // named task stops the first separation from looking frozen at 0% while the
+  // runtime downloads silently in the background (#226).
+  if (
+    runtimeStatus?.state === "downloading" ||
+    runtimeStatus?.state === "downloading_candidate"
+  ) {
+    const total = runtimeStatus.total_bytes;
+    const down = runtimeStatus.downloaded_bytes;
+    const hasTotal = total != null && total > 0;
+    const hasDown = down != null && down >= 0;
+    const percent =
+      hasTotal && hasDown
+        ? Math.min(100, Math.max(0, (down / total) * 100))
+        : 0;
+    const indeterminate = !hasTotal;
+    tasks.push({
+      key: "runtime-download",
+      label: t("bootstrap.downloadingRuntime"),
+      detail:
+        down != null
+          ? formatBytes(down) + (hasTotal ? ` / ${formatBytes(total!)}` : "")
+          : undefined,
+      percent,
+      indeterminate,
     });
   }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -393,7 +393,13 @@
       },
       "banner": {
         "updateReady": "A runtime update is ready — restart to apply.",
-        "activationFailed": "The runtime update failed to activate; the previous runtime was restored."
+        "activationFailed": "The runtime update failed to activate; the previous runtime was restored.",
+        "runtimeRequired": "ONNX Runtime required for AI stem separation.",
+        "runtimeRequiredHint": "It downloads automatically the first time you separate a song.",
+        "downloadingRuntime": "Downloading ONNX Runtime...",
+        "downloadFailed": "ONNX Runtime download failed: {{error}}",
+        "downloadFailedHint": "Check your connection, then retry the download.",
+        "retryDownload": "Retry"
       }
     },
     "hideBatchSeparate": {
@@ -550,6 +556,7 @@
     "modelRequired": "AI separation model required for karaoke mode.",
     "downloadingBackground": "Downloading in background...",
     "downloadingModel": "Downloading AI model...",
+    "downloadingRuntime": "Downloading runtime...",
     "outdatedModel": "The installed model file is from an older release and cannot be used.",
     "outdatedModelHint": "Open Settings → Danger Zone, delete the model file, then download again to upgrade.",
     "openSettingsToUpgrade": "Open Settings",

--- a/src/locales/locales.test.ts
+++ b/src/locales/locales.test.ts
@@ -126,3 +126,58 @@ describe("remote-library flow i18n completeness", () => {
     ).toEqual([]);
   });
 });
+
+// The bootstrap banners (model + runtime) drive the first-run separation UX,
+// so their Missing/Downloading/Failed copy must never fall back to a raw
+// English `defaultValue` for zh-CN users. Same guard as above, scoped to the
+// banner sources so a newly referenced key without a locale entry fails CI
+// (issue #226 added the runtime banner's three-state copy).
+const BOOTSTRAP_BANNER_SOURCES = import.meta.glob(
+  [
+    "../components/Bootstrap/ModelBootstrapBanner.tsx",
+    "../components/Bootstrap/RuntimeUpdateBanner.tsx",
+  ],
+  { query: "?raw", import: "default", eager: true },
+) as Record<string, string>;
+
+describe("bootstrap banner i18n completeness", () => {
+  const EXPECTED_FILE_COUNT = 2;
+
+  const T_CALL = /\bt\(\s*["']([^"']+)["']/g;
+
+  function collectKeys(): string[] {
+    const keys = new Set<string>();
+    for (const source of Object.values(BOOTSTRAP_BANNER_SOURCES)) {
+      for (const match of source.matchAll(T_CALL)) {
+        keys.add(match[1]);
+      }
+    }
+    return [...keys].sort();
+  }
+
+  test("resolves every bootstrap banner source file", () => {
+    expect(Object.keys(BOOTSTRAP_BANNER_SOURCES)).toHaveLength(
+      EXPECTED_FILE_COUNT,
+    );
+  });
+
+  test("every referenced key resolves in en.json and zh-CN.json", () => {
+    const keys = collectKeys();
+    expect(keys.length).toBeGreaterThan(0);
+
+    const missing = keys
+      .map((key) => ({
+        key,
+        en: isPresent(en, key),
+        zh: isPresent(zh, key),
+      }))
+      .filter((entry) => !entry.en || !entry.zh);
+
+    expect(
+      missing,
+      `Missing locale keys referenced in the bootstrap banners: ${missing
+        .map((m) => `${m.key} (en=${m.en}, zh=${m.zh})`)
+        .join(", ")}`,
+    ).toEqual([]);
+  });
+});

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -393,7 +393,13 @@
       },
       "banner": {
         "updateReady": "运行时更新已就绪 — 请重启以应用。",
-        "activationFailed": "运行时更新未能激活，已恢复到先前的运行时。"
+        "activationFailed": "运行时更新未能激活，已恢复到先前的运行时。",
+        "runtimeRequired": "AI 分离需要 ONNX 运行时。",
+        "runtimeRequiredHint": "首次分离歌曲时会自动下载。",
+        "downloadingRuntime": "正在下载 ONNX 运行时...",
+        "downloadFailed": "ONNX 运行时下载失败：{{error}}",
+        "downloadFailedHint": "请检查网络连接后重试下载。",
+        "retryDownload": "重试"
       }
     },
     "hideBatchSeparate": {
@@ -550,6 +556,7 @@
     "modelRequired": "卡拉OK模式需要 AI 分离模型。",
     "downloadingBackground": "正在后台下载...",
     "downloadingModel": "正在下载 AI 模型...",
+    "downloadingRuntime": "正在下载运行时...",
     "outdatedModel": "已安装的模型文件来自旧版本，无法继续使用。",
     "outdatedModelHint": "请打开「设置」→「危险区」，删除该模型文件后再重新下载以完成升级。",
     "openSettingsToUpgrade": "打开设置",


### PR DESCRIPTION
Fixes #226

## Problem

On a fresh install, the first separation pulls the ONNX Runtime in the background before the model loads. The UI only showed "Separating 0%" with no labeled task, so it looked frozen for several seconds (longer on weak networks) — the first suspected failure a new user hits.

Root cause: the runtime download closure only stored the progress snapshot; unlike the model path (`MODEL_BOOTSTRAP_PROGRESS_EVENT`), it never emitted `runtime-bootstrap-progress`, so the frontend only ever received the initial 0% snapshot. And `GlobalProgressBar` had no runtime task, while `RuntimeUpdateBanner` didn't cover the Missing/Downloading/Failed states the backend defines.

## Changes (the issue's 3-step plan)

1. **Backend progress event** — `runtime_bootstrap.rs` now emits `RUNTIME_BOOTSTRAP_PROGRESS_EVENT` during the download via a new `report_download_progress` helper (store + emit), mirroring the model bootstrap pattern. Applied to both the first-install and candidate/update download paths. The frontend event wiring already existed in `use-playback-runtime.ts`.
2. **Named progress task** — `GlobalProgressBar` shows a "Downloading runtime" task driven by the runtime bootstrap store (`downloading` + `downloading_candidate`), with the same byte/percent readout as the model task.
3. **Three-state banner** — `RuntimeUpdateBanner` now covers Missing / Downloading / Failed (keeping the existing update/activation states); Failed is retryable via `download_runtime`, the same recovery loop as the #217 `ModelBootstrapBanner`.
4. **i18n** — en + zh-CN keys added (no `defaultValue`), plus a new bootstrap-banner i18n completeness guard in `locales.test.ts` (`GlobalProgressBar` was already scanned).

## Acceptance criteria

| Criterion | Status |
| --- | --- |
| Component test: `Downloading` → `GlobalProgressBar` shows a named runtime task with progress | Added — asserts the labeled task + a determinate 50% bar |
| Component test: `Failed` → banner appears and Retry triggers the download command | Added — asserts error/hint/Retry, `downloadRuntime` called, banner flips to `downloading` |
| Backend event added → unit test | `report_download_progress_stores_and_emits_the_snapshot` |
| i18n en/zh-CN complete, guarded (no `defaultValue`) | Added banner + progress keys; new completeness guard block |
| Manual: fresh-install first separation shows the runtime download stage, no unexplained 0% stall | Backend now emits live progress; task + banner surface it |

## Gates

- Rust: `cargo check` (lib+tests), `cargo nextest` (runtime_bootstrap, 20 passed incl. new test), `cargo clippy --all-targets -D warnings` — all green.
- Frontend: `vitest run` (GlobalProgressBar + RuntimeUpdateBanner + locales, 17 passed), `tsc --noEmit`, `pnpm lint` (oxlint --deny-warnings), `pnpm check:i18n` — all green.

Note: scope kept tight to `GlobalProgressBar` / `RuntimeUpdateBanner` / `runtime_bootstrap` / locales; locale JSON keys were only appended (no reformat) to minimize conflict with the parallel observability branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)