### PR TITLE
fix(shell): stop the launch flash and reveal the window only once it can paint

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Tells the engine to paint a dark default canvas before any CSS loads,
+         so the very first composited frame cannot be white. -->
+    <meta name="color-scheme" content="dark light" />
     <title>OpenKara</title>
     <style>
       html,

--- a/src-tauri/src/macos/window_shell.m
+++ b/src-tauri/src/macos/window_shell.m
@@ -178,7 +178,15 @@ bool ok_window_shell_configure_main_window(
         // default capability or that affordance becomes a dead button.
         window.movableByWindowBackground = NO;
 
-        window.backgroundColor = [NSColor windowBackgroundColor];
+        // RATIONALE: windowBackgroundColor is near-white under the Light system
+        // appearance, so it painted a white frame behind the WKWebView before
+        // the document's own dark background composited — the white flash seen
+        // at launch. Pin the native backing to the app shell's dark surface
+        // (#121212) so nothing brighter than the UI can ever be exposed.
+        window.backgroundColor = [NSColor colorWithSRGBRed:(18.0 / 255.0)
+                                                    green:(18.0 / 255.0)
+                                                     blue:(18.0 / 255.0)
+                                                    alpha:1.0];
 
         NSWindowStyleMask styleMask = [window styleMask];
         if ((styleMask & NSWindowStyleMaskFullSizeContentView) == 0) {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,8 @@
         "height": 800,
         "resizable": true,
         "visible": false,
-        "center": true
+        "center": true,
+        "backgroundColor": "#121212"
       }
     ],
     "security": {

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -9,7 +9,10 @@
         "minWidth": 680,
         "height": 800,
         "resizable": true,
-        "decorations": false
+        "decorations": false,
+        "visible": false,
+        "center": true,
+        "backgroundColor": "#121212"
       }
     ]
   }

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -10,7 +10,10 @@
         "height": 800,
         "resizable": true,
         "titleBarStyle": "Overlay",
-        "hiddenTitle": true
+        "hiddenTitle": true,
+        "visible": false,
+        "center": true,
+        "backgroundColor": "#121212"
       }
     ]
   }

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -11,7 +11,10 @@
         "resizable": true,
         "decorations": false,
         "shadow": true,
-        "scrollBarStyle": "fluentOverlay"
+        "scrollBarStyle": "fluentOverlay",
+        "visible": false,
+        "center": true,
+        "backgroundColor": "#121212"
       }
     ]
   }

--- a/src-tauri/tests/window_config_flash_guard.rs
+++ b/src-tauri/tests/window_config_flash_guard.rs
@@ -1,0 +1,81 @@
+//! Guards the launch-flash fix in the Tauri window configuration.
+//!
+//! Tauri merges the platform override files into `tauri.conf.json` with RFC
+//! 7396 JSON Merge Patch, under which an array in the patch REPLACES the base
+//! array wholesale. Because every platform file redefines the whole
+//! `app.windows` array, keys that only exist in the base config (`visible`,
+//! `center`, `backgroundColor`) are silently dropped on that platform — which
+//! is exactly how the window ended up visible during the webview load and
+//! flashed white before the dark UI painted.
+//!
+//! These assertions fail if a window object stops carrying the keys itself.
+
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+
+const CONFIG_FILES: [&str; 4] = [
+    "tauri.conf.json",
+    "tauri.macos.conf.json",
+    "tauri.windows.conf.json",
+    "tauri.linux.conf.json",
+];
+
+fn windows_array(file: &str) -> Vec<Value> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(file);
+    let raw = fs::read_to_string(&path).unwrap_or_else(|error| {
+        panic!("failed to read {}: {error}", path.display());
+    });
+    let config: Value = serde_json::from_str(&raw)
+        .unwrap_or_else(|error| panic!("failed to parse {}: {error}", path.display()));
+
+    config
+        .get("app")
+        .and_then(|app| app.get("windows"))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_else(|| panic!("{} declares no app.windows array", path.display()))
+}
+
+#[test]
+fn every_platform_window_starts_hidden_so_the_webview_load_is_never_shown() {
+    for file in CONFIG_FILES {
+        for window in windows_array(file) {
+            assert_eq!(
+                window.get("visible"),
+                Some(&Value::Bool(false)),
+                "{file}: window must set visible:false itself; the platform merge \
+                 replaces the whole windows array, so inheriting it from the base \
+                 config does not work"
+            );
+        }
+    }
+}
+
+#[test]
+fn every_platform_window_paints_a_dark_background_before_the_document_loads() {
+    for file in CONFIG_FILES {
+        for window in windows_array(file) {
+            assert_eq!(
+                window.get("backgroundColor"),
+                Some(&Value::String("#121212".to_owned())),
+                "{file}: window must pin a dark backgroundColor so the webview's \
+                 default white surface can never be exposed"
+            );
+        }
+    }
+}
+
+#[test]
+fn every_platform_window_keeps_the_centered_placement() {
+    for file in CONFIG_FILES {
+        for window in windows_array(file) {
+            assert_eq!(
+                window.get("center"),
+                Some(&Value::Bool(true)),
+                "{file}: window must set center:true itself for the same \
+                 array-replacement reason as visible:false"
+            );
+        }
+    }
+}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -38,9 +38,14 @@ describe("App", () => {
     expect(markup).not.toContain('data-testid="full-app-layout"');
   });
 
-  test("renders nothing while the library path probe is still pending", () => {
+  test("renders the dark shell skeleton while the library path probe is still pending", () => {
     const markup = renderToStaticMarkup(<App initialLibraryReady={null} />);
 
-    expect(markup).toBe("");
+    // Rendering nothing here made launch jump from a blank surface straight to
+    // the populated layout; the skeleton gives the reveal a frame to start on.
+    expect(markup).toContain('data-testid="app-shell-skeleton"');
+    expect(markup).toContain("bg-[var(--color-surface)]");
+    expect(markup).not.toContain('data-testid="full-app-layout"');
+    expect(markup).not.toContain('data-testid="library-setup"');
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 import { AppLayout } from "@/components/Layout/AppLayout";
+import { AppShellSkeleton } from "@/components/Layout/AppShellSkeleton";
 import { LibrarySetup } from "@/components/Settings/LibrarySetup";
 import {
   useAppReadyRuntime,
@@ -42,7 +43,7 @@ function App({ initialLibraryReady = null, previewMode = false }: AppProps) {
   }, []);
 
   if (libraryReady === null) {
-    return null;
+    return <AppShellSkeleton />;
   }
 
   if (!libraryReady) {

--- a/src/components/Layout/AppShellSkeleton.tsx
+++ b/src/components/Layout/AppShellSkeleton.tsx
@@ -1,0 +1,33 @@
+/**
+ * Structural stand-in for the app shell, shown while the first-run library
+ * check is still in flight.
+ *
+ * RATIONALE: rendering nothing meant the launch sequence went straight from an
+ * empty surface to a fully populated layout. A dark outline of the sidebar,
+ * toolbar, and playback bar lets the window reveal progressively — frame
+ * first, content second — instead of appearing as a blank panel.
+ */
+export function AppShellSkeleton() {
+  return (
+    <div
+      data-testid="app-shell-skeleton"
+      aria-hidden="true"
+      className="flex h-screen w-full bg-[var(--color-surface)]"
+    >
+      <div className="hidden w-[240px] shrink-0 flex-col gap-3 border-r border-[var(--color-border)] bg-[var(--color-sidebar)] p-4 sm:flex">
+        <div className="h-7 w-2/3 rounded-md bg-[var(--color-border)]/50" />
+        <div className="mt-2 space-y-2">
+          <div className="h-4 w-1/2 rounded bg-[var(--color-border)]/40" />
+          <div className="h-4 w-3/4 rounded bg-[var(--color-border)]/30" />
+          <div className="h-4 w-2/3 rounded bg-[var(--color-border)]/30" />
+        </div>
+      </div>
+
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="h-14 shrink-0 border-b border-[var(--color-border)]" />
+        <div className="flex-1" />
+        <div className="h-[84px] shrink-0 border-t border-[var(--color-border)] bg-[var(--color-sidebar)]" />
+      </div>
+    </div>
+  );
+}

--- a/src/runtime/app-ready-runtime.test.tsx
+++ b/src/runtime/app-ready-runtime.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const { mockWindowReady } = vi.hoisted(() => ({
+  mockWindowReady: vi.fn(),
+}));
+
+vi.mock("@/lib/tauri", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/tauri")>()),
+  windowReady: mockWindowReady,
+}));
+
+import { useAppReadyRuntime } from "./app-runtime";
+
+function Harness({
+  scheduleFrame,
+  windowShown,
+  setWindowShown,
+}: {
+  scheduleFrame: (callback: FrameRequestCallback) => number;
+  windowShown: boolean;
+  setWindowShown: (shown: boolean) => void;
+}) {
+  useAppReadyRuntime(
+    true,
+    true,
+    true,
+    windowShown,
+    setWindowShown,
+    scheduleFrame,
+  );
+  return null;
+}
+
+describe("useAppReadyRuntime", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockWindowReady.mockReset();
+    mockWindowReady.mockResolvedValue(undefined);
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  test("reveals the window even when animation frames never run", () => {
+    // REGRESSION: the main window starts hidden, and macOS suspends animation
+    // frames for a hidden WebView — so a reveal scheduled only through
+    // requestAnimationFrame left the app running with no window at all.
+    const setWindowShown = vi.fn();
+    const neverFiringScheduleFrame = vi.fn(() => 1);
+
+    act(() => {
+      root.render(
+        <Harness
+          scheduleFrame={neverFiringScheduleFrame}
+          windowShown={false}
+          setWindowShown={setWindowShown}
+        />,
+      );
+    });
+
+    expect(neverFiringScheduleFrame).toHaveBeenCalled();
+    expect(mockWindowReady).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(120);
+    });
+
+    expect(mockWindowReady).toHaveBeenCalledTimes(1);
+    expect(setWindowShown).toHaveBeenCalledWith(true);
+  });
+
+  test("requests the reveal once when the frame fires first", () => {
+    const setWindowShown = vi.fn();
+    const immediateScheduleFrame = vi.fn((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+
+    act(() => {
+      root.render(
+        <Harness
+          scheduleFrame={immediateScheduleFrame}
+          windowShown={false}
+          setWindowShown={setWindowShown}
+        />,
+      );
+    });
+
+    expect(mockWindowReady).toHaveBeenCalledTimes(1);
+
+    // The fallback timer must not fire a second request.
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(mockWindowReady).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not ask again once the window is shown", () => {
+    const setWindowShown = vi.fn();
+
+    act(() => {
+      root.render(
+        <Harness
+          scheduleFrame={vi.fn(() => 1)}
+          windowShown
+          setWindowShown={setWindowShown}
+        />,
+      );
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(mockWindowReady).not.toHaveBeenCalled();
+  });
+});

--- a/src/runtime/app-runtime.ts
+++ b/src/runtime/app-runtime.ts
@@ -85,6 +85,15 @@ export function useAppStartupRuntime(
   }, [libraryReady, loadBootstrapStatus, loadLibrary, loadPlayerState]);
 }
 
+/**
+ * Backstop for the reveal request. The main window starts hidden, and a hidden
+ * (occluded) WebView has its animation frames suspended — so the rAF callback
+ * that asks the backend to show the window would never run, leaving the app
+ * running with no window at all. The timer guarantees the request goes out;
+ * rAF still wins whenever frames are actually being produced.
+ */
+const WINDOW_REVEAL_FALLBACK_MS = 120;
+
 export function useAppReadyRuntime(
   libraryReady: boolean | null,
   settingsHydrated: boolean,
@@ -103,13 +112,22 @@ export function useAppReadyRuntime(
       return;
     }
 
-    const frameId = scheduleFrame(() => {
+    let requested = false;
+    const requestReveal = () => {
+      if (requested) {
+        return;
+      }
+      requested = true;
       void api.windowReady();
       setWindowShown(true);
-    });
+    };
+
+    const frameId = scheduleFrame(requestReveal);
+    const timeoutId = setTimeout(requestReveal, WINDOW_REVEAL_FALLBACK_MS);
 
     return () => {
       cancelAnimationFrame(frameId);
+      clearTimeout(timeoutId);
     };
   }, [
     libraryReady,


### PR DESCRIPTION
Fixes #239

实测反馈：启动先黑屏 → 闪白屏 → 再闪黑屏 → 才出现主界面。希望渐进加载，不要闪。

## 根因

「窗口先隐藏、首帧就绪后再显示」的保护**一直是失效的**：`visible:false` 只写在 base 的 `tauri.conf.json`，而三个平台配置各自**重定义了整个 `app.windows` 数组**。Tauri 用 RFC 7396 JSON Merge Patch 合并平台配置（`tauri-utils/src/config/parse.rs` → `json_patch::merge`），**数组在该语义下整体替换**、不按元素合并，所以每个桌面平台上 `visible` 回落到默认 `true`（`center` 一起丢）。窗口在整个 webview 加载期间可见，`window_ready` → `window.show()` 成了空操作。

白帧来源：没有任何窗口配置 `backgroundColor`/`windowEffects`/`transparent`，WebView 在文档背景绘制前显示默认**不透明白底**；macOS 上 `window_shell.m` 还把 NSWindow 底色设为 `[NSColor windowBackgroundColor]`（Light 外观接近白）。

## 改动

- 四个窗口配置**各自**携带 `visible:false` / `center:true` / `backgroundColor:#121212`（因为数组会被整体替换，写在 base 无效）。
- macOS NSWindow 底色钉成 `#121212`，Light 外观下也不会露白。
- `index.html` 加 `<meta name="color-scheme" content="dark light">`，让引擎在 CSS 加载前就用深色画布。
- 库探测未完成时渲染深色骨架（侧栏/工具栏/播放条轮廓）而不是 `return null`。
- 新增 `src-tauri/tests/window_config_flash_guard.rs`：断言**每个**平台窗口都带上述三个键，防止数组替换陷阱再次悄悄吃掉它们。

## 顺带修掉一个被暴露出来的潜在缺陷

让窗口真正隐藏之后，实测**窗口根本不出现**——app 在跑，但没有任何窗口。原因是 reveal 请求排在 `requestAnimationFrame` 里，而 macOS 对隐藏（被遮挡）的 WebView 会**暂停动画帧**，回调永远不执行。以前窗口一直可见，所以这条路从未被真正走过。

改为在 rAF 之外并行一个短定时器兜底（帧正常产出时仍由 rAF 先触发，请求幂等）。实测日志确认：

```
[debug] window_ready for main visible_before=Ok(false) …
[debug] show -> Ok(()) visible_after=Ok(true) minimized=Ok(false)
```

（调试打印已移除。）随后截图确认窗口出现即为深色完整界面。

## 测试

- `src-tauri/tests/window_config_flash_guard.rs` 3 个断言全绿。
- 新增 `src/runtime/app-ready-runtime.test.tsx`：注入一个**永不触发**的 `scheduleFrame`，断言定时器兜底仍会发出 reveal；帧先触发时不会重复请求；窗口已显示后不再请求。
- `src/App.test.tsx` 改为断言渲染骨架而非空。

`pnpm vitest run src/App.test.tsx src/runtime` 全绿（85）；typecheck / oxlint / oxfmt / cargo fmt 干净。

⚠️ 仅在 macOS 实测。Windows / Linux 上「隐藏窗口是否也暂停 rAF」未验证，但定时器兜底对两者同样生效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
