### PR TITLE
fix(audience): fullscreen lyrics own the whole monitor, controls hide on pointer idle

### DIFF
--- a/src/components/Lyrics/LyricsPanel.tsx
+++ b/src/components/Lyrics/LyricsPanel.tsx
@@ -362,6 +362,13 @@ export function LyricsPanel({ presentation = "standard" }: LyricsPanelProps) {
               : undefined
           }
         >
+          {/* Audience windows own the whole screen: a half-viewport spacer at
+              each end lets the first and last lines center like every other
+              line, instead of clamping them against the viewport edge. Paged
+              plain text must fill the viewport exactly, so it gets neither. */}
+          {isAudience && !shouldRenderAudiencePlainTextPages ? (
+            <div className="h-[50vh] w-full shrink-0" />
+          ) : null}
           {visibleLines.map((line, idx) => {
             const absoluteIndex = shouldRenderAudiencePlainTextPages
               ? currentPageStart + idx
@@ -399,7 +406,11 @@ export function LyricsPanel({ presentation = "standard" }: LyricsPanelProps) {
             );
           })}
           {/* Keep the last lyric line readable above floating controls */}
-          <div className="h-[30vh] w-full shrink-0" />
+          {shouldRenderAudiencePlainTextPages ? null : (
+            <div
+              className={`w-full shrink-0 ${isAudience ? "h-[50vh]" : "h-[30vh]"}`}
+            />
+          )}
         </div>
       </div>
       {shouldRenderAudiencePlainTextPages ? (

--- a/src/components/Playback/PlaybackStage.test.tsx
+++ b/src/components/Playback/PlaybackStage.test.tsx
@@ -95,12 +95,12 @@ describe("PlaybackStage", () => {
     expect(markup).not.toContain("lyrics-panel");
   });
 
-  test("applies a bottom inset for audience-safe overlays", () => {
+  test("audience stages reserve no bottom band so lyrics own the whole screen", () => {
     const markup = renderToStaticMarkup(
-      <PlaybackStage presentation="audience" bottomInsetPx={144} />,
+      <PlaybackStage presentation="audience" />,
     );
 
-    expect(markup).toContain('style="padding-bottom:144px"');
+    expect(markup).not.toContain("padding-bottom");
   });
 
   test("renders a cover-art ambience backdrop for standard lyric stages without CDG", () => {

--- a/src/components/Playback/PlaybackStage.tsx
+++ b/src/components/Playback/PlaybackStage.tsx
@@ -12,12 +12,10 @@ import type { CoverArtBytes } from "@/types/ipc";
 
 interface PlaybackStageProps {
   presentation?: "standard" | "audience";
-  bottomInsetPx?: number;
 }
 
 export function PlaybackStage({
   presentation = "standard",
-  bottomInsetPx = 0,
 }: PlaybackStageProps) {
   const hasCdg = useCdgStore((s) => s.hasCdg);
   const songId = usePlayerStore((s) => s.snapshot?.song_id ?? null);
@@ -67,11 +65,6 @@ export function PlaybackStage({
     <div
       className="relative flex h-full w-full flex-1 overflow-hidden"
       data-stage-visual-variant={stageAmbience ? "ambience" : "default"}
-      style={
-        presentation === "audience" && bottomInsetPx > 0
-          ? { paddingBottom: bottomInsetPx }
-          : undefined
-      }
     >
       {showCdg ? (
         <CdgCanvas />

--- a/src/components/Player/FullscreenControls.test.tsx
+++ b/src/components/Player/FullscreenControls.test.tsx
@@ -301,34 +301,112 @@ describe("FullscreenControls Romanize button", () => {
     // The mock lyrics store is the projection; click must not flip it.
     expect(mockLyricsStore.showRomanized).toBe(false);
   });
+});
 
-  test("the measured control footer still reports its new height with the Romanize button present", async () => {
-    const onHeightChange = vi.fn();
-    const fixedHeight = 220;
+describe("FullscreenControls auto-hide", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
 
-    await act(async () => {
-      root.render(<FullscreenControls onHeightChange={onHeightChange} />);
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockLyricsStore.showRomanized = false;
+    mockLyricsStore.isRomanizing = false;
+    mockLyricsStore.songId = "song-1";
+    mockLyricsStore.lines = [{ time_ms: 0, text: "hello" }];
+    mockPlayerStore.snapshot = {
+      song_id: "song-1",
+      is_playing: true,
+      volume: 0.5,
+    };
+    document.body.style.cursor = "";
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  function getFooter(): HTMLElement {
+    return container.firstElementChild as HTMLElement;
+  }
+
+  test("hides once the pointer has been still for the idle window, and wakes on movement", () => {
+    act(() => {
+      root.render(<FullscreenControls />);
     });
 
-    // The FullscreenControls measures its own container ref via
-    // getBoundingClientRect. Patch the rendered footer element's height so
-    // the measure callback reports a non-zero value that includes the
-    // Romanize button row.
-    const footer = container.firstElementChild as HTMLElement;
-    expect(footer).not.toBeNull();
-    expect(footer.contains(getRomanizeButton())).toBe(true);
+    const footer = getFooter();
+    expect(footer.getAttribute("data-idle")).toBe("false");
 
-    const original = footer.getBoundingClientRect.bind(footer);
-    vi.spyOn(footer, "getBoundingClientRect").mockImplementation(() => ({
-      ...original(),
-      height: fixedHeight,
-    }));
+    act(() => {
+      window.dispatchEvent(new Event("pointermove"));
+    });
+    expect(footer.getAttribute("data-idle")).toBe("false");
 
-    await act(async () => {
-      // Trigger a remeasure by dispatching a resize event.
-      window.dispatchEvent(new Event("resize"));
+    act(() => {
+      vi.advanceTimersByTime(3000);
     });
 
-    expect(onHeightChange).toHaveBeenCalledWith(fixedHeight);
+    expect(footer.getAttribute("data-idle")).toBe("true");
+    expect(footer.className).toContain("opacity-0");
+    // The cursor hides with the controls so it cannot linger as a bright dot
+    // on a projected audience screen.
+    expect(document.body.style.cursor).toBe("none");
+
+    act(() => {
+      window.dispatchEvent(new Event("pointermove"));
+    });
+    expect(footer.getAttribute("data-idle")).toBe("false");
+    expect(document.body.style.cursor).toBe("");
+  });
+
+  test("keeps the controls up while the pointer rests on them", () => {
+    act(() => {
+      root.render(<FullscreenControls />);
+    });
+
+    const footer = getFooter();
+
+    act(() => {
+      footer.dispatchEvent(new Event("pointerenter"));
+    });
+    act(() => {
+      vi.advanceTimersByTime(6000);
+    });
+
+    // A stationary pointer over the bar must not fade the button out from
+    // under the user.
+    expect(footer.getAttribute("data-idle")).toBe("false");
+
+    act(() => {
+      footer.dispatchEvent(new Event("pointerleave"));
+    });
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(footer.getAttribute("data-idle")).toBe("true");
+  });
+
+  test("hides while paused, because the idle timer ignores playback state", () => {
+    mockPlayerStore.snapshot = {
+      song_id: "song-1",
+      is_playing: false,
+      volume: 0.5,
+    };
+
+    act(() => {
+      root.render(<FullscreenControls />);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(getFooter().getAttribute("data-idle")).toBe("true");
   });
 });

--- a/src/components/Player/FullscreenControls.tsx
+++ b/src/components/Player/FullscreenControls.tsx
@@ -12,33 +12,63 @@ import {
 import { useLyricsStore } from "@/stores/lyrics-store";
 import { usePlayerStore, selectCurrentPositionMs } from "@/stores/player-store";
 
-interface FullscreenControlsProps {
-  onHeightChange?: (height: number) => void;
-}
+/**
+ * Pointer-idle window before the controls fade, matching the convention every
+ * video player uses: the timer keys off pointer *movement* only, so it does
+ * not matter whether playback is running or where the pointer rests.
+ */
+const CONTROLS_IDLE_MS = 3000;
 
-export function FullscreenControls({
-  onHeightChange,
-}: FullscreenControlsProps = {}) {
+export function FullscreenControls() {
   const { t } = useTranslation();
   const [idle, setIdle] = useState(true);
   const idleTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const containerRef = useRef<HTMLDivElement>(null);
+  // The one exception to the idle timer: a pointer resting on the control bar
+  // itself keeps it up, so the user can read and aim at a button without the
+  // target fading out from under them.
+  const hoveringControlsRef = useRef(false);
 
   useEffect(() => {
-    const resetTimer = () => {
-      setIdle(false);
+    const armIdleTimer = () => {
       clearTimeout(idleTimerRef.current);
-      idleTimerRef.current = setTimeout(() => setIdle(true), 3000);
+      if (hoveringControlsRef.current) return;
+      idleTimerRef.current = setTimeout(() => setIdle(true), CONTROLS_IDLE_MS);
     };
 
-    resetTimer();
-    window.addEventListener("mousemove", resetTimer);
-    window.addEventListener("mousedown", resetTimer);
+    const wake = () => {
+      setIdle(false);
+      armIdleTimer();
+    };
+
+    const handleControlsEnter = () => {
+      hoveringControlsRef.current = true;
+      clearTimeout(idleTimerRef.current);
+      setIdle(false);
+    };
+
+    const handleControlsLeave = () => {
+      hoveringControlsRef.current = false;
+      armIdleTimer();
+    };
+
+    wake();
+    // Pointer events so pen and touch wake the controls too.
+    window.addEventListener("pointermove", wake);
+    window.addEventListener("pointerdown", wake);
+    // Native (not synthetic) enter/leave: the bar must stay up while the
+    // pointer rests on it, and React's synthetic enter/leave would not fire
+    // once the bar is pointer-events-none mid-fade.
+    const controls = containerRef.current;
+    controls?.addEventListener("pointerenter", handleControlsEnter);
+    controls?.addEventListener("pointerleave", handleControlsLeave);
 
     return () => {
       clearTimeout(idleTimerRef.current);
-      window.removeEventListener("mousemove", resetTimer);
-      window.removeEventListener("mousedown", resetTimer);
+      window.removeEventListener("pointermove", wake);
+      window.removeEventListener("pointerdown", wake);
+      controls?.removeEventListener("pointerenter", handleControlsEnter);
+      controls?.removeEventListener("pointerleave", handleControlsLeave);
     };
   }, []);
 
@@ -127,37 +157,20 @@ export function FullscreenControls({
     };
   }, []);
 
+  // Hide the OS cursor along with the controls so it does not linger as a
+  // bright dot on a projected audience screen.
   useEffect(() => {
-    if (!onHeightChange) {
-      return;
-    }
-
-    const measure = () => {
-      const height = Math.ceil(
-        containerRef.current?.getBoundingClientRect().height ?? 0,
-      );
-      if (height > 0) {
-        onHeightChange(height);
-      }
-    };
-
-    measure();
-
-    if (typeof ResizeObserver !== "undefined" && containerRef.current) {
-      const observer = new ResizeObserver(measure);
-      observer.observe(containerRef.current);
-      return () => observer.disconnect();
-    }
-
-    window.addEventListener("resize", measure);
+    const previousCursor = document.body.style.cursor;
+    document.body.style.cursor = idle ? "none" : "";
     return () => {
-      window.removeEventListener("resize", measure);
+      document.body.style.cursor = previousCursor;
     };
-  }, [onHeightChange]);
+  }, [idle]);
 
   return (
     <div
       ref={containerRef}
+      data-idle={idle ? "true" : "false"}
       className={`absolute inset-x-0 bottom-0 z-50 bg-gradient-to-t from-black/80 to-transparent px-8 pb-6 pt-16 transition-opacity duration-300 ${
         idle ? "pointer-events-none opacity-0" : "opacity-100"
       }`}

--- a/src/components/Player/FullscreenPlayerView.test.tsx
+++ b/src/components/Player/FullscreenPlayerView.test.tsx
@@ -15,35 +15,16 @@ const {
 }));
 
 vi.mock("@/components/Playback/PlaybackStage", () => ({
-  PlaybackStage: ({
-    presentation,
-    bottomInsetPx,
-  }: {
-    presentation?: string;
-    bottomInsetPx?: number;
-  }) => (
-    <div
-      data-testid="playback-stage"
-      data-presentation={presentation}
-      data-bottom-inset={bottomInsetPx}
-    >
+  PlaybackStage: ({ presentation }: { presentation?: string }) => (
+    <div data-testid="playback-stage" data-presentation={presentation}>
       Stage
     </div>
   ),
 }));
 
 vi.mock("./FullscreenControls", () => ({
-  FullscreenControls: ({
-    onHeightChange,
-  }: {
-    onHeightChange?: (height: number) => void;
-  }) => (
-    <div
-      data-testid="fullscreen-controls"
-      data-has-height-change={String(typeof onHeightChange === "function")}
-    >
-      Controls
-    </div>
+  FullscreenControls: () => (
+    <div data-testid="fullscreen-controls">Controls</div>
   ),
 }));
 
@@ -72,7 +53,7 @@ describe("FullscreenPlayerView", () => {
     mockUseLocalAudienceRomanizeReceiver.mockImplementation(() => {});
   });
 
-  test("passes audience presentation and a persistent bottom inset to the stage", () => {
+  test("gives the audience stage the full window with no reserved controls band", () => {
     const markup = renderToStaticMarkup(<FullscreenPlayerView />);
 
     expect(markup).toContain(
@@ -80,9 +61,10 @@ describe("FullscreenPlayerView", () => {
     );
     expect(markup).toContain("flex flex-1 overflow-hidden");
     expect(markup).toContain('data-presentation="audience"');
-    expect(markup).toContain('data-bottom-inset="144"');
-    expect(markup).toContain('data-has-height-change="true"');
     expect(markup).toContain("playback-stage");
+    expect(markup).toContain("fullscreen-controls");
+    // No bottom inset is reserved for the auto-hiding controls.
+    expect(markup).not.toContain("data-bottom-inset");
   });
 
   test("announces when the local audience window opens and closes", async () => {

--- a/src/components/Player/FullscreenPlayerView.tsx
+++ b/src/components/Player/FullscreenPlayerView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useEffect } from "react";
 import { PlaybackStage } from "@/components/Playback/PlaybackStage";
 import { useCdgFrameReceiver } from "@/hooks/use-cdg-frame-receiver";
 import { useLocalAudienceRomanizeReceiver } from "@/hooks/use-local-audience-romanize-receiver";
@@ -9,15 +9,7 @@ import {
 import { announceLocalAudienceOutputActive } from "@/lib/plain-text-page-controls";
 import { FullscreenControls } from "./FullscreenControls";
 
-const FULLSCREEN_STAGE_BOTTOM_INSET_PX = 144;
-
 export function FullscreenPlayerView() {
-  // Keep a conservative default so the first paint never renders beneath the
-  // floating footer before the client measures its actual height.
-  const [bottomInsetPx, setBottomInsetPx] = useState(
-    FULLSCREEN_STAGE_BOTTOM_INSET_PX,
-  );
-
   useFullscreenPlaybackRuntime();
   useLyricsAutoFetch();
   useCdgFrameReceiver();
@@ -39,22 +31,16 @@ export function FullscreenPlayerView() {
     };
   }, []);
 
-  const handleControlsHeightChange = useCallback((height: number) => {
-    const nextHeight = Math.max(
-      FULLSCREEN_STAGE_BOTTOM_INSET_PX,
-      Math.ceil(height),
-    );
-    setBottomInsetPx((current) =>
-      current === nextHeight ? current : nextHeight,
-    );
-  }, []);
-
+  // RATIONALE: the stage spans the full window height. Reserving a permanent
+  // band for the auto-hiding controls left a dead black strip along the
+  // bottom of the audience screen even while the controls were hidden; the
+  // controls float above the lyrics with their own scrim instead.
   return (
     <div className="relative flex h-screen w-screen flex-col bg-black">
       <div className="flex flex-1 overflow-hidden">
-        <PlaybackStage presentation="audience" bottomInsetPx={bottomInsetPx} />
+        <PlaybackStage presentation="audience" />
       </div>
-      <FullscreenControls onHeightChange={handleControlsHeightChange} />
+      <FullscreenControls />
     </div>
   );
 }

--- a/src/lib/fullscreen-player.test.ts
+++ b/src/lib/fullscreen-player.test.ts
@@ -34,14 +34,18 @@ vi.mock("@tauri-apps/api/window", () => ({
   availableMonitors: mockAvailableMonitors,
 }));
 
+// Monitor geometry mirrors availableMonitors(): PHYSICAL pixels plus the
+// scale factor the implementation must divide by to obtain logical pixels.
 const monitors = [
   {
     position: { x: 0, y: 0 },
     size: { width: 1920, height: 1080 },
+    scaleFactor: 1,
   },
   {
     position: { x: 1920, y: 0 },
-    size: { width: 2560, height: 1440 },
+    size: { width: 5120, height: 2880 },
+    scaleFactor: 2,
   },
 ];
 
@@ -125,21 +129,25 @@ describe("openFullscreenPlayer", () => {
     expect(mockCloseByLabel).toHaveBeenCalledOnce();
   });
 
-  test("creates window on secondary monitor by default when multiple monitors exist", async () => {
+  test("creates a fullscreen window on the secondary monitor in logical pixels", async () => {
     mockGetByLabel.mockResolvedValue(null);
     mockAvailableMonitors.mockResolvedValue(monitors);
 
     await openFullscreenPlayer();
 
+    // The 5120x2880 @ 2x monitor at physical x=1920 must be addressed with
+    // logical (÷ scaleFactor) coordinates or the window misses the monitor.
     expect(mockWebviewWindowConstructor).toHaveBeenCalledWith(
       "fullscreen-player",
       expect.objectContaining({
         url: "index.html?mode=fullscreen-player",
         title: "OpenKara Player",
-        x: 1920,
+        x: 960,
         y: 0,
         width: 2560,
         height: 1440,
+        decorations: false,
+        fullscreen: true,
       }),
     );
   });
@@ -170,10 +178,11 @@ describe("openFullscreenPlayer", () => {
     expect(mockWebviewWindowConstructor).toHaveBeenCalledWith(
       "fullscreen-player",
       expect.objectContaining({
-        x: 1920,
+        x: 960,
         y: 0,
         width: 2560,
         height: 1440,
+        fullscreen: true,
       }),
     );
   });

--- a/src/lib/fullscreen-player.ts
+++ b/src/lib/fullscreen-player.ts
@@ -17,15 +17,31 @@ export async function openFullscreenPlayer(monitorIndex?: number) {
 
   const monitors = await availableMonitors();
   // Default to secondary monitor if available, else primary
-  const target = monitors[monitorIndex ?? (monitors.length > 1 ? 1 : 0)];
+  const target =
+    monitors[monitorIndex ?? (monitors.length > 1 ? 1 : 0)] ?? monitors[0];
+  if (!target) {
+    return;
+  }
+
+  // Monitor geometry is reported in PHYSICAL pixels while window-creation
+  // options are interpreted as LOGICAL pixels, so divide by the monitor's
+  // scale factor — otherwise the window overshoots the monitor on HiDPI and
+  // mixed-DPI setups and the overflow renders as a black band.
+  const scaleFactor = target.scaleFactor > 0 ? target.scaleFactor : 1;
 
   new WebviewWindow("fullscreen-player", {
     url: "index.html?mode=fullscreen-player",
     title: "OpenKara Player",
-    x: target.position.x,
-    y: target.position.y,
-    width: target.size.width,
-    height: target.size.height,
+    x: target.position.x / scaleFactor,
+    y: target.position.y / scaleFactor,
+    width: target.size.width / scaleFactor,
+    height: target.size.height / scaleFactor,
+    // Borderless + real fullscreen so the webview viewport coincides exactly
+    // with the monitor regardless of scale factor; the black background
+    // covers the interval before the document paints.
+    decorations: false,
+    fullscreen: true,
+    backgroundColor: "#000000",
   });
 }
 


### PR DESCRIPTION
Fixes #234

实测反馈：Select Monitor 进入全屏后，窗口下方有一条很大的黑条压缩了歌词行数；播放条的自动隐藏无法预测（鼠标不移出窗口、或暂停时似乎就不隐藏）。

## 根因

**黑条**（两处）：

1. `openFullscreenPlayer` 把 `availableMonitors()` 的**物理像素**几何直接传给 `WebviewWindow` 的 `x/y/width/height`，而这些选项按**逻辑像素**解释（`@tauri-apps/api` 的 `Monitor` 文档明确要求先按 `scaleFactor` 换算），而且从未请求真正的 fullscreen。HiDPI / 混合 DPI 下窗口与显示器对不上，`bg-black` 的窗口底色露出来。
2. `FullscreenPlayerView` 给会自动隐藏的播放条**常驻预留** 144px（`bottomInsetPx` → `PlaybackStage` 的 `paddingBottom`），控件隐藏时那条留白依然是死区。

**自动隐藏**：`FullscreenControls` 本来就是「指针静止 3 秒淡出」，代码里既无暂停判断也无「鼠标在窗口内」判断（grep 过整个 Player/Playback）——用户感知的不隐藏来自操作时指针持续移动不断重置计时器。真正的缺陷是指针**停在控件上**时也会在 3 秒后淡出，按钮从指针底下消失。

## 改动

- 按 `scaleFactor` 换算几何 + `decorations:false, fullscreen:true, backgroundColor:#000000`，让 viewport 在任意缩放比下与显示器精确重合。
- 移除常驻底部预留（连带删掉 `PlaybackStage` 已无人使用的 `bottomInsetPx` 与 `FullscreenControls` 的高度上报链路）。
- 观众端歌词列表首尾各加半屏留白，任何一行（含首行/末行）都能居中；纯文本分页模式不加留白，页面仍精确铺满。
- 保留 3 秒指针静止淡出（与播放/暂停无关），新增：指针停在控件上保持可见、改用 pointer 事件（笔/触摸也能唤醒）、隐藏时一并隐藏鼠标指针。

## 测试

- `src/lib/fullscreen-player.test.ts`：monitor fixture 补上 `scaleFactor`（2x 的 5120×2880 @ 物理 x=1920），断言窗口按逻辑像素定位（960,0 / 2560×1440）且 `fullscreen:true`。
- `FullscreenControls.test.tsx` 新增三个用例：静止 3 秒后 `data-idle="true"` + `opacity-0` + 鼠标指针隐藏、移动即恢复；指针停在控件上 6 秒仍可见、离开后 3 秒隐藏；**暂停状态**同样会隐藏。
- `PlaybackStage` / `FullscreenPlayerView` 测试改为断言不再预留底部留白。

`pnpm vitest run src/components/Player src/components/Playback src/components/Lyrics src/lib/fullscreen-player.test.ts` 全绿（251）。

⚠️ 未做真机多显示器验证：本机只有内置屏。DPI 换算方向已由单测锁定，建议合并前在外接 1x 显示器 + 内置 2x 屏各试一次。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
