### PR TITLE
fix(audio): keep the accompaniment master and its sub-stems in lockstep

### DIFF
--- a/src/components/Player/AudioLevelSlider.tsx
+++ b/src/components/Player/AudioLevelSlider.tsx
@@ -5,6 +5,8 @@ interface AudioLevelSliderProps {
   label: string;
   value: number;
   onChange: (value: number) => void;
+  onDragStart?: () => void;
+  onDragEnd?: () => void;
   disabled?: boolean;
   widthClass?: string;
   ariaLabel?: string;
@@ -19,6 +21,8 @@ export function AudioLevelSlider({
   label,
   value,
   onChange,
+  onDragStart,
+  onDragEnd,
   disabled = false,
   widthClass = "w-16",
   ariaLabel,
@@ -33,6 +37,7 @@ export function AudioLevelSlider({
 
     const handlePointerFinish = () => {
       setIsDragging(false);
+      onDragEnd?.();
     };
 
     window.addEventListener("pointerup", handlePointerFinish);
@@ -42,7 +47,7 @@ export function AudioLevelSlider({
       window.removeEventListener("pointerup", handlePointerFinish);
       window.removeEventListener("pointercancel", handlePointerFinish);
     };
-  }, [isDragging]);
+  }, [isDragging, onDragEnd]);
 
   // Keep the native range input so we preserve platform drag semantics and only
   // layer immediate tooltip/highlight behavior on top.
@@ -55,8 +60,14 @@ export function AudioLevelSlider({
         max="100"
         value={Math.round(value * 100)}
         onChange={(e) => onChange(Number(e.target.value) / 100)}
-        onPointerDown={() => setIsDragging(true)}
-        onBlur={() => setIsDragging(false)}
+        onPointerDown={() => {
+          setIsDragging(true);
+          onDragStart?.();
+        }}
+        onBlur={() => {
+          setIsDragging(false);
+          onDragEnd?.();
+        }}
         className={`native-slider audio-level-slider shrink-0 ${widthClass}`}
         disabled={disabled}
         data-dragging={isDragging ? "true" : undefined}

--- a/src/components/Player/VolumeSliders.interaction.test.tsx
+++ b/src/components/Player/VolumeSliders.interaction.test.tsx
@@ -161,6 +161,170 @@ describe("VolumeSliders stem popup portal", () => {
     }
   });
 
+  test("fast master drags scale sub-stems from a frozen base so they cannot drift", () => {
+    mockPlayerState.setStemVolume.mockClear();
+
+    act(() => {
+      root.render(<VolumeSliders density="relaxed" />);
+    });
+
+    const accompSlider = container.querySelector(
+      'input[aria-label="Accompaniment"]',
+    ) as HTMLInputElement;
+    expect(accompSlider).not.toBeNull();
+
+    const setSliderValue = (value: string) => {
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )?.set;
+      setter?.call(accompSlider, value);
+      accompSlider.dispatchEvent(new Event("input", { bubbles: true }));
+    };
+
+    // Gesture start freezes the base mix {drums: 0.8, bass: 0.35, other: 0.55}.
+    act(() => {
+      accompSlider.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+    });
+
+    // First event commits immediately (leading edge of the rate limiter).
+    act(() => {
+      setSliderValue("100");
+    });
+
+    // Simulate the async backend lag that caused the historical drift: only
+    // drums has been committed to the store snapshot mid-drag.
+    mockPlayerState.snapshot.stem_volumes = {
+      vocals: 0.45,
+      drums: 1,
+      bass: 0.35,
+      other: 0.55,
+    };
+    act(() => {
+      root.render(<VolumeSliders density="relaxed" />);
+    });
+
+    // Further drag events must keep scaling from the frozen base, not the
+    // inconsistent live snapshot.
+    act(() => {
+      setSliderValue("40");
+      setSliderValue("80");
+    });
+
+    // Releasing the pointer flushes the pending trailing value atomically.
+    act(() => {
+      window.dispatchEvent(new Event("pointerup"));
+    });
+
+    const calls = mockPlayerState.setStemVolume.mock.calls as Array<
+      [string, number]
+    >;
+    expect(calls.length % 3).toBe(0);
+    const triples: Array<Record<string, number>> = [];
+    for (let i = 0; i < calls.length; i += 3) {
+      triples.push(Object.fromEntries(calls.slice(i, i + 3)));
+    }
+
+    // Every commit is a consistent triple scaled by one factor from the base.
+    expect(triples[0]).toEqual({
+      drums: 1,
+      bass: 0.35 * (1 / 0.8),
+      other: 0.55 * (1 / 0.8),
+    });
+
+    // Dragging back to the starting value restores the exact original mix —
+    // reversible through the clamp and immune to the stale snapshot.
+    expect(triples[triples.length - 1]).toEqual({
+      drums: 0.8,
+      bass: 0.35,
+      other: 0.55,
+    });
+  });
+
+  test("releases a drag whose slider disappears before the pointer comes up", () => {
+    mockPlayerState.setStemVolume.mockClear();
+
+    act(() => {
+      root.render(<VolumeSliders density="relaxed" />);
+    });
+
+    const accompSlider = container.querySelector(
+      'input[aria-label="Accompaniment"]',
+    ) as HTMLInputElement;
+    const setSliderValue = (value: string) => {
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )?.set;
+      setter?.call(accompSlider, value);
+      accompSlider.dispatchEvent(new Event("input", { bubbles: true }));
+    };
+
+    act(() => {
+      accompSlider.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+    });
+    act(() => {
+      setSliderValue("30");
+    });
+
+    // The song ends mid-drag, so the stems go away and the pointerup that
+    // would have ended the gesture never reaches this component.
+    mockPlayerState.snapshot.has_stems = false;
+    act(() => {
+      root.render(<VolumeSliders density="relaxed" />);
+    });
+
+    // A new separated song arrives with an even mix.
+    mockPlayerState.snapshot.has_stems = true;
+    mockPlayerState.snapshot.stem_volumes = {
+      vocals: 1,
+      drums: 1,
+      bass: 1,
+      other: 1,
+    };
+    act(() => {
+      root.render(<VolumeSliders density="relaxed" />);
+    });
+
+    const nextSlider = container.querySelector(
+      'input[aria-label="Accompaniment"]',
+    ) as HTMLInputElement;
+    // The thumb follows the new song's mix instead of staying pinned at the
+    // abandoned gesture value.
+    expect(nextSlider.value).toBe("100");
+
+    mockPlayerState.setStemVolume.mockClear();
+    act(() => {
+      nextSlider.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+    });
+    const setNextValue = (value: string) => {
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )?.set;
+      setter?.call(nextSlider, value);
+      nextSlider.dispatchEvent(new Event("input", { bubbles: true }));
+    };
+    act(() => {
+      setNextValue("50");
+    });
+    // Release flushes the trailing value (back-to-back gestures in a test run
+    // land inside the 20ms throttle window).
+    act(() => {
+      window.dispatchEvent(new Event("pointerup"));
+    });
+
+    // Scaled from the NEW mix (all 1) — not the previous song's frozen base.
+    const calls = mockPlayerState.setStemVolume.mock.calls as Array<
+      [string, number]
+    >;
+    expect(Object.fromEntries(calls.slice(0, 3))).toEqual({
+      drums: 0.5,
+      bass: 0.5,
+      other: 0.5,
+    });
+  });
+
   test("popup mute button dims the icon when stem is muted", () => {
     mockPlayerState.snapshot.stem_volumes = {
       vocals: 0,

--- a/src/components/Player/VolumeSliders.tsx
+++ b/src/components/Player/VolumeSliders.tsx
@@ -56,12 +56,21 @@ export function VolumeSliders({
   const throttledSetStemVolumeRef = useRef(
     new Map<StemName, TrailingRateLimiter<number>>(),
   );
+  const accompGroupLimiterRef = useRef<TrailingRateLimiter<{
+    drums: number;
+    bass: number;
+    other: number;
+  }> | null>(null);
 
   useEffect(() => {
     throttledSetStemVolumeRef.current.forEach((limiter) => limiter.cancel());
     throttledSetStemVolumeRef.current = new Map();
-    return () =>
+    accompGroupLimiterRef.current?.cancel();
+    accompGroupLimiterRef.current = null;
+    return () => {
       throttledSetStemVolumeRef.current.forEach((limiter) => limiter.cancel());
+      accompGroupLimiterRef.current?.cancel();
+    };
   }, [setStemVolume]);
 
   const stemVolumes = useMemo(
@@ -83,12 +92,29 @@ export function VolumeSliders({
   const isTwoStem = stemMode === "two_stem";
   const isFourStem = stemMode === "four_stem";
 
-  // Track previous non-zero values for mute/unmute toggle
+  // Track previous non-zero values for mute/unmute toggle. Accompaniment
+  // remembers all three sub-stems so unmuting restores the exact mix
+  // instead of collapsing the three stems to one shared level.
   const prevVocalsRef = useRef(1);
-  const prevAccompRef = useRef(1);
+  const prevAccompRef = useRef({ drums: 1, bass: 1, other: 1 });
   const prevDrumsRef = useRef(1);
   const prevBassRef = useRef(1);
   const prevOtherRef = useRef(1);
+
+  // Frozen per-gesture base for the accompaniment master slider. Captured at
+  // drag start so every slider event maps sub-stems as a pure function of the
+  // master value; recomputing from live (async, per-stem) store values lets
+  // the three stems drift apart during a fast drag.
+  const accompGestureBaseRef = useRef<{
+    drums: number;
+    bass: number;
+    other: number;
+    master: number;
+  } | null>(null);
+  // While a master drag is active the accompaniment slider renders the
+  // gesture value. Deriving it from max(sub-stems) mid-drag pins the thumb
+  // at 1 as soon as the loudest stem clamps.
+  const [accompDragValue, setAccompDragValue] = useState<number | null>(null);
 
   // Floating popup: portal to body so stage overflow / settings z-index cannot clip it.
   const popupRef = useRef<HTMLDivElement>(null);
@@ -168,33 +194,117 @@ export function VolumeSliders({
     [setStemVolume],
   );
 
-  // Accompaniment display value = max of the three sub-stems
+  // Accompaniment resting display value = max of the three sub-stems
   const accompValue = Math.max(
     stemVolumes.drums,
     stemVolumes.bass,
     stemVolumes.other,
   );
 
+  // The three sub-stems are committed through ONE trailing limiter so a
+  // throttled flush always carries a consistent triple; three independent
+  // limiters can flush values sampled at different moments of the drag.
+  const dispatchAccompGroup = useCallback(
+    (drums: number, bass: number, other: number) => {
+      let limiter = accompGroupLimiterRef.current;
+      if (!limiter) {
+        limiter = createTrailingRateLimiter(
+          (triple: { drums: number; bass: number; other: number }) => {
+            setStemVolume("drums", triple.drums);
+            setStemVolume("bass", triple.bass);
+            setStemVolume("other", triple.other);
+          },
+          20,
+        );
+        accompGroupLimiterRef.current = limiter;
+      }
+      limiter({ drums, bass, other });
+    },
+    [setStemVolume],
+  );
+
+  const handleAccompDragStart = useCallback(() => {
+    if (accompGestureBaseRef.current) return;
+    const { drums, bass, other } = stemVolumes;
+    accompGestureBaseRef.current = {
+      drums,
+      bass,
+      other,
+      master: Math.max(drums, bass, other),
+    };
+  }, [stemVolumes]);
+
+  const handleAccompDragEnd = useCallback(() => {
+    accompGroupLimiterRef.current?.flush();
+    accompGestureBaseRef.current = null;
+    // Keep rendering the released value: setStemVolume is an async round-trip,
+    // so falling straight back to max(store stems) makes the thumb hop
+    // backwards for one commit. The effect below hands the display back to the
+    // store as soon as it reflects the release.
+  }, []);
+
+  // A gesture whose slider disappears (the song ends, the mixer popup closes)
+  // never sees pointerup, so the frozen base has to be released explicitly —
+  // otherwise the next drag would scale the current mix by the stale one, and
+  // the thumb would stay pinned at the abandoned gesture value.
+  useEffect(() => {
+    if (stemsAvailable) {
+      return;
+    }
+    accompGroupLimiterRef.current?.cancel();
+    accompGestureBaseRef.current = null;
+    setAccompDragValue(null);
+  }, [stemsAvailable]);
+
+  // Same for a track change mid-drag: a pending triple belongs to the previous
+  // song's mix, so drop it rather than applying it to the new one.
+  useEffect(() => {
+    accompGroupLimiterRef.current?.cancel();
+    accompGestureBaseRef.current = null;
+    setAccompDragValue(null);
+  }, [songId]);
+
+  // Hand the display back to the store once it catches up with the gesture.
+  useEffect(() => {
+    if (accompGestureBaseRef.current !== null) {
+      return;
+    }
+    setAccompDragValue(null);
+  }, [accompValue]);
+
   const handleAccompChange = useCallback(
     (newValue: number) => {
+      const clamp01 = (v: number) => Math.min(1, Math.max(0, v));
+      const gestureBase = accompGestureBaseRef.current;
+      if (gestureBase) {
+        setAccompDragValue(newValue);
+      }
       if (isTwoStem) {
         // In 2-stem mode, set all three sub-stems to the same value;
         // the backend uses max gain as the accompaniment gain.
-        handleStemChange("drums", newValue);
-        handleStemChange("bass", newValue);
-        handleStemChange("other", newValue);
-      } else if (accompValue === 0) {
-        handleStemChange("drums", newValue);
-        handleStemChange("bass", newValue);
-        handleStemChange("other", newValue);
-      } else {
-        const ratio = newValue / accompValue;
-        handleStemChange("drums", Math.min(1, stemVolumes.drums * ratio));
-        handleStemChange("bass", Math.min(1, stemVolumes.bass * ratio));
-        handleStemChange("other", Math.min(1, stemVolumes.other * ratio));
+        dispatchAccompGroup(newValue, newValue, newValue);
+        return;
       }
+      // Keyboard adjustments arrive without a pointer gesture; scale from
+      // the current committed mix as a one-shot base.
+      const base = gestureBase ?? {
+        drums: stemVolumes.drums,
+        bass: stemVolumes.bass,
+        other: stemVolumes.other,
+        master: accompValue,
+      };
+      if (base.master === 0) {
+        dispatchAccompGroup(newValue, newValue, newValue);
+        return;
+      }
+      const factor = newValue / base.master;
+      dispatchAccompGroup(
+        clamp01(base.drums * factor),
+        clamp01(base.bass * factor),
+        clamp01(base.other * factor),
+      );
     },
-    [isTwoStem, accompValue, stemVolumes, handleStemChange],
+    [isTwoStem, accompValue, stemVolumes, dispatchAccompGroup],
   );
 
   const handleVocalsMuteToggle = useCallback(() => {
@@ -208,17 +318,21 @@ export function VolumeSliders({
 
   const handleAccompMuteToggle = useCallback(() => {
     if (accompValue > 0) {
-      prevAccompRef.current = accompValue;
+      prevAccompRef.current = {
+        drums: stemVolumes.drums,
+        bass: stemVolumes.bass,
+        other: stemVolumes.other,
+      };
       setStemVolume("drums", 0);
       setStemVolume("bass", 0);
       setStemVolume("other", 0);
     } else {
       const prev = prevAccompRef.current;
-      setStemVolume("drums", prev);
-      setStemVolume("bass", prev);
-      setStemVolume("other", prev);
+      setStemVolume("drums", prev.drums);
+      setStemVolume("bass", prev.bass);
+      setStemVolume("other", prev.other);
     }
-  }, [accompValue, setStemVolume]);
+  }, [accompValue, stemVolumes, setStemVolume]);
 
   const handleDrumsMuteToggle = useCallback(() => {
     if (stemVolumes.drums > 0) {
@@ -318,8 +432,10 @@ export function VolumeSliders({
       <StemSlider
         icon={Music}
         label={t("stems.accompaniment")}
-        value={accompValue}
+        value={accompDragValue ?? accompValue}
         onChange={handleAccompChange}
+        onDragStart={handleAccompDragStart}
+        onDragEnd={handleAccompDragEnd}
         onIconClick={handleAccompMuteToggle}
         sliderWidthClass={popupSliderWidthClass}
         iconButtonVariant="playback_bar"
@@ -431,8 +547,10 @@ export function VolumeSliders({
         <StemSlider
           icon={Music}
           label={t("stems.accompaniment")}
-          value={accompValue}
+          value={accompDragValue ?? accompValue}
           onChange={handleAccompChange}
+          onDragStart={handleAccompDragStart}
+          onDragEnd={handleAccompDragEnd}
           onIconClick={stemsAvailable ? handleAccompMuteToggle : undefined}
           disabled={!stemsAvailable}
           sliderWidthClass={inlineSliderWidthClass}
@@ -475,6 +593,8 @@ interface StemSliderProps {
   label: string;
   value: number;
   onChange: (value: number) => void;
+  onDragStart?: () => void;
+  onDragEnd?: () => void;
   onIconClick?: () => void;
   disabled?: boolean;
   sliderWidthClass?: string;
@@ -490,6 +610,8 @@ export function StemSlider({
   label,
   value,
   onChange,
+  onDragStart,
+  onDragEnd,
   onIconClick,
   disabled = false,
   sliderWidthClass = "w-16 mr-[14px]",
@@ -538,6 +660,8 @@ export function StemSlider({
           label={label}
           value={value}
           onChange={onChange}
+          onDragStart={onDragStart}
+          onDragEnd={onDragEnd}
           disabled={disabled}
           widthClass={sliderWidthClass}
           ariaLabel={label}
@@ -571,6 +695,8 @@ export function StemSlider({
         label={label}
         value={value}
         onChange={onChange}
+        onDragStart={onDragStart}
+        onDragEnd={onDragEnd}
         disabled={disabled}
         widthClass={sliderWidthClass}
         ariaLabel={label}


### PR DESCRIPTION
Fixes #235

实测反馈：四轨模式下拖动 accompaniment 主推子，展开面板里的三个子推子移动不同步；快速左右拖动会出现一个到顶、另外两个没到顶。

## 根因

`handleAccompChange` 每个滑块事件都用 `ratio = newValue / max(drums,bass,other)` 重算，基准取自**上一次渲染的 store 快照**，而 `setStemVolume` 是每轨独立的异步 IPC 往返、各自还过一条 20ms 尾随限流器。快速拖动时同一个基准被反复使用且处于「部分已提交」的不一致状态，三轨因此按不同比例缩放。放大因素：主推子的值既是 `max(三轨)` 又用作除数，任一轨饱和到 1 就劫持主推子；`Math.min(1, stem*ratio)` 是不可逆钳制，触顶后配比永久丢失。

不是增量累积误差 —— 滑块发出的是绝对值（`AudioLevelSlider` 的 `onChange`）。

## 改动

- **冻结手势基准**：`AudioLevelSlider` 新增可选 `onDragStart`/`onDragEnd`；伴奏推子在 pointerdown 时冻结 `{drums,bass,other,master}`，之后每个事件都从这份基准纯函数映射 → 幂等、可逆，且不受快照滞后影响。
- **原子提交**：三轨走**同一条**尾随限流器（而非三条），松手时 `flush()`，所以任何一次提交都是一致的三元组。
- **拖动中显示手势值**：避免饱和轨把拇指钉在顶端；松手后保留该值直到 store 追上，防止一次往返的拇指回跳。
- **手势生命周期**：滑块在未收到 pointerup 就消失（歌曲结束、mixer 弹层关闭）或中途切歌时显式释放基准并丢弃待提交值，否则下一次拖动会用上一首的配比。
- **静音恢复**：`prevAccompRef` 改存三轨各自的值，取消静音恢复原始配比而不是塌缩成同一个值。

## 测试

`src/components/Player/VolumeSliders.interaction.test.tsx` 新增两个回归：

1. 模拟「仅 drums 已提交」的不一致快照下快速拖动 → 断言每次提交都是同一因子缩放的一致三元组，且拖回起点精确还原 `{0.8, 0.35, 0.55}`。
2. 拖动中歌曲结束导致滑块卸载 → 断言拇指跟随新歌曲的混音，且下一次拖动按**新**混音（全 1）缩放而非旧基准。

`pnpm vitest run src/components/Player` 全绿（144）；typecheck / oxlint / oxfmt 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
