### PR TITLE
feat(observability): file logging, cross-platform About, and useful debug export

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,34 @@ MyKaraokeLibrary/
 
 All paths in the database are relative — including CD+G sidecars and MP3+G ZIP assets — so the whole library can be moved to a NAS, USB drive, or network share and opened by any OpenKara instance on any OS. Per-machine configuration (library location) is stored separately in the app data directory.
 
+## Reporting a Bug
+
+OpenKara writes a rolling log file (info level by default, errors always) so a
+problem can be diagnosed after the fact — even when the app was double-clicked
+and had no terminal attached. Logs rotate daily and the last 7 days are kept.
+
+When filing an issue, please include your **debug info** and, if relevant,
+attach the **log file**:
+
+1. Open **Settings → About** and click **Copy debug info**. Paste the result
+   into your report — it lists the app version, build SHA, OS/architecture,
+   catalog generation, model and runtime status, execution provider, and the
+   log-file path. (On macOS the same export is also available from
+   **Help → Copy Debug Info**.)
+2. Attach the current log file if the problem is reproducible.
+
+Log file location (`<date>` is the rotation day, e.g. `2026-07-25`):
+
+| Platform | Path                                                           |
+| -------- | -------------------------------------------------------------- |
+| macOS    | `~/Library/Logs/com.openkara.desktop/openkara.<date>.log`      |
+| Windows  | `%LOCALAPPDATA%\com.openkara.desktop\logs\openkara.<date>.log` |
+| Linux    | `~/.local/share/com.openkara.desktop/logs/openkara.<date>.log` |
+
+To raise verbosity for a repro, launch OpenKara with `OPENKARA_LOG=debug` (or a
+[`tracing`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html)
+filter such as `OPENKARA_LOG=openkara_lib=trace,warn`).
+
 ## Roadmap
 
 - **[Changelog](./CHANGELOG.md)** — Completed changes by version

--- a/README_CN.md
+++ b/README_CN.md
@@ -211,6 +211,25 @@ MyKaraokeLibrary/
 
 数据库中的所有路径均为相对路径 — 曲库可以移动到 NAS、USB 硬盘或网络共享目录，任何操作系统上的 OpenKara 实例都可以直接打开使用。每台设备的配置（曲库位置）单独存储在应用数据目录中。
 
+## 报告问题
+
+OpenKara 会写入滚动日志文件（默认 info 级别，错误必录），即使双击启动、没有终端也能在事后排查问题。日志按天滚动，保留最近 7 天。
+
+提交 issue 时，请附上**调试信息**，如有需要再附上**日志文件**：
+
+1. 打开**设置 → 关于**，点击**复制调试信息**，把结果粘贴到反馈中 — 其中包含应用版本、构建 SHA、操作系统/架构、catalog generation、模型与运行时状态、执行提供程序，以及日志文件路径。（macOS 上也可从**帮助 → Copy Debug Info** 导出同样的信息。）
+2. 如果问题可复现，请附上当前的日志文件。
+
+日志文件位置（`<date>` 为滚动日期，例如 `2026-07-25`）：
+
+| 平台    | 路径                                                           |
+| ------- | -------------------------------------------------------------- |
+| macOS   | `~/Library/Logs/com.openkara.desktop/openkara.<date>.log`      |
+| Windows | `%LOCALAPPDATA%\com.openkara.desktop\logs\openkara.<date>.log` |
+| Linux   | `~/.local/share/com.openkara.desktop/logs/openkara.<date>.log` |
+
+需要更详细的日志时，可用 `OPENKARA_LOG=debug` 启动 OpenKara（或使用 [`tracing`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html) 过滤器，例如 `OPENKARA_LOG=openkara_lib=trace,warn`）。
+
 ## 路线图
 
 - **[Changelog](./CHANGELOG.md)** — 已完成改动和版本记录

--- a/packaging/flatpak/generated/cargo-sources.json
+++ b/packaging/flatpak/generated/cargo-sources.json
@@ -2953,6 +2953,19 @@
   {
     "type": "archive",
     "archive-type": "tar-gzip",
+    "url": "https://static.crates.io/crates/matchers/matchers-0.2.0.crate",
+    "sha256": "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9",
+    "dest": "cargo/vendor/matchers-0.2.0"
+  },
+  {
+    "type": "inline",
+    "contents": "{\"package\":\"d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9\",\"files\":{}}",
+    "dest": "cargo/vendor/matchers-0.2.0",
+    "dest-filename": ".cargo-checksum.json"
+  },
+  {
+    "type": "archive",
+    "archive-type": "tar-gzip",
     "url": "https://static.crates.io/crates/matrixmultiply/matrixmultiply-0.3.11.crate",
     "sha256": "3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7",
     "dest": "cargo/vendor/matrixmultiply-0.3.11"
@@ -3130,6 +3143,19 @@
     "type": "inline",
     "contents": "{\"package\":\"650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086\",\"files\":{}}",
     "dest": "cargo/vendor/new_debug_unreachable-1.0.6",
+    "dest-filename": ".cargo-checksum.json"
+  },
+  {
+    "type": "archive",
+    "archive-type": "tar-gzip",
+    "url": "https://static.crates.io/crates/nu-ansi-term/nu-ansi-term-0.50.3.crate",
+    "sha256": "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5",
+    "dest": "cargo/vendor/nu-ansi-term-0.50.3"
+  },
+  {
+    "type": "inline",
+    "contents": "{\"package\":\"7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5\",\"files\":{}}",
+    "dest": "cargo/vendor/nu-ansi-term-0.50.3",
     "dest-filename": ".cargo-checksum.json"
   },
   {
@@ -4955,6 +4981,19 @@
   {
     "type": "archive",
     "archive-type": "tar-gzip",
+    "url": "https://static.crates.io/crates/sharded-slab/sharded-slab-0.1.7.crate",
+    "sha256": "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6",
+    "dest": "cargo/vendor/sharded-slab-0.1.7"
+  },
+  {
+    "type": "inline",
+    "contents": "{\"package\":\"f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6\",\"files\":{}}",
+    "dest": "cargo/vendor/sharded-slab-0.1.7",
+    "dest-filename": ".cargo-checksum.json"
+  },
+  {
+    "type": "archive",
+    "archive-type": "tar-gzip",
     "url": "https://static.crates.io/crates/shlex/shlex-2.0.1.crate",
     "sha256": "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba",
     "dest": "cargo/vendor/shlex-2.0.1"
@@ -5210,6 +5249,19 @@
     "type": "inline",
     "contents": "{\"package\":\"4057c98e2e852d51fdcfca832aac7b571f6b351ad159f9eda5db1655f8d0c4d7\",\"files\":{}}",
     "dest": "cargo/vendor/swift-rs-1.0.7",
+    "dest-filename": ".cargo-checksum.json"
+  },
+  {
+    "type": "archive",
+    "archive-type": "tar-gzip",
+    "url": "https://static.crates.io/crates/symlink/symlink-0.1.0.crate",
+    "sha256": "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a",
+    "dest": "cargo/vendor/symlink-0.1.0"
+  },
+  {
+    "type": "inline",
+    "contents": "{\"package\":\"a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a\",\"files\":{}}",
+    "dest": "cargo/vendor/symlink-0.1.0",
     "dest-filename": ".cargo-checksum.json"
   },
   {
@@ -5735,6 +5787,19 @@
   {
     "type": "archive",
     "archive-type": "tar-gzip",
+    "url": "https://static.crates.io/crates/thread_local/thread_local-1.1.10.crate",
+    "sha256": "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070",
+    "dest": "cargo/vendor/thread_local-1.1.10"
+  },
+  {
+    "type": "inline",
+    "contents": "{\"package\":\"1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070\",\"files\":{}}",
+    "dest": "cargo/vendor/thread_local-1.1.10",
+    "dest-filename": ".cargo-checksum.json"
+  },
+  {
+    "type": "archive",
+    "archive-type": "tar-gzip",
     "url": "https://static.crates.io/crates/time/time-0.3.53.crate",
     "sha256": "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50",
     "dest": "cargo/vendor/time-0.3.53"
@@ -6086,6 +6151,19 @@
   {
     "type": "archive",
     "archive-type": "tar-gzip",
+    "url": "https://static.crates.io/crates/tracing-appender/tracing-appender-0.2.5.crate",
+    "sha256": "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c",
+    "dest": "cargo/vendor/tracing-appender-0.2.5"
+  },
+  {
+    "type": "inline",
+    "contents": "{\"package\":\"050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c\",\"files\":{}}",
+    "dest": "cargo/vendor/tracing-appender-0.2.5",
+    "dest-filename": ".cargo-checksum.json"
+  },
+  {
+    "type": "archive",
+    "archive-type": "tar-gzip",
     "url": "https://static.crates.io/crates/tracing-attributes/tracing-attributes-0.1.31.crate",
     "sha256": "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da",
     "dest": "cargo/vendor/tracing-attributes-0.1.31"
@@ -6107,6 +6185,32 @@
     "type": "inline",
     "contents": "{\"package\":\"db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a\",\"files\":{}}",
     "dest": "cargo/vendor/tracing-core-0.1.36",
+    "dest-filename": ".cargo-checksum.json"
+  },
+  {
+    "type": "archive",
+    "archive-type": "tar-gzip",
+    "url": "https://static.crates.io/crates/tracing-log/tracing-log-0.2.0.crate",
+    "sha256": "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3",
+    "dest": "cargo/vendor/tracing-log-0.2.0"
+  },
+  {
+    "type": "inline",
+    "contents": "{\"package\":\"ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3\",\"files\":{}}",
+    "dest": "cargo/vendor/tracing-log-0.2.0",
+    "dest-filename": ".cargo-checksum.json"
+  },
+  {
+    "type": "archive",
+    "archive-type": "tar-gzip",
+    "url": "https://static.crates.io/crates/tracing-subscriber/tracing-subscriber-0.3.23.crate",
+    "sha256": "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319",
+    "dest": "cargo/vendor/tracing-subscriber-0.3.23"
+  },
+  {
+    "type": "inline",
+    "contents": "{\"package\":\"cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319\",\"files\":{}}",
+    "dest": "cargo/vendor/tracing-subscriber-0.3.23",
     "dest-filename": ".cargo-checksum.json"
   },
   {
@@ -6341,6 +6445,19 @@
     "type": "inline",
     "contents": "{\"package\":\"bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239\",\"files\":{}}",
     "dest": "cargo/vendor/uuid-1.24.0",
+    "dest-filename": ".cargo-checksum.json"
+  },
+  {
+    "type": "archive",
+    "archive-type": "tar-gzip",
+    "url": "https://static.crates.io/crates/valuable/valuable-0.1.1.crate",
+    "sha256": "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65",
+    "dest": "cargo/vendor/valuable-0.1.1"
+  },
+  {
+    "type": "inline",
+    "contents": "{\"package\":\"ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65\",\"files\":{}}",
+    "dest": "cargo/vendor/valuable-0.1.1",
     "dest-filename": ".cargo-checksum.json"
   },
   {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2262,6 +2262,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2419,6 +2428,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-complex"
@@ -2811,6 +2829,8 @@ dependencies = [
  "tiny_http",
  "tokio",
  "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "uuid",
  "vorbis_rs",
  "zip",
@@ -3978,6 +3998,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4157,6 +4186,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "symphonia"
@@ -4786,6 +4821,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5079,6 +5123,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.19",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5096,6 +5153,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -5255,6 +5342,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -58,6 +58,8 @@ httpdate = "1.0.3"
 tokio = { version = "1.53", features = ["sync"] }
 image = { version = "0.25.10", default-features = false, features = ["jpeg", "png", "webp"] }
 realfft = "3.5.0"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tracing-appender = "0.2.3"
 
 [dev-dependencies]
 filetime = "0.2.29"

--- a/src-tauri/src/app_menu.rs
+++ b/src-tauri/src/app_menu.rs
@@ -52,6 +52,10 @@ fn build_about_metadata<R: Runtime>(app_handle: &AppHandle<R>) -> AboutMetadata<
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub fn build_app_menu<R: Runtime>(app_handle: &AppHandle<R>) -> tauri::Result<Menu<R>> {
     let _pkg_info = app_handle.package_info();
+    // The application menu is only mounted on macOS (see `run()`), and the
+    // About item lives in the macOS app submenu, so its metadata is macOS-only.
+    // Cross-platform version/debug visibility now lives in Settings → About.
+    #[cfg(target_os = "macos")]
     let about_metadata = build_about_metadata(app_handle);
 
     let import_item = MenuItem::with_id(
@@ -88,10 +92,6 @@ pub fn build_app_menu<R: Runtime>(app_handle: &AppHandle<R>) -> tauri::Result<Me
         "Help",
         true,
         &[
-            #[cfg(not(target_os = "macos"))]
-            &PredefinedMenuItem::about(app_handle, None, Some(about_metadata.clone()))?,
-            #[cfg(not(target_os = "macos"))]
-            &PredefinedMenuItem::separator(app_handle)?,
             &copy_debug_info_item,
             #[cfg(target_os = "macos")]
             &PredefinedMenuItem::separator(app_handle)?,

--- a/src-tauri/src/app_runtime.rs
+++ b/src-tauri/src/app_runtime.rs
@@ -20,6 +20,29 @@ use std::{
 use tauri::{Emitter, Manager, Runtime};
 
 pub fn setup_app<R: Runtime>(app: &mut tauri::App<R>) -> Result<(), Box<dyn std::error::Error>> {
+    // Install file logging first so every diagnostic below reaches the rolling
+    // log file. A failure here must not brick startup — logging is a
+    // best-effort aid, not a launch precondition — so we fall back to plain
+    // stderr and carry on.
+    match app.path().app_log_dir() {
+        Ok(log_dir) => {
+            if let Err(err) = crate::logging::init(&log_dir) {
+                // Logging failed to install, so `tracing` is a no-op here —
+                // fall back to raw stderr or the message is lost entirely.
+                eprintln!("warning: failed to initialize file logging: {err:#}");
+            } else {
+                tracing::info!(
+                    log_dir = %log_dir.display(),
+                    "OpenKara starting; file logging initialized"
+                );
+            }
+        }
+        Err(err) => {
+            // No log directory means no subscriber; raw stderr is all we have.
+            eprintln!("warning: could not resolve log directory; file logging disabled: {err:#}");
+        }
+    }
+
     let app_resource_dir = app
         .path()
         .resource_dir()
@@ -48,13 +71,13 @@ pub fn setup_app<R: Runtime>(app: &mut tauri::App<R>) -> Result<(), Box<dyn std:
                         if let Err(err) =
                             separator::runtime_bootstrap::finish_activation_success(&app_data_dir)
                         {
-                            eprintln!("warning: failed to finalize runtime activation: {err:#}");
+                            tracing::warn!("failed to finalize runtime activation: {err:#}");
                         }
                     }
                 }
                 Err(err) => {
-                    eprintln!(
-                        "warning: failed to load ONNX Runtime from {}: {err:#}",
+                    tracing::warn!(
+                        "failed to load ONNX Runtime from {}: {err:#}",
                         plan.library_path.display()
                     );
                     if !plan.proving_candidate && !plan.is_legacy {
@@ -78,16 +101,16 @@ pub fn setup_app<R: Runtime>(app: &mut tauri::App<R>) -> Result<(), Box<dyn std:
                                         &previous.library_path,
                                     )
                                 {
-                                    eprintln!(
-                                        "warning: failed to load previous ONNX Runtime {}: {load_err:#}",
+                                    tracing::warn!(
+                                        "failed to load previous ONNX Runtime {}: {load_err:#}",
                                         previous.library_path.display()
                                     );
                                 }
                             }
                             Ok(None) => {}
                             Err(rollback_err) => {
-                                eprintln!(
-                                    "warning: failed to record runtime load failure: {rollback_err:#}"
+                                tracing::warn!(
+                                    "failed to record runtime load failure: {rollback_err:#}"
                                 );
                             }
                         }
@@ -109,21 +132,21 @@ pub fn setup_app<R: Runtime>(app: &mut tauri::App<R>) -> Result<(), Box<dyn std:
                                         &previous.library_path,
                                     )
                                 {
-                                    eprintln!(
-                                    "warning: failed to restore previous ONNX Runtime {}: {load_err:#}",
-                                    previous.library_path.display()
-                                );
+                                    tracing::warn!(
+                                        "failed to restore previous ONNX Runtime {}: {load_err:#}",
+                                        previous.library_path.display()
+                                    );
                                 }
                             }
                             Ok(None) => {
-                                eprintln!(
-                                "warning: no previous ONNX Runtime available after failed activation"
-                            );
+                                tracing::warn!(
+                                    "no previous ONNX Runtime available after failed activation"
+                                );
                             }
                             Err(rollback_err) => {
-                                eprintln!(
-                                "warning: failed to roll back runtime activation: {rollback_err:#}"
-                            );
+                                tracing::warn!(
+                                    "failed to roll back runtime activation: {rollback_err:#}"
+                                );
                             }
                         }
                     }
@@ -132,7 +155,7 @@ pub fn setup_app<R: Runtime>(app: &mut tauri::App<R>) -> Result<(), Box<dyn std:
         }
         Ok(None) => {}
         Err(err) => {
-            eprintln!("warning: runtime startup resolution failed: {err:#}");
+            tracing::warn!("runtime startup resolution failed: {err:#}");
         }
     }
 
@@ -147,8 +170,8 @@ pub fn setup_app<R: Runtime>(app: &mut tauri::App<R>) -> Result<(), Box<dyn std:
     let app_config = match config::load_config(&app_data_dir) {
         Ok(config) => config,
         Err(err) => {
-            eprintln!(
-                "warning: failed to load application config from {} ({err:#}); \
+            tracing::warn!(
+                "failed to load application config from {} ({err:#}); \
                  starting with default settings",
                 app_data_dir.display()
             );
@@ -164,14 +187,14 @@ pub fn setup_app<R: Runtime>(app: &mut tauri::App<R>) -> Result<(), Box<dyn std:
     let app_config = if let Some(mut config) = app_config {
         if config.pending_mirror_restore {
             let original_id = config.pending_mirror_restore_active_library_id.take();
-            eprintln!(
+            tracing::info!(
                 "recovering from interrupted mirror: restoring active_library_id to {:?}",
                 original_id
             );
             config.active_library_id = original_id;
             config.pending_mirror_restore = false;
             if let Err(e) = config::save_config(&app_data_dir, &config) {
-                eprintln!("warning: failed to persist mirror recovery config: {e}");
+                tracing::warn!("failed to persist mirror recovery config: {e}");
             }
         }
         Some(config)
@@ -180,7 +203,7 @@ pub fn setup_app<R: Runtime>(app: &mut tauri::App<R>) -> Result<(), Box<dyn std:
     };
     let configured_window_count = app.webview_windows().len();
     if configured_window_count == 0 {
-        eprintln!("warning: no Tauri webview windows were created during startup");
+        tracing::warn!("no Tauri webview windows were created during startup");
     }
     let window_shell_state = crate::window_shell::initialize_main_window(app, app_config.as_ref());
 
@@ -308,7 +331,7 @@ pub fn setup_app<R: Runtime>(app: &mut tauri::App<R>) -> Result<(), Box<dyn std:
         playback_state_for_output.peak_ring.clone(),
         playback_state_for_output.output_format.clone(),
     ) {
-        eprintln!("warning: failed to pre-warm audio output: {err:#}");
+        tracing::warn!("failed to pre-warm audio output: {err:#}");
     }
 
     airplay_stream::spawn_audio_forwarder(Arc::clone(&airplay_audio_tap));
@@ -366,7 +389,7 @@ fn spawn_runtime_update_check_worker<R: Runtime>(
             let catalog = match separator::catalog::fetch_stable_catalog() {
                 Ok(catalog) => catalog,
                 Err(error) => {
-                    eprintln!("runtime update check skipped: {error:#}");
+                    tracing::warn!("runtime update check skipped: {error:#}");
                     return;
                 }
             };
@@ -395,7 +418,7 @@ fn spawn_runtime_update_check_worker<R: Runtime>(
             ) {
                 Ok(comparison) => comparison,
                 Err(error) => {
-                    eprintln!("runtime update check skipped: {error:#}");
+                    tracing::warn!("runtime update check skipped: {error:#}");
                     return;
                 }
             };
@@ -426,7 +449,7 @@ fn spawn_runtime_update_check_worker<R: Runtime>(
                             &mut emit,
                         )
                     {
-                        eprintln!("automatic runtime update download failed: {error:#}");
+                        tracing::warn!("automatic runtime update download failed: {error:#}");
                     }
                 }
                 config::UpdatePolicy::Notify | config::UpdatePolicy::Manual => {
@@ -491,8 +514,8 @@ fn load_library(app_config: Option<&config::AppConfig>) -> Option<LibraryRoot> {
         Ok(lib) => {
             let db_path = lib.database_path();
             if let Err(err) = cache::initialize_library_database(&db_path) {
-                eprintln!(
-                    "warning: failed to apply migrations on library at {}: {}",
+                tracing::warn!(
+                    "failed to apply migrations on library at {}: {}",
                     lib_path.display(),
                     err
                 );
@@ -500,11 +523,7 @@ fn load_library(app_config: Option<&config::AppConfig>) -> Option<LibraryRoot> {
             Some(lib)
         }
         Err(err) => {
-            eprintln!(
-                "warning: could not open library at {}: {}",
-                lib_path.display(),
-                err
-            );
+            tracing::warn!("could not open library at {}: {}", lib_path.display(), err);
             None
         }
     }
@@ -732,7 +751,7 @@ fn run_remote_recovery(remote_state: &RemoteState, app_data_dir: &std::path::Pat
         let conn = match remote_state.control_db.lock() {
             Ok(conn) => conn,
             Err(_) => {
-                eprintln!("warning: remote control DB lock was poisoned during recovery");
+                tracing::warn!("remote control DB lock was poisoned during recovery");
                 return;
             }
         };
@@ -756,7 +775,7 @@ fn run_remote_recovery(remote_state: &RemoteState, app_data_dir: &std::path::Pat
     };
 
     if let Err(error) = recovery_result {
-        eprintln!("warning: remote control DB recovery failed: {:?}", error);
+        tracing::warn!("remote control DB recovery failed: {:?}", error);
     }
 
     // Remove stale `*.part.*` temp files left by interrupted downloads in
@@ -771,8 +790,8 @@ fn run_remote_recovery(remote_state: &RemoteState, app_data_dir: &std::path::Pat
         // Fail closed: without the control plane we cannot tell which
         // partials are resumable. Leave every `*.part.*` file in place
         // rather than deleting them as orphans.
-        eprintln!(
-            "warning: control DB unavailable during part-file recovery; \
+        tracing::warn!(
+            "control DB unavailable during part-file recovery; \
              preserving all partial downloads (fail-closed)"
         );
     }
@@ -840,8 +859,8 @@ fn project_library_outboxes_into_control_db(
             continue;
         };
         if let Err(error) = crate::cache::apply_migrations(&lib_conn) {
-            eprintln!(
-                "warning: library migrations failed during outbox projection for {}: {error}",
+            tracing::warn!(
+                "library migrations failed during outbox projection for {}: {error}",
                 root_path.display()
             );
             continue;
@@ -849,8 +868,8 @@ fn project_library_outboxes_into_control_db(
         let rows = match list_unprojected_library_outbox(&lib_conn) {
             Ok(rows) => rows,
             Err(error) => {
-                eprintln!(
-                    "warning: failed to list library outbox for {}: {:?}",
+                tracing::warn!(
+                    "failed to list library outbox for {}: {:?}",
                     root_path.display(),
                     error
                 );
@@ -861,7 +880,7 @@ fn project_library_outboxes_into_control_db(
             continue;
         }
         let Ok(control) = remote_state.control_db.lock() else {
-            eprintln!("warning: control DB lock poisoned during outbox projection");
+            tracing::warn!("control DB lock poisoned during outbox projection");
             continue;
         };
         let now = crate::remote::types::current_unix_time_ms();
@@ -887,8 +906,8 @@ fn project_library_outboxes_into_control_db(
                     ) {
                         true
                     } else {
-                        eprintln!(
-                            "warning: residual outbox {} not covered by terminal op; keeping",
+                        tracing::warn!(
+                            "residual outbox {} not covered by terminal op; keeping",
                             row.operation_id
                         );
                         false
@@ -911,9 +930,10 @@ fn project_library_outboxes_into_control_db(
                     let payload_json = match payload.to_json() {
                         Ok(json) => json,
                         Err(error) => {
-                            eprintln!(
-                                "warning: outbox payload serialize failed for {}: {:?}",
-                                row.operation_id, error
+                            tracing::warn!(
+                                "outbox payload serialize failed for {}: {:?}",
+                                row.operation_id,
+                                error
                             );
                             continue;
                         }
@@ -944,18 +964,20 @@ fn project_library_outboxes_into_control_db(
                         )
                         .is_ok(),
                         Err(error) => {
-                            eprintln!(
-                                "warning: control projection upsert failed for {}: {:?}",
-                                row.operation_id, error
+                            tracing::warn!(
+                                "control projection upsert failed for {}: {:?}",
+                                row.operation_id,
+                                error
                             );
                             false
                         }
                     }
                 }
                 Err(error) => {
-                    eprintln!(
-                        "warning: control get_operation failed for {}: {:?}",
-                        row.operation_id, error
+                    tracing::warn!(
+                        "control get_operation failed for {}: {:?}",
+                        row.operation_id,
+                        error
                     );
                     false
                 }
@@ -963,9 +985,10 @@ fn project_library_outboxes_into_control_db(
             // Only remove the library outbox after control projection succeeds.
             if projected {
                 if let Err(error) = delete_library_publish_outbox(&lib_conn, &row.operation_id) {
-                    eprintln!(
-                        "warning: failed to delete projected outbox {}: {:?}",
-                        row.operation_id, error
+                    tracing::warn!(
+                        "failed to delete projected outbox {}: {:?}",
+                        row.operation_id,
+                        error
                     );
                 }
             }
@@ -995,8 +1018,8 @@ fn recover_stale_part_files_for_all_libraries(
         if let Err(error) =
             crate::remote::recovery::recover_stale_part_files(&root_path, control_db)
         {
-            eprintln!(
-                "warning: stale part-file recovery failed for {}: {:?}",
+            tracing::warn!(
+                "stale part-file recovery failed for {}: {:?}",
                 root_path.display(),
                 error
             );
@@ -1017,8 +1040,8 @@ fn spawn_durable_operation_executor(app_state: AppState) {
     std::thread::spawn(move || {
         // Immediate pass on startup.
         if let Err(error) = crate::remote::recovery::retry_pending_operations(&app_state) {
-            eprintln!(
-                "warning: durable operation executor initial pass failed: {:?}",
+            tracing::warn!(
+                "durable operation executor initial pass failed: {:?}",
                 error
             );
         }
@@ -1028,8 +1051,8 @@ fn spawn_durable_operation_executor(app_state: AppState) {
         loop {
             std::thread::sleep(poll_interval);
             if let Err(error) = crate::remote::recovery::retry_pending_operations(&app_state) {
-                eprintln!(
-                    "warning: durable operation executor periodic pass failed: {:?}",
+                tracing::warn!(
+                    "durable operation executor periodic pass failed: {:?}",
                     error
                 );
             }

--- a/src-tauri/src/cache/stems.rs
+++ b/src-tauri/src/cache/stems.rs
@@ -411,8 +411,8 @@ pub fn downgrade_to_two_stem(
     ] {
         let stem_len = audio.samples.len() as f64;
         if stem_len > 0.0 && (max_len - stem_len) / max_len > 0.01 {
-            eprintln!(
-                "warning: stem {name} length differs from max by >1% ({} vs {max_len})",
+            tracing::warn!(
+                "stem {name} length differs from max by >1% ({} vs {max_len})",
                 audio.samples.len()
             );
         }

--- a/src-tauri/src/commands/diagnostics.rs
+++ b/src-tauri/src/commands/diagnostics.rs
@@ -1,0 +1,328 @@
+//! Debug-info export: a single structured snapshot that a user can copy from
+//! Settings → About (every platform) or the macOS Help menu's "Copy Debug
+//! Info". Both surfaces call [`get_debug_info`], so there is exactly one
+//! data-generation path — the front-end only renders the plain-text form.
+
+use serde::Serialize;
+use tauri::{AppHandle, Manager, State};
+
+use crate::commands::bootstrap::ModelBootstrapState;
+use crate::commands::error::{internal_error, CommandResult};
+use crate::commands::runtime_bootstrap::RuntimeBootstrapState;
+use crate::config::{self, ExecutionProviderPreference, ModelVariant};
+use crate::{separator, AppState};
+
+/// Compile-time git short SHA, injected by `build.rs`. `"unknown"` when the
+/// build happened outside a git checkout.
+const BUILD_SHA: &str = match option_env!("GIT_BUILD_HASH") {
+    Some(sha) => sha,
+    None => "unknown",
+};
+
+/// Everything a bug report needs, in one snapshot. Serialized to the
+/// front-end, which owns the plain-text formatting shared by every copy
+/// surface.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DebugInfo {
+    /// Application version from the bundle (`package.version`).
+    pub app_version: String,
+    /// Git short SHA the binary was built from, or `"unknown"`.
+    pub build_sha: String,
+    /// Operating system family (`macos` / `windows` / `linux`).
+    pub os: String,
+    /// CPU architecture (`aarch64` / `x86_64`).
+    pub arch: String,
+    /// Embedded catalog generation the binary ships with.
+    pub catalog_generation: u64,
+    /// Embedded catalog release id the binary ships with.
+    pub catalog_release_id: String,
+    /// Active separation model variant.
+    pub model_variant: String,
+    /// Bootstrap state of the active model (`ready` / `pending` / …).
+    pub model_state: String,
+    /// Whether the active model is installed and verified.
+    pub model_installed: bool,
+    /// Installed model upstream tag, when known.
+    pub model_installed_version: Option<String>,
+    /// Upstream tag pinned by the embedded catalog for the active variant.
+    pub model_pinned_version: String,
+    /// Bootstrap state of the ONNX Runtime (`ready` / `missing` / …).
+    pub runtime_state: String,
+    /// Active runtime upstream version (or the pinned version when absent).
+    pub runtime_version: String,
+    /// Active runtime artifact id, when a slot install is active.
+    pub runtime_artifact_id: Option<String>,
+    /// Runtime target triple this build resolves against.
+    pub runtime_target_triple: String,
+    /// Current execution-provider preference.
+    pub execution_provider: String,
+    /// Path pattern of the rolling log file the user can attach.
+    pub log_file: String,
+}
+
+fn model_state_label(state: &ModelBootstrapState) -> &'static str {
+    match state {
+        ModelBootstrapState::Pending => "pending",
+        ModelBootstrapState::Downloading => "downloading",
+        ModelBootstrapState::Outdated => "outdated",
+        ModelBootstrapState::Ready => "ready",
+        ModelBootstrapState::Failed => "failed",
+    }
+}
+
+fn runtime_state_label(state: &RuntimeBootstrapState) -> &'static str {
+    match state {
+        RuntimeBootstrapState::Missing => "missing",
+        RuntimeBootstrapState::Downloading => "downloading",
+        RuntimeBootstrapState::Ready => "ready",
+        RuntimeBootstrapState::UpdateAvailable => "update_available",
+        RuntimeBootstrapState::DownloadingCandidate => "downloading_candidate",
+        RuntimeBootstrapState::CandidateReadyRestartRequired => "candidate_ready_restart_required",
+        RuntimeBootstrapState::ActivationFailedPreviousRestored => {
+            "activation_failed_previous_restored"
+        }
+        RuntimeBootstrapState::Corrupt => "corrupt",
+        RuntimeBootstrapState::Failed => "failed",
+    }
+}
+
+/// Pure assembler kept separate from the Tauri command so it is unit-testable
+/// without an `AppHandle`.
+pub fn assemble_debug_info(
+    app_version: String,
+    build_sha: &str,
+    os: &str,
+    arch: &str,
+    catalog_generation: u64,
+    catalog_release_id: String,
+    model_variant: &str,
+    model_state: &str,
+    model_installed: bool,
+    model_installed_version: Option<String>,
+    model_pinned_version: String,
+    runtime_state: &str,
+    runtime_version: String,
+    runtime_artifact_id: Option<String>,
+    runtime_target_triple: String,
+    execution_provider: &str,
+    log_file: String,
+) -> DebugInfo {
+    DebugInfo {
+        app_version,
+        build_sha: build_sha.to_owned(),
+        os: os.to_owned(),
+        arch: arch.to_owned(),
+        catalog_generation,
+        catalog_release_id,
+        model_variant: model_variant.to_owned(),
+        model_state: model_state.to_owned(),
+        model_installed,
+        model_installed_version,
+        model_pinned_version,
+        runtime_state: runtime_state.to_owned(),
+        runtime_version,
+        runtime_artifact_id,
+        runtime_target_triple,
+        execution_provider: execution_provider.to_owned(),
+        log_file,
+    }
+}
+
+#[tauri::command]
+pub fn get_debug_info(
+    app_handle: AppHandle,
+    state: State<'_, AppState>,
+) -> CommandResult<DebugInfo> {
+    let app_data_dir = state.shell.app_data_dir.clone();
+
+    let log_file = app_handle
+        .path()
+        .app_log_dir()
+        .map(|dir| crate::logging::log_file_hint(&dir).display().to_string())
+        .unwrap_or_else(|_| "unknown".to_owned());
+
+    let config = config::load_config(&app_data_dir)
+        .ok()
+        .flatten()
+        .unwrap_or_default();
+    let variant: ModelVariant = config.effective_model_variant();
+    let execution_provider: ExecutionProviderPreference = config.effective_execution_provider();
+
+    let catalog = separator::catalog::embedded_catalog();
+
+    // Model: derive installed/version from the managed path for the active
+    // variant, and the runtime bootstrap state for the human-facing status.
+    let descriptor = separator::bootstrap::descriptor_for(variant);
+    let managed_model_path =
+        separator::bootstrap::managed_model_path_for(&app_data_dir, descriptor);
+    let model_snapshot = state
+        .shell
+        .model_bootstrap_status
+        .lock()
+        .map(|snapshot| snapshot.clone())
+        .map_err(|_| internal_error("model bootstrap status lock was poisoned"))?;
+    let model_installed = matches!(model_snapshot.state, ModelBootstrapState::Ready);
+    let model_installed_version = if model_installed {
+        separator::catalog::read_installed_identity(&managed_model_path)
+            .map(|identity| identity.upstream_version)
+            .or_else(|| Some(descriptor.upstream_tag.clone()))
+    } else {
+        None
+    };
+
+    let runtime_snapshot = state
+        .shell
+        .runtime_bootstrap_status
+        .lock()
+        .map(|snapshot| snapshot.clone())
+        .map_err(|_| internal_error("runtime bootstrap status lock was poisoned"))?;
+
+    Ok(assemble_debug_info(
+        app_handle.package_info().version.to_string(),
+        BUILD_SHA,
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        catalog.generation,
+        catalog.release_id.clone(),
+        variant.as_str(),
+        model_state_label(&model_snapshot.state),
+        model_installed,
+        model_installed_version,
+        descriptor.upstream_tag.clone(),
+        runtime_state_label(&runtime_snapshot.state),
+        runtime_snapshot.version.clone(),
+        runtime_snapshot.active_artifact_id.clone(),
+        runtime_snapshot.target_triple.clone(),
+        execution_provider.as_str(),
+        log_file,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> DebugInfo {
+        assemble_debug_info(
+            "0.9.1".to_owned(),
+            "abc1234",
+            "macos",
+            "aarch64",
+            9,
+            "2026-07-25-006".to_owned(),
+            "htdemucs",
+            "ready",
+            true,
+            Some("model-v2.1.0".to_owned()),
+            "model-v2.1.0".to_owned(),
+            "ready",
+            "v1.27.1".to_owned(),
+            Some("onnxruntime-1.27.1-openkara-aarch64-apple-darwin".to_owned()),
+            "aarch64-apple-darwin".to_owned(),
+            "xnnpack",
+            "/Users/me/Library/Logs/com.openkara.desktop/openkara.<date>.log".to_owned(),
+        )
+    }
+
+    #[test]
+    fn assembles_every_field() {
+        let info = sample();
+        assert_eq!(info.app_version, "0.9.1");
+        assert_eq!(info.build_sha, "abc1234");
+        assert_eq!(info.os, "macos");
+        assert_eq!(info.arch, "aarch64");
+        assert_eq!(info.catalog_generation, 9);
+        assert_eq!(info.catalog_release_id, "2026-07-25-006");
+        assert_eq!(info.model_variant, "htdemucs");
+        assert_eq!(info.model_state, "ready");
+        assert!(info.model_installed);
+        assert_eq!(
+            info.model_installed_version.as_deref(),
+            Some("model-v2.1.0")
+        );
+        assert_eq!(info.model_pinned_version, "model-v2.1.0");
+        assert_eq!(info.runtime_state, "ready");
+        assert_eq!(info.runtime_version, "v1.27.1");
+        assert_eq!(
+            info.runtime_artifact_id.as_deref(),
+            Some("onnxruntime-1.27.1-openkara-aarch64-apple-darwin")
+        );
+        assert_eq!(info.runtime_target_triple, "aarch64-apple-darwin");
+        assert_eq!(info.execution_provider, "xnnpack");
+        assert!(info.log_file.ends_with("openkara.<date>.log"));
+    }
+
+    #[test]
+    fn serializes_to_snake_case_json() {
+        let json = serde_json::to_value(sample()).expect("debug info serializes");
+        // The front-end reads these exact keys; a rename would silently break
+        // the About section and the debug-info paste.
+        for key in [
+            "app_version",
+            "build_sha",
+            "os",
+            "arch",
+            "catalog_generation",
+            "catalog_release_id",
+            "model_variant",
+            "model_state",
+            "model_installed",
+            "model_installed_version",
+            "model_pinned_version",
+            "runtime_state",
+            "runtime_version",
+            "runtime_artifact_id",
+            "runtime_target_triple",
+            "execution_provider",
+            "log_file",
+        ] {
+            assert!(json.get(key).is_some(), "missing key: {key}");
+        }
+    }
+
+    #[test]
+    fn model_state_labels_are_stable() {
+        assert_eq!(model_state_label(&ModelBootstrapState::Ready), "ready");
+        assert_eq!(model_state_label(&ModelBootstrapState::Pending), "pending");
+        assert_eq!(model_state_label(&ModelBootstrapState::Failed), "failed");
+    }
+
+    #[test]
+    fn runtime_state_labels_are_stable() {
+        assert_eq!(runtime_state_label(&RuntimeBootstrapState::Ready), "ready");
+        assert_eq!(
+            runtime_state_label(&RuntimeBootstrapState::Missing),
+            "missing"
+        );
+        assert_eq!(
+            runtime_state_label(&RuntimeBootstrapState::CandidateReadyRestartRequired),
+            "candidate_ready_restart_required"
+        );
+    }
+
+    #[test]
+    fn not_installed_model_reports_no_version() {
+        let info = assemble_debug_info(
+            "0.9.1".to_owned(),
+            "abc1234",
+            "linux",
+            "x86_64",
+            9,
+            "2026-07-25-006".to_owned(),
+            "htdemucs_ft",
+            "pending",
+            false,
+            None,
+            "model-v2.1.0".to_owned(),
+            "missing",
+            "v1.27.1".to_owned(),
+            None,
+            "x86_64-unknown-linux-gnu".to_owned(),
+            "cpu",
+            "/home/me/.local/share/com.openkara.desktop/logs/openkara.<date>.log".to_owned(),
+        );
+        assert!(!info.model_installed);
+        assert!(info.model_installed_version.is_none());
+        assert!(info.runtime_artifact_id.is_none());
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod airplay;
 pub mod batch_separation;
 pub mod bootstrap;
 pub mod cdg;
+pub mod diagnostics;
 pub mod error;
 pub mod import;
 pub mod integrity;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ pub mod config;
 pub mod hash;
 pub mod library;
 pub mod library_root;
+pub mod logging;
 pub mod lyrics;
 pub mod media_g;
 pub mod metadata;
@@ -84,6 +85,7 @@ pub fn run() {
         .setup(|app| app_runtime::setup_app(app))
         .invoke_handler(tauri::generate_handler![
             commands::bootstrap::get_model_bootstrap_status,
+            commands::diagnostics::get_debug_info,
             commands::import::import_songs,
             commands::import::get_import_candidate_details,
             commands::import::expand_import_paths,

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -1,0 +1,104 @@
+//! File + stderr logging via a `tracing` subscriber.
+//!
+//! OpenKara ships as a double-clickable desktop app, so `stderr` is discarded
+//! by the OS on launch and any diagnostic printed there is lost the moment a
+//! user hits a bug. This module installs a global `tracing` subscriber that
+//! writes to a daily-rolling file under the platform log directory (the same
+//! `appLogDir()` Tauri exposes) *and* keeps mirroring to `stderr` so logs stay
+//! visible when the app is launched from a terminal during development.
+//!
+//! We deliberately use `tracing-subscriber` rather than a `log`-facade plugin:
+//! the crate already depends on `tracing` and `ort` emits its runtime
+//! diagnostics through `tracing`, so a `tracing` subscriber captures both our
+//! own events and ONNX Runtime's — exactly the signal that matters in a bug
+//! report — without adding an IPC/capability surface.
+
+use std::path::{Path, PathBuf};
+
+use tracing_appender::rolling::{Builder, Rotation};
+use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+
+/// Prefix of every rolling log file: `openkara.<date>.log`.
+pub const LOG_FILENAME_PREFIX: &str = "openkara";
+/// Suffix (extension) of every rolling log file.
+pub const LOG_FILENAME_SUFFIX: &str = "log";
+/// How many days of rolled files to retain before the oldest is pruned.
+const MAX_LOG_FILES: usize = 7;
+/// Environment variable that overrides the default filter directives, e.g.
+/// `OPENKARA_LOG=debug` or `OPENKARA_LOG=openkara_lib=trace,warn`.
+const LOG_FILTER_ENV: &str = "OPENKARA_LOG";
+/// Default filter: `info` for the whole process. Errors and warnings are
+/// always in scope, and third-party crates (including ONNX Runtime) surface at
+/// `info` and above so a bug report carries their diagnostics too.
+const DEFAULT_FILTER: &str = "info";
+
+/// Human-facing hint describing where today's log file lives, e.g.
+/// `/Users/me/Library/Logs/com.openkara.desktop/openkara.<date>.log`. Used by
+/// the debug-info export so a bug report points at the right file.
+pub fn log_file_hint(log_dir: &Path) -> PathBuf {
+    log_dir.join(format!(
+        "{LOG_FILENAME_PREFIX}.<date>.{LOG_FILENAME_SUFFIX}"
+    ))
+}
+
+fn default_filter() -> EnvFilter {
+    EnvFilter::try_from_env(LOG_FILTER_ENV)
+        .or_else(|_| EnvFilter::try_new(DEFAULT_FILTER))
+        .unwrap_or_else(|_| EnvFilter::new(DEFAULT_FILTER))
+}
+
+/// Install the global `tracing` subscriber writing to `log_dir`.
+///
+/// Idempotent: a second call (or a call after another subscriber was already
+/// installed, as can happen across tests) is a no-op that returns `Ok(())`.
+/// Writes are synchronous so a crash still leaves the most recent lines on
+/// disk — the exact moment a diagnostic matters most.
+pub fn init(log_dir: &Path) -> anyhow::Result<()> {
+    std::fs::create_dir_all(log_dir)?;
+
+    let file_appender = Builder::new()
+        .rotation(Rotation::DAILY)
+        .filename_prefix(LOG_FILENAME_PREFIX)
+        .filename_suffix(LOG_FILENAME_SUFFIX)
+        .max_log_files(MAX_LOG_FILES)
+        .build(log_dir)?;
+
+    // No ANSI colour in the file; timestamps + target aid triage from a paste.
+    let file_layer = fmt::layer()
+        .with_ansi(false)
+        .with_target(true)
+        .with_writer(file_appender);
+
+    // Preserve stderr output for terminal launches during development.
+    let stderr_layer = fmt::layer().with_writer(std::io::stderr);
+
+    // `try_init` (not `init`) so a duplicate install never panics the app.
+    tracing_subscriber::registry()
+        .with(default_filter())
+        .with(file_layer)
+        .with(stderr_layer)
+        .try_init()
+        .map_err(|error| anyhow::anyhow!("failed to install tracing subscriber: {error}"))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn log_file_hint_joins_prefix_and_suffix() {
+        let hint = log_file_hint(Path::new("/var/logs/openkara"));
+        assert_eq!(
+            hint,
+            PathBuf::from("/var/logs/openkara/openkara.<date>.log")
+        );
+    }
+
+    #[test]
+    fn default_filter_is_constructible() {
+        // Guards against a malformed default directive string shipping.
+        let _ = default_filter();
+    }
+}

--- a/src-tauri/src/separator/model.rs
+++ b/src-tauri/src/separator/model.rs
@@ -179,8 +179,8 @@ fn preload_runtime_companions(runtime_path: &Path) {
         match unsafe { libloading::Library::new(&path) } {
             Ok(library) => std::mem::forget(library),
             Err(error) => {
-                eprintln!(
-                    "warning: failed to preload runtime companion {}: {error}",
+                tracing::warn!(
+                    "failed to preload runtime companion {}: {error}",
                     path.display()
                 );
             }
@@ -240,8 +240,8 @@ pub fn load_from_path(
     path: &Path,
     ep_preference: ExecutionProviderPreference,
 ) -> Result<LoadedModel> {
-    eprintln!(
-        "Attempting ONNX session load for {} via {}",
+    tracing::info!(
+        "attempting ONNX session load for {} via {}",
         path.display(),
         provider_diagnostic_summary(ep_preference)
     );
@@ -253,8 +253,8 @@ pub fn load_from_path(
         match load_with_ep(path, provider) {
             Ok(model) => {
                 if index > 0 {
-                    eprintln!(
-                        "Recovered ONNX session load by falling back to {} for {}",
+                    tracing::warn!(
+                        "recovered ONNX session load by falling back to {} for {}",
                         provider.as_str(),
                         path.display()
                     );
@@ -263,7 +263,7 @@ pub fn load_from_path(
             }
             Err(error) => {
                 if index + 1 < provider_chain.len() {
-                    eprintln!(
+                    tracing::warn!(
                         "ONNX session load failed with {} for {}: {error:#}",
                         provider.as_str(),
                         path.display()
@@ -334,8 +334,8 @@ fn load_with_ep(path: &Path, ep_preference: ExecutionProviderPreference) -> Resu
             .map_err(|e| anyhow::anyhow!("failed to configure execution providers: {e}"))?;
     }
 
-    eprintln!(
-        "Committing ONNX session for {} (provider preference: {})",
+    tracing::info!(
+        "committing ONNX session for {} (provider preference: {})",
         path.display(),
         ep_preference.as_str()
     );
@@ -343,8 +343,8 @@ fn load_with_ep(path: &Path, ep_preference: ExecutionProviderPreference) -> Resu
     let session = builder
         .commit_from_file(path)
         .with_context(|| format!("failed to load ONNX model from {}", path.display()))?;
-    eprintln!(
-        "Committed ONNX session for {} in {:?}",
+    tracing::info!(
+        "committed ONNX session for {} in {:?}",
         path.display(),
         commit_start.elapsed()
     );

--- a/src/components/Settings/SettingsAboutSection.test.tsx
+++ b/src/components/Settings/SettingsAboutSection.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { DebugInfo } from "@/types/ipc";
+import { SettingsAboutSection } from "./SettingsAboutSection";
+
+const { mockGetDebugInfo, mockNotifyError } = vi.hoisted(() => ({
+  mockGetDebugInfo: vi.fn(),
+  mockNotifyError: vi.fn(),
+}));
+
+// Labels resolve to their keys so assertions do not depend on locale copy; the
+// values under test come from the debug-info snapshot, not translation.
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>();
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+  };
+});
+
+vi.mock("@/lib/tauri", () => ({ getDebugInfo: mockGetDebugInfo }));
+vi.mock("@/lib/errors", () => ({ notifyError: mockNotifyError }));
+
+const sample: DebugInfo = {
+  app_version: "0.9.1",
+  build_sha: "abc1234",
+  os: "macos",
+  arch: "aarch64",
+  catalog_generation: 9,
+  catalog_release_id: "2026-07-25-006",
+  model_variant: "htdemucs",
+  model_state: "ready",
+  model_installed: true,
+  model_installed_version: "model-v2.1.0",
+  model_pinned_version: "model-v2.1.0",
+  runtime_state: "ready",
+  runtime_version: "v1.27.1",
+  runtime_artifact_id: "onnxruntime-1.27.1-openkara-aarch64-apple-darwin",
+  runtime_target_triple: "aarch64-apple-darwin",
+  execution_provider: "xnnpack",
+  log_file: "/Users/me/Library/Logs/com.openkara.desktop/openkara.<date>.log",
+};
+
+let writeText: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SettingsAboutSection", () => {
+  test("renders version, system, and log path from the snapshot", async () => {
+    mockGetDebugInfo.mockResolvedValue(sample);
+
+    const { container } = render(<SettingsAboutSection />);
+
+    await waitFor(() => {
+      expect(mockGetDebugInfo).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(container.textContent).toContain("0.9.1");
+    });
+    expect(container.textContent).toContain("abc1234");
+    expect(container.textContent).toContain("macos");
+    expect(container.textContent).toContain("aarch64");
+    expect(container.textContent).toContain("2026-07-25-006");
+    expect(container.textContent).toContain("xnnpack");
+    expect(container.textContent).toContain("openkara.<date>.log");
+  });
+
+  test("copies formatted debug info to the clipboard", async () => {
+    mockGetDebugInfo.mockResolvedValue(sample);
+
+    render(<SettingsAboutSection />);
+    await waitFor(() => {
+      expect(mockGetDebugInfo).toHaveBeenCalled();
+    });
+
+    // fireEvent (not userEvent) so the clipboard mock installed above stays in
+    // place — userEvent.setup() would swap in its own clipboard stub.
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "settings.about.copyDebugInfo" }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledOnce();
+    });
+    const copied = writeText.mock.calls[0][0] as string;
+    expect(copied).toContain("OpenKara debug info");
+    expect(copied).toContain("0.9.1");
+    expect(copied).toContain("v1.27.1");
+  });
+
+  test("reports an error when copying fails", async () => {
+    mockGetDebugInfo.mockResolvedValue(sample);
+    writeText.mockRejectedValueOnce(new Error("clipboard blocked"));
+
+    render(<SettingsAboutSection />);
+    await waitFor(() => {
+      expect(mockGetDebugInfo).toHaveBeenCalled();
+    });
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "settings.about.copyDebugInfo" }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockNotifyError).toHaveBeenCalledOnce();
+    });
+  });
+
+  test("still renders placeholders when the fetch fails", async () => {
+    mockGetDebugInfo.mockRejectedValue(new Error("ipc down"));
+
+    const { container } = render(<SettingsAboutSection />);
+
+    await waitFor(() => {
+      expect(mockGetDebugInfo).toHaveBeenCalled();
+    });
+    // The section renders its labels/button regardless of fetch outcome.
+    expect(
+      screen.getByRole("button", { name: "settings.about.copyDebugInfo" }),
+    ).toBeTruthy();
+    expect(container.textContent).toContain("—");
+  });
+});

--- a/src/components/Settings/SettingsAboutSection.tsx
+++ b/src/components/Settings/SettingsAboutSection.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { copyDebugInfo } from "@/lib/debug-info";
+import { notifyError } from "@/lib/errors";
+import { getDebugInfo } from "@/lib/tauri";
+import type { DebugInfo } from "@/types/ipc";
+import { SettingsSectionCard } from "./SettingsSectionCard";
+
+const COPIED_RESET_MS = 2000;
+
+function AboutRow({ label, value }: { label: string; value: string }) {
+  return (
+    <>
+      <dt className="text-[var(--color-text-dim)]">{label}</dt>
+      <dd className="break-words text-[var(--color-text)]">{value}</dd>
+    </>
+  );
+}
+
+/**
+ * Cross-platform About panel: shows the app version + build SHA, catalog
+ * generation, model/runtime status, execution provider, and the log-file
+ * path, plus a "Copy debug info" button. This is the version/diagnostic
+ * surface for Windows and Linux (which have no native menu) and complements
+ * the macOS Help menu — both copy paths share {@link copyDebugInfo}.
+ */
+export function SettingsAboutSection() {
+  const { t } = useTranslation();
+  const [info, setInfo] = useState<DebugInfo | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    getDebugInfo()
+      .then((value) => {
+        if (!cancelled) {
+          setInfo(value);
+        }
+      })
+      .catch(() => {
+        // About is display-only; a failed fetch just leaves placeholders. The
+        // copy button still fetches fresh on demand.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleCopy = async () => {
+    try {
+      await copyDebugInfo();
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), COPIED_RESET_MS);
+    } catch (error) {
+      notifyError(error);
+    }
+  };
+
+  const placeholder = "—";
+  const version = info
+    ? `${info.app_version} (${t("settings.about.build")} ${info.build_sha})`
+    : placeholder;
+  const system = info ? `${info.os} · ${info.arch}` : placeholder;
+  const catalog = info
+    ? `${info.catalog_generation} · ${info.catalog_release_id}`
+    : placeholder;
+  const model = info
+    ? `${info.model_variant} · ${info.model_state}`
+    : placeholder;
+  const runtime = info
+    ? `${info.runtime_state} · ${info.runtime_version}`
+    : placeholder;
+  const executionProvider = info ? info.execution_provider : placeholder;
+  const logFile = info ? info.log_file : placeholder;
+
+  return (
+    <SettingsSectionCard
+      title={t("settings.about.label")}
+      description={t("settings.about.description")}
+    >
+      <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 text-[12px]">
+        <AboutRow label={t("settings.about.version")} value={version} />
+        <AboutRow label={t("settings.about.system")} value={system} />
+        <AboutRow label={t("settings.about.catalog")} value={catalog} />
+        <AboutRow label={t("settings.about.model")} value={model} />
+        <AboutRow label={t("settings.about.runtime")} value={runtime} />
+        <AboutRow
+          label={t("settings.about.executionProvider")}
+          value={executionProvider}
+        />
+        <AboutRow label={t("settings.about.logFile")} value={logFile} />
+      </dl>
+
+      <p className="text-[11px] text-[var(--color-text-dim)]">
+        {t("settings.about.reportHint")}
+      </p>
+
+      <button
+        type="button"
+        onClick={() => void handleCopy()}
+        className="self-start rounded-md border border-[var(--color-border-light)] bg-[var(--color-surface)] px-3 py-1.5 text-[12px] text-[var(--color-text)] transition-colors hover:bg-[var(--color-hover)]"
+      >
+        {copied
+          ? t("settings.about.copied")
+          : t("settings.about.copyDebugInfo")}
+      </button>
+    </SettingsSectionCard>
+  );
+}

--- a/src/components/Settings/SettingsOverlay.tsx
+++ b/src/components/Settings/SettingsOverlay.tsx
@@ -1,5 +1,6 @@
 import { X } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { SettingsAboutSection } from "./SettingsAboutSection";
 import { SettingsCrossfadeSection } from "./SettingsCrossfadeSection";
 import { SettingsDangerZoneSection } from "./SettingsDangerZoneSection";
 import { SettingsDialogHost } from "./SettingsDialogHost";
@@ -49,6 +50,7 @@ export function SettingsOverlay() {
           <SettingsCrossfadeSection />
           <SettingsRemoteCacheSection />
           <SettingsRemoteDiagnosticsSection />
+          <SettingsAboutSection />
           <SettingsDangerZoneSection />
           <SettingsDialogHost />
         </SettingsOverlayProvider>

--- a/src/lib/debug-info.test.ts
+++ b/src/lib/debug-info.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test, vi } from "vitest";
+import type { DebugInfo } from "@/types/ipc";
+import { copyDebugInfo, formatDebugInfo } from "./debug-info";
+
+// Keep the module's default `getDebugInfo` import from pulling in the real
+// Tauri bindings; every test here supplies its own dependencies.
+vi.mock("@/lib/tauri", () => ({ getDebugInfo: vi.fn() }));
+
+const sample: DebugInfo = {
+  app_version: "0.9.1",
+  build_sha: "abc1234",
+  os: "macos",
+  arch: "aarch64",
+  catalog_generation: 9,
+  catalog_release_id: "2026-07-25-006",
+  model_variant: "htdemucs",
+  model_state: "ready",
+  model_installed: true,
+  model_installed_version: "model-v2.1.0",
+  model_pinned_version: "model-v2.1.0",
+  runtime_state: "ready",
+  runtime_version: "v1.27.1",
+  runtime_artifact_id: "onnxruntime-1.27.1-openkara-aarch64-apple-darwin",
+  runtime_target_triple: "aarch64-apple-darwin",
+  execution_provider: "xnnpack",
+  log_file: "/Users/me/Library/Logs/com.openkara.desktop/openkara.<date>.log",
+};
+
+describe("formatDebugInfo", () => {
+  test("includes every field value", () => {
+    const text = formatDebugInfo(sample);
+    for (const fragment of [
+      "OpenKara debug info",
+      "0.9.1",
+      "abc1234",
+      "macos",
+      "aarch64",
+      "generation 9",
+      "2026-07-25-006",
+      "htdemucs",
+      "ready",
+      "model-v2.1.0",
+      "v1.27.1",
+      "onnxruntime-1.27.1-openkara-aarch64-apple-darwin",
+      "aarch64-apple-darwin",
+      "xnnpack",
+      "openkara.<date>.log",
+    ]) {
+      expect(text).toContain(fragment);
+    }
+  });
+
+  test("reports an uninstalled model without a version", () => {
+    const text = formatDebugInfo({
+      ...sample,
+      model_installed: false,
+      model_installed_version: null,
+    });
+    expect(text).toContain("not installed");
+    expect(text).not.toContain("installed model-v2.1.0");
+  });
+
+  test("renders 'none' when no runtime artifact is active", () => {
+    const text = formatDebugInfo({ ...sample, runtime_artifact_id: null });
+    expect(text).toMatch(/Runtime: .* · none · /);
+  });
+
+  test("is stable, newline-delimited plain text", () => {
+    const lines = formatDebugInfo(sample).split("\n");
+    expect(lines[0]).toBe("OpenKara debug info");
+    expect(lines).toHaveLength(8);
+  });
+});
+
+describe("copyDebugInfo", () => {
+  test("fetches the snapshot and writes its formatted text", async () => {
+    const fetchDebugInfo = vi.fn(async () => sample);
+    const writeText = vi.fn(async () => {});
+
+    await copyDebugInfo({ fetchDebugInfo, writeText });
+
+    expect(fetchDebugInfo).toHaveBeenCalledOnce();
+    expect(writeText).toHaveBeenCalledWith(formatDebugInfo(sample));
+  });
+
+  test("propagates a fetch failure to the caller", async () => {
+    const fetchDebugInfo = vi.fn(async () => {
+      throw new Error("ipc down");
+    });
+    const writeText = vi.fn(async () => {});
+
+    await expect(copyDebugInfo({ fetchDebugInfo, writeText })).rejects.toThrow(
+      "ipc down",
+    );
+    expect(writeText).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/debug-info.ts
+++ b/src/lib/debug-info.ts
@@ -1,0 +1,47 @@
+import { getDebugInfo } from "@/lib/tauri";
+import type { DebugInfo } from "@/types/ipc";
+
+/**
+ * Render a {@link DebugInfo} snapshot as fixed-English plain text suitable for
+ * pasting into a bug report.
+ *
+ * The text is intentionally NOT localized: a maintainer triaging an issue
+ * should read the same labels regardless of the reporter's app language. The
+ * Settings → About section localizes its own on-screen labels separately.
+ */
+export function formatDebugInfo(info: DebugInfo): string {
+  const model = info.model_installed
+    ? `installed ${info.model_installed_version ?? "unknown"}`
+    : "not installed";
+  const runtimeArtifact = info.runtime_artifact_id ?? "none";
+
+  return [
+    "OpenKara debug info",
+    `Version: ${info.app_version} (build ${info.build_sha})`,
+    `OS: ${info.os} ${info.arch}`,
+    `Catalog: generation ${info.catalog_generation} · ${info.catalog_release_id}`,
+    `Model: ${info.model_variant} · ${info.model_state} · ${model} (pinned ${info.model_pinned_version})`,
+    `Runtime: ${info.runtime_state} · ${info.runtime_version} · ${runtimeArtifact} · ${info.runtime_target_triple}`,
+    `Execution provider: ${info.execution_provider}`,
+    `Log file: ${info.log_file}`,
+  ].join("\n");
+}
+
+interface CopyDebugInfoDependencies {
+  fetchDebugInfo?: () => Promise<DebugInfo>;
+  writeText?: (text: string) => Promise<void>;
+}
+
+/**
+ * Fetch the current debug info and copy its plain-text form to the clipboard.
+ *
+ * Shared by the Settings → About button and the macOS Help menu's "Copy Debug
+ * Info" so both surfaces produce byte-identical output from one code path.
+ */
+export async function copyDebugInfo({
+  fetchDebugInfo = getDebugInfo,
+  writeText = (text: string) => navigator.clipboard.writeText(text),
+}: CopyDebugInfoDependencies = {}): Promise<void> {
+  const info = await fetchDebugInfo();
+  await writeText(formatDebugInfo(info));
+}

--- a/src/lib/tauri/settings.ts
+++ b/src/lib/tauri/settings.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import type {
   AppSettings,
+  DebugInfo,
   ExecutionProvider,
   LibrarySortMode,
   ModelBootstrapStatusSnapshot,
@@ -19,6 +20,10 @@ export function getModelBootstrapStatus(): Promise<ModelBootstrapStatusSnapshot>
 
 export function getSettings(): Promise<AppSettings> {
   return invoke<AppSettings>("get_settings");
+}
+
+export function getDebugInfo(): Promise<DebugInfo> {
+  return invoke<DebugInfo>("get_debug_info");
 }
 
 export function getWindowShellState(): Promise<WindowShellStateSnapshot> {

--- a/src/lib/tauri/tauri-wrappers.test.ts
+++ b/src/lib/tauri/tauri-wrappers.test.ts
@@ -467,6 +467,14 @@ describe("settings", () => {
     expect(returned).toBe(appSettings);
   });
 
+  test("getDebugInfo invokes get_debug_info", async () => {
+    const debugInfo = { app_version: "0.9.1" };
+    mockInvoke.mockResolvedValueOnce(debugInfo);
+    const returned = await settings.getDebugInfo();
+    expect(mockInvoke).toHaveBeenCalledWith("get_debug_info");
+    expect(returned).toBe(debugInfo);
+  });
+
   test("getWindowShellState invokes get_window_shell_state", async () => {
     const result = {
       chrome_variant: "desktop" as const,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -550,6 +550,21 @@
       "checkFailed": "Update check failed.",
       "updateAvailable": "{{variant}} update available ({{version}})",
       "updateButton": "Update"
+    },
+    "about": {
+      "label": "About",
+      "description": "Version and diagnostic details to include in bug reports.",
+      "version": "Version",
+      "build": "build",
+      "system": "System",
+      "catalog": "Catalog",
+      "model": "Model",
+      "runtime": "Runtime",
+      "executionProvider": "Execution provider",
+      "logFile": "Log file",
+      "reportHint": "Reporting a bug? Copy this info into your report and attach the log file shown above.",
+      "copyDebugInfo": "Copy debug info",
+      "copied": "Copied!"
     }
   },
   "bootstrap": {

--- a/src/locales/locales.test.ts
+++ b/src/locales/locales.test.ts
@@ -54,6 +54,37 @@ describe("locale copy", () => {
       "正在发布到远程资料库：{{title}}",
     );
   });
+
+  test("defines every Settings → About key in both locales", () => {
+    // The About section is the cross-platform version + debug-export surface;
+    // a key missing from either locale would ship English (or a raw key) to
+    // the other language's users, exactly the gap the completeness guard
+    // below the remote-library flow exists to catch.
+    const aboutKeys = [
+      "settings.about.label",
+      "settings.about.description",
+      "settings.about.version",
+      "settings.about.build",
+      "settings.about.system",
+      "settings.about.catalog",
+      "settings.about.model",
+      "settings.about.runtime",
+      "settings.about.executionProvider",
+      "settings.about.logFile",
+      "settings.about.reportHint",
+      "settings.about.copyDebugInfo",
+      "settings.about.copied",
+    ];
+    const missing = aboutKeys
+      .map((key) => ({ key, en: isPresent(en, key), zh: isPresent(zh, key) }))
+      .filter((entry) => !entry.en || !entry.zh);
+    expect(
+      missing,
+      `Missing About keys: ${missing
+        .map((m) => `${m.key} (en=${m.en}, zh=${m.zh})`)
+        .join(", ")}`,
+    ).toEqual([]);
+  });
 });
 
 // Load the remote-library flow source files as raw strings at build time via

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -550,6 +550,21 @@
       "checkFailed": "检查更新失败。",
       "updateAvailable": "{{variant}}有可用更新（{{version}}）",
       "updateButton": "更新"
+    },
+    "about": {
+      "label": "关于",
+      "description": "版本与诊断信息，报告问题时请一并附上。",
+      "version": "版本",
+      "build": "构建",
+      "system": "系统",
+      "catalog": "目录",
+      "model": "模型",
+      "runtime": "运行时",
+      "executionProvider": "执行提供程序",
+      "logFile": "日志文件",
+      "reportHint": "报告问题？请把这些信息复制到反馈中，并附上上方显示的日志文件。",
+      "copyDebugInfo": "复制调试信息",
+      "copied": "已复制！"
     }
   },
   "bootstrap": {

--- a/src/runtime/menu-runtime.test.ts
+++ b/src/runtime/menu-runtime.test.ts
@@ -5,9 +5,12 @@ import {
   type AppMenuAction,
 } from "./menu-runtime";
 
-const { mockGetShortcutPlatform } = vi.hoisted(() => ({
-  mockGetShortcutPlatform: vi.fn(() => "mac"),
-}));
+const { mockGetShortcutPlatform, mockCopyDebugInfo, mockNotifyError } =
+  vi.hoisted(() => ({
+    mockGetShortcutPlatform: vi.fn(() => "mac"),
+    mockCopyDebugInfo: vi.fn(),
+    mockNotifyError: vi.fn(),
+  }));
 
 vi.mock("@/lib/app-shortcuts", async () => {
   const actual = await vi.importActual<typeof import("@/lib/app-shortcuts")>(
@@ -19,6 +22,10 @@ vi.mock("@/lib/app-shortcuts", async () => {
     getShortcutPlatform: mockGetShortcutPlatform,
   };
 });
+
+vi.mock("@/lib/debug-info", () => ({ copyDebugInfo: mockCopyDebugInfo }));
+
+vi.mock("@/lib/errors", () => ({ notifyError: mockNotifyError }));
 
 describe("app menu runtime", () => {
   test("opens settings when the settings menu item is selected", async () => {
@@ -225,6 +232,44 @@ describe("app menu runtime", () => {
       }),
     );
     expect(pickImportPaths).not.toHaveBeenCalled();
+  });
+
+  test("copies debug info when the copy-debug-info menu item is selected", async () => {
+    // This suite has no beforeEach reset; clear the shared spies per test.
+    mockCopyDebugInfo.mockClear();
+    mockNotifyError.mockClear();
+    mockCopyDebugInfo.mockResolvedValueOnce(undefined);
+    const toggleSettings = vi.fn();
+    const importFromDialog = vi.fn();
+    const toggleSidebar = vi.fn();
+
+    await handleAppMenuAction("copy-debug-info", {
+      toggleSettings,
+      importFromDialog,
+      toggleSidebar,
+    });
+
+    expect(mockCopyDebugInfo).toHaveBeenCalledOnce();
+    expect(mockNotifyError).not.toHaveBeenCalled();
+    expect(toggleSettings).not.toHaveBeenCalled();
+  });
+
+  test("surfaces an error when copying debug info fails", async () => {
+    mockCopyDebugInfo.mockClear();
+    mockNotifyError.mockClear();
+    mockCopyDebugInfo.mockRejectedValueOnce(new Error("clipboard blocked"));
+    const toggleSettings = vi.fn();
+    const importFromDialog = vi.fn();
+    const toggleSidebar = vi.fn();
+
+    await handleAppMenuAction("copy-debug-info", {
+      toggleSettings,
+      importFromDialog,
+      toggleSidebar,
+    });
+
+    expect(mockCopyDebugInfo).toHaveBeenCalledOnce();
+    expect(mockNotifyError).toHaveBeenCalledOnce();
   });
 
   test("ignores unknown menu actions", async () => {

--- a/src/runtime/menu-runtime.ts
+++ b/src/runtime/menu-runtime.ts
@@ -3,6 +3,7 @@ import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { audioDir } from "@tauri-apps/api/path";
 import { confirm, open } from "@tauri-apps/plugin-dialog";
 import i18next from "@/lib/i18n";
+import { copyDebugInfo } from "@/lib/debug-info";
 import { notifyError } from "@/lib/errors";
 import * as api from "@/lib/tauri";
 import { getShortcutPlatform } from "@/lib/app-shortcuts";
@@ -167,15 +168,14 @@ export async function handleAppMenuAction(
       await importFromDialog();
       return;
     case "copy-debug-info": {
-      // Build a minimal diagnostic string without secrets.
-      // The native About dialog shows the authoritative version + build SHA;
-      // this clipboard export is a quick triage aid.
-      const lines = [
-        `OpenKara (version info in About dialog)`,
-        `Platform: ${navigator.platform}`,
-      ];
-      const text = lines.join("\n");
-      await navigator.clipboard.writeText(text);
+      // Shares the exact data path and plain-text format used by the
+      // Settings → About "Copy debug info" button (see src/lib/debug-info.ts),
+      // so the macOS Help menu produces byte-identical output.
+      try {
+        await copyDebugInfo();
+      } catch (error) {
+        notifyError(error);
+      }
       return;
     }
     default:

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -257,6 +257,32 @@ export interface AppSettings {
   update_policy: UpdatePolicy;
 }
 
+/**
+ * One-shot diagnostic snapshot assembled by the `get_debug_info` command. The
+ * same payload backs the Settings → About display and the copy-to-clipboard
+ * export (in-app button and the macOS Help menu), so there is a single source
+ * of truth. Field names mirror the Rust struct's snake_case serialization.
+ */
+export interface DebugInfo {
+  app_version: string;
+  build_sha: string;
+  os: string;
+  arch: string;
+  catalog_generation: number;
+  catalog_release_id: string;
+  model_variant: string;
+  model_state: string;
+  model_installed: boolean;
+  model_installed_version: string | null;
+  model_pinned_version: string;
+  runtime_state: string;
+  runtime_version: string;
+  runtime_artifact_id: string | null;
+  runtime_target_triple: string;
+  execution_provider: string;
+  log_file: string;
+}
+
 export interface ModelStatusSnapshot {
   variant: string;
   downloaded: boolean;

--- a/website/faq.md
+++ b/website/faq.md
@@ -69,6 +69,18 @@ Then open the app again. This only needs to be done once.
 
 OpenKara isn't code-signed yet, so Windows SmartScreen warns before running it. Click **More info**, then **Run anyway** to launch OpenKara. You only need to do this the first time you run a new build.
 
+### How do I report a bug or find the logs?
+
+Open **Settings → About** and click **Copy debug info**, then paste the result into your bug report. It includes the app version, build, OS, and the model/runtime status a maintainer needs. On macOS the same export is available from **Help → Copy Debug Info**.
+
+OpenKara also keeps a rolling log file you can attach:
+
+- **macOS:** `~/Library/Logs/com.openkara.desktop/openkara.<date>.log`
+- **Windows:** `%LOCALAPPDATA%\com.openkara.desktop\logs\openkara.<date>.log`
+- **Linux:** `~/.local/share/com.openkara.desktop/logs/openkara.<date>.log`
+
+`<date>` is the rotation day (for example `2026-07-25`); the debug info above also prints the exact path.
+
 ## Need more detail?
 
 - [Project README](https://github.com/thedavidweng/OpenKara/blob/main/README.md)

--- a/website/zh/faq.md
+++ b/website/zh/faq.md
@@ -69,6 +69,18 @@ xattr -rd com.apple.quarantine /Applications/OpenKara.app
 
 OpenKara 目前还没有代码签名，Windows SmartScreen 会在运行前弹出提示。点击**更多信息**，再点击**仍要运行**即可启动 OpenKara。每次运行新版本时只需操作一次。
 
+### 怎么报告问题、日志在哪里？
+
+打开**设置 → 关于**，点击**复制调试信息**，把结果粘贴到反馈里。其中包含应用版本、构建、操作系统，以及维护者需要的模型/运行时状态。macOS 上也可以从**帮助 → Copy Debug Info** 导出同样的信息。
+
+OpenKara 还会保留一个滚动日志文件，可以一并附上：
+
+- **macOS：** `~/Library/Logs/com.openkara.desktop/openkara.<date>.log`
+- **Windows：** `%LOCALAPPDATA%\com.openkara.desktop\logs\openkara.<date>.log`
+- **Linux：** `~/.local/share/com.openkara.desktop/logs/openkara.<date>.log`
+
+`<date>` 是滚动日期（例如 `2026-07-25`）；上面的调试信息里也会打印确切路径。
+
 ## 想了解更多？
 
 - [项目 README](https://github.com/thedavidweng/OpenKara/blob/main/README_CN.md)


### PR DESCRIPTION
## Why

Closes the 1.0 observability gap (S2): "when a user reports a bug, can we get useful information?" Today there is no file logging (92 `eprintln!`/`println!` calls go to stderr, discarded on double-click launch), no version visibility on Windows/Linux (the About dialog + Copy Debug Info only mount on macOS; the non-macOS About branch was dead code), and even the macOS debug export was near-useless (`"OpenKara (version info in About dialog)"` + `navigator.platform`).

## What

### a. File logging
- Rolling file log via `tracing-subscriber` + `tracing-appender` under Tauri's `appLogDir()` — daily rotation, 7-day retention, mirrored to stderr (dev still sees output). Default level `info` (errors always recorded), overridable with `OPENKARA_LOG`. Writes are blocking so a crash still leaves the last lines on disk.
- **Why tracing over `tauri-plugin-log`:** the crate already depends on `tracing` and ONNX Runtime emits its diagnostics through `tracing`, so one subscriber captures both our events and ORT's — the exact signal a bug report needs — with **no new capability/permission surface**. (`tauri-plugin-log` uses the `log` facade and would need a capabilities entry while dropping ORT's tracing events.)
- Migrated the diagnostic `eprintln!` calls in the key paths — `app_runtime` (startup, runtime activation, config, library, remote recovery), `separator::model` (ONNX session load), and `cache::stems` — to `tracing` macros. Scoped intentionally (not all 92) to avoid an oversized diff.

### b. Version visibility + debug export (all platforms)
- New `get_debug_info` command assembles one structured `DebugInfo` snapshot.
- New **Settings → About** section (frontend, cross-platform) renders it and offers **Copy debug info**.
- The macOS Help menu's **Copy Debug Info** now routes through the **same** command + plain-text formatter (`src/lib/debug-info.ts`) — one data-generation path, two surfaces (no duplicate implementation).
- Removed the dead non-macOS About branch in `app_menu.rs` (the menu mounts on macOS only); `about_metadata` is now macOS-gated.

### c. Debug-info fields
App version · build SHA · OS/arch · catalog generation + release id · model variant/state/installed version/pinned version · runtime state/version/artifact id/target triple · execution provider · log-file path. Emitted as issue-pasteable plain text (fixed English, so a maintainer reads the same labels regardless of the reporter's locale).

### d. Docs + i18n
- README, README_CN, and the EN/zh FAQ gained a "reporting a bug / getting logs" section with the per-platform log paths and the Settings → About → Copy debug info flow.
- `settings.about.*` keys added to `en.json` and `zh-CN.json` (structural i18n guard + a new About completeness test pass).

### Deps + packaging
- Added `tracing-subscriber` + `tracing-appender` (both MIT; pass `cargo deny`). Regenerated `packaging/flatpak/generated/cargo-sources.json` for the new transitive crates (fixes the Flatpak/ONNX packaging tests).

## Log file paths

`<date>` is the rotation day (e.g. `2026-07-25`).

| Platform | Path |
| --- | --- |
| macOS | `~/Library/Logs/com.openkara.desktop/openkara.<date>.log` |
| Windows | `%LOCALAPPDATA%\com.openkara.desktop\logs\openkara.<date>.log` |
| Linux | `~/.local/share/com.openkara.desktop/logs/openkara.<date>.log` |

## Verification

- `cargo fmt --check` ✅ · `cargo clippy --all-targets -- -D warnings` ✅ · `cargo deny check` ✅ (advisories/bans/licenses/sources ok)
- `cargo nextest run` (scoped) ✅ — diagnostics (5), logging (2), app_menu (4), plus all lib unit tests in touched files (app_runtime, cache::stems). The 3 `phase3_inference` failures are pre-existing environment failures (require the ~350 MB `models/htdemucs.spectral.onnx`, absent from the checkout) and are unrelated to this change.
- `pnpm test` ✅ (1955 tests) · `pnpm check:i18n` ✅ · `tsc --noEmit` ✅ · `pnpm lint` (`--deny-warnings`) ✅ · `oxfmt --check` ✅
- `pnpm test:coverage` ✅ (thresholds met) · patch coverage **100% (37/37)** ≥ 80% target

🤖 Generated with [Claude Code](https://claude.com/claude-code)