### PR TITLE
feat(audio): readable equalizer with named bands, dB scale, and presets

### DIFF
--- a/src/components/Settings/SettingsEqSection.test.tsx
+++ b/src/components/Settings/SettingsEqSection.test.tsx
@@ -30,6 +30,21 @@ vi.mock("react-i18next", async (importOriginal) => {
           "settings.eq.band910": "910 Hz",
           "settings.eq.band3600": "3.6 kHz",
           "settings.eq.band14000": "14 kHz",
+          "settings.eq.bandNameBass": "Bass",
+          "settings.eq.bandNameLowMid": "Low mid",
+          "settings.eq.bandNameMid": "Mid",
+          "settings.eq.bandNameHighMid": "High mid",
+          "settings.eq.bandNameTreble": "Treble",
+          "settings.eq.presetLabel": "Preset",
+          "settings.eq.presetCustom": "Custom",
+          "settings.eq.presetFlat": "Flat",
+          "settings.eq.presetVocalBoost": "Vocal Boost",
+          "settings.eq.presetBassBoost": "Bass Boost",
+          "settings.eq.presetTrebleBoost": "Treble Boost",
+          "settings.eq.presetWarm": "Warm",
+          "settings.eq.presetBright": "Bright",
+          "settings.eq.presetRock": "Rock",
+          "settings.eq.presetPop": "Pop",
           "settings.eq.reset": "Reset to flat",
         };
         return map[key] ?? key;
@@ -67,6 +82,127 @@ describe("SettingsEqSection", () => {
     expect(markup).toContain("Reset to flat");
     const sliderCount = (markup.match(/type="range"/g) ?? []).length;
     expect(sliderCount).toBe(5);
+  });
+
+  test("renders friendly band names alongside the Hz captions", () => {
+    const value = createSettingsOverlayTestContextValue({
+      state: {
+        eqEnabled: true,
+        eqGainsDb: [0, 0, 0, 0, 0],
+      },
+    });
+
+    const markup = renderToStaticMarkup(
+      <SettingsOverlayContext value={value}>
+        <SettingsEqSection />
+      </SettingsOverlayContext>,
+    );
+
+    expect(markup).toContain("Bass");
+    expect(markup).toContain("Low mid");
+    expect(markup).toContain("Mid");
+    expect(markup).toContain("High mid");
+    expect(markup).toContain("Treble");
+    // Hz captions remain as the secondary label.
+    expect(markup).toContain("60 Hz");
+    // dB scale ruler anchors the -12..+12 range.
+    expect(markup).toContain("-12 dB");
+    expect(markup).toContain("+12 dB");
+  });
+
+  test("renders preset chips and highlights the matching preset", () => {
+    const value = createSettingsOverlayTestContextValue({
+      state: {
+        eqEnabled: true,
+        // Matches the Bass Boost preset exactly.
+        eqGainsDb: [6, 3, 0, 0, 1],
+      },
+    });
+
+    render(
+      <SettingsOverlayContext value={value}>
+        <SettingsEqSection />
+      </SettingsOverlayContext>,
+    );
+
+    const bassBoost = screen.getByRole("button", { name: "Bass Boost" });
+    expect(bassBoost.getAttribute("aria-pressed")).toBe("true");
+    const flat = screen.getByRole("button", { name: "Flat" });
+    expect(flat.getAttribute("aria-pressed")).toBe("false");
+    // A matching preset means no "Custom" indicator.
+    expect(screen.queryByText("Custom")).toBeNull();
+  });
+
+  test("shows the Custom indicator when gains match no preset", () => {
+    const value = createSettingsOverlayTestContextValue({
+      state: {
+        eqEnabled: true,
+        eqGainsDb: [1.5, -4, 7, 0, 2],
+      },
+    });
+
+    render(
+      <SettingsOverlayContext value={value}>
+        <SettingsEqSection />
+      </SettingsOverlayContext>,
+    );
+
+    expect(screen.getByText("Custom")).not.toBeNull();
+  });
+
+  test("clicking a preset commits its gains through setEqGains", () => {
+    const setEqGains = vi.fn().mockResolvedValue(undefined);
+    const value = createSettingsOverlayTestContextValue(
+      {
+        state: { eqEnabled: true, eqGainsDb: [0, 0, 0, 0, 0] },
+        meta: { isInitializing: false },
+      },
+      { setEqGains },
+    );
+
+    render(
+      <SettingsOverlayContext value={value}>
+        <SettingsEqSection />
+      </SettingsOverlayContext>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Vocal Boost" }));
+
+    expect(setEqGains).toHaveBeenCalledTimes(1);
+    expect(setEqGains).toHaveBeenCalledWith([-1, -1, 2, 4, 1]);
+  });
+
+  test("clicking a preset cancels a pending debounced band commit", () => {
+    vi.useFakeTimers();
+    const setEqGains = vi.fn().mockResolvedValue(undefined);
+    const value = createSettingsOverlayTestContextValue(
+      {
+        state: { eqEnabled: true, eqGainsDb: [0, 0, 0, 0, 0] },
+        meta: { isInitializing: false },
+      },
+      { setEqGains },
+    );
+
+    const { container } = render(
+      <SettingsOverlayContext value={value}>
+        <SettingsEqSection />
+      </SettingsOverlayContext>,
+    );
+
+    const sliders = container.querySelectorAll('input[type="range"]');
+    fireEvent.change(sliders[0], { target: { value: "5" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Flat" }));
+
+    act(() => {
+      vi.advanceTimersByTime(75);
+    });
+
+    // Only the preset commit fires; the in-flight band drag must not clobber
+    // it 75 ms later.
+    expect(setEqGains).toHaveBeenCalledTimes(1);
+    expect(setEqGains).toHaveBeenCalledWith([0, 0, 0, 0, 0]);
+    vi.useRealTimers();
   });
 
   test("shows gain values in dB with sign", () => {
@@ -318,7 +454,7 @@ describe("SettingsEqSection", () => {
       </SettingsOverlayContext>,
     );
 
-    const resetButton = screen.getByRole("button");
+    const resetButton = screen.getByRole("button", { name: "Reset to flat" });
     fireEvent.click(resetButton);
 
     expect(resetEqGains).toHaveBeenCalled();

--- a/src/components/Settings/SettingsEqSection.tsx
+++ b/src/components/Settings/SettingsEqSection.tsx
@@ -11,6 +11,17 @@ const EQ_BAND_KEYS = [
   "settings.eq.band14000",
 ] as const;
 
+// Friendly names shown as the primary band label; the raw center frequency
+// (EQ_BAND_KEYS) stays visible as a secondary caption. Index-aligned with the
+// backend EQ_BAND_FREQUENCIES_HZ = [60, 230, 910, 3600, 14000].
+const EQ_BAND_NAME_KEYS = [
+  "settings.eq.bandNameBass",
+  "settings.eq.bandNameLowMid",
+  "settings.eq.bandNameMid",
+  "settings.eq.bandNameHighMid",
+  "settings.eq.bandNameTreble",
+] as const;
+
 /// Trailing debounce window for slider → IPC commits. Local draft updates
 /// immediately so the slider feels responsive; the complete five-value array
 /// is sent once after this quiet period (or immediately on pointer/key
@@ -18,6 +29,40 @@ const EQ_BAND_KEYS = [
 const EQ_DEBOUNCE_MS = 75;
 
 type EqGains = [number, number, number, number, number];
+
+// Named starting points, ordered [60, 230, 910, 3600, 14000] Hz. Every value
+// must stay within ±12 dB (validate_gains_db rejects the commit otherwise).
+// A preset is nothing more than a gain array pushed through setEqGains.
+const EQ_PRESETS = [
+  { key: "settings.eq.presetFlat", gains: [0, 0, 0, 0, 0] },
+  { key: "settings.eq.presetVocalBoost", gains: [-1, -1, 2, 4, 1] },
+  { key: "settings.eq.presetBassBoost", gains: [6, 3, 0, 0, 1] },
+  { key: "settings.eq.presetTrebleBoost", gains: [0, 0, 0, 3, 6] },
+  { key: "settings.eq.presetWarm", gains: [3, 2, 0, -1, -2] },
+  { key: "settings.eq.presetBright", gains: [-2, -1, 0, 2, 4] },
+  { key: "settings.eq.presetRock", gains: [4, 2, -1, 2, 4] },
+  { key: "settings.eq.presetPop", gains: [2, 1, 2, 3, 2] },
+] as const satisfies ReadonlyArray<{
+  key: string;
+  gains: readonly [number, number, number, number, number];
+}>;
+
+// Sliders move on a 0.5 dB grid, so half a step cleanly separates "matches
+// the preset" from "user nudged a band".
+const EQ_PRESET_MATCH_EPSILON = 0.25;
+
+function matchEqPreset(gains: EqGains): string | null {
+  for (const preset of EQ_PRESETS) {
+    if (
+      preset.gains.every(
+        (gain, band) => Math.abs(gain - gains[band]) < EQ_PRESET_MATCH_EPSILON,
+      )
+    ) {
+      return preset.key;
+    }
+  }
+  return null;
+}
 
 export function SettingsEqSection() {
   const { t } = useTranslation();
@@ -92,6 +137,26 @@ export function SettingsEqSection() {
     });
   };
 
+  // Highlight the preset the current draft matches; null renders as
+  // "Custom". Matching against the draft (not the committed store state)
+  // keeps the chips honest the moment a band slider moves.
+  const activePresetKey = matchEqPreset(draft);
+
+  /// Apply a named preset through the existing commit path. The pending
+  /// debounced band commit is cancelled first so an in-flight slider drag
+  /// cannot fire 75 ms later and clobber the preset.
+  const applyPreset = (
+    gains: readonly [number, number, number, number, number],
+  ) => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    pendingRef.current = null;
+    setDraft([...gains] as EqGains);
+    void actions.setEqGains([...gains] as EqGains);
+  };
+
   return (
     <SettingsSectionCard title={t("settings.eq.label")}>
       <div className="space-y-4">
@@ -120,11 +185,47 @@ export function SettingsEqSection() {
             state.eqEnabled ? "" : "opacity-50"
           }`}
         >
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between">
+              <span className="text-[12px] font-medium text-[var(--color-text-dim)]">
+                {t("settings.eq.presetLabel")}
+              </span>
+              {activePresetKey === null ? (
+                <span className="text-[11px] text-[var(--color-text-dim)]">
+                  {t("settings.eq.presetCustom")}
+                </span>
+              ) : null}
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {EQ_PRESETS.map((preset) => (
+                <button
+                  key={preset.key}
+                  type="button"
+                  onClick={() => applyPreset(preset.gains)}
+                  disabled={meta.isInitializing || !state.eqEnabled}
+                  aria-pressed={activePresetKey === preset.key}
+                  className={`rounded-full border px-2.5 py-1 text-[11px] transition-colors disabled:opacity-50 ${
+                    activePresetKey === preset.key
+                      ? "border-[var(--color-control-selected-border)] bg-[var(--color-control-selected-bg)] text-[var(--color-text)]"
+                      : "border-[var(--color-border-light)] bg-[var(--color-surface)] text-[var(--color-text-dim)] hover:text-[var(--color-text)]"
+                  }`}
+                >
+                  {t(preset.key)}
+                </button>
+              ))}
+            </div>
+          </div>
+
           {draft.map((gain, band) => (
             <div key={band} className="space-y-1">
               <div className="flex items-center justify-between">
-                <label className="text-[12px] font-medium text-[var(--color-text-dim)]">
-                  {t(EQ_BAND_KEYS[band])}
+                <label className="flex items-baseline gap-2 text-[12px]">
+                  <span className="font-medium text-[var(--color-text)]">
+                    {t(EQ_BAND_NAME_KEYS[band])}
+                  </span>
+                  <span className="text-[10px] text-[var(--color-text-dim)]">
+                    {t(EQ_BAND_KEYS[band])}
+                  </span>
                 </label>
                 <span className="text-[11px] tabular-nums text-[var(--color-text-dim)]">
                   {gain > 0 ? "+" : ""}
@@ -147,6 +248,15 @@ export function SettingsEqSection() {
               />
             </div>
           ))}
+
+          <div
+            aria-hidden="true"
+            className="flex items-center justify-between text-[10px] tabular-nums text-[var(--color-text-dim)]"
+          >
+            <span>-12 dB</span>
+            <span>0</span>
+            <span>+12 dB</span>
+          </div>
 
           <button
             type="button"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -424,7 +424,22 @@
       "band230": "230 Hz",
       "band910": "910 Hz",
       "band3600": "3.6 kHz",
-      "band14000": "14 kHz"
+      "band14000": "14 kHz",
+      "bandNameBass": "Bass",
+      "bandNameLowMid": "Low mid",
+      "bandNameMid": "Mid",
+      "bandNameHighMid": "High mid",
+      "bandNameTreble": "Treble",
+      "presetLabel": "Preset",
+      "presetCustom": "Custom",
+      "presetFlat": "Flat",
+      "presetVocalBoost": "Vocal Boost",
+      "presetBassBoost": "Bass Boost",
+      "presetTrebleBoost": "Treble Boost",
+      "presetWarm": "Warm",
+      "presetBright": "Bright",
+      "presetRock": "Rock",
+      "presetPop": "Pop"
     },
     "crossfade": {
       "label": "Crossfade",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -424,7 +424,22 @@
       "band230": "230 Hz",
       "band910": "910 Hz",
       "band3600": "3.6 kHz",
-      "band14000": "14 kHz"
+      "band14000": "14 kHz",
+      "bandNameBass": "低音",
+      "bandNameLowMid": "中低音",
+      "bandNameMid": "中音",
+      "bandNameHighMid": "中高音",
+      "bandNameTreble": "高音",
+      "presetLabel": "预设",
+      "presetCustom": "自定义",
+      "presetFlat": "平直",
+      "presetVocalBoost": "人声增强",
+      "presetBassBoost": "低音增强",
+      "presetTrebleBoost": "高音增强",
+      "presetWarm": "温暖",
+      "presetBright": "明亮",
+      "presetRock": "摇滚",
+      "presetPop": "流行"
     },
     "crossfade": {
       "label": "淡入淡出",


### PR DESCRIPTION
Fixes #237

实测反馈：设置里的 EQ 各档只标 `60 Hz / 230 Hz / 910 Hz / 3.6 kHz / 14 kHz`，普通用户根本看不懂怎么调。

## 现状

每档的唯一标签就是原始中心频率；滑块 `-12..+12 dB, step 0.5` 但**没有任何刻度**，0 dB 中心不可见；全仓库没有预设（`grep preset` 只命中无关的 CD+G 图形指令）。

## 改动（纯表现层）

- **友好档位名作主标签**，Hz 降为小字副标：低音 / 中低音 / 中音 / 中高音 / 高音（按索引对齐后端 `EQ_BAND_FREQUENCIES_HZ = [60,230,910,3600,14000]`）。
- **dB 刻度**：滑块组下方标 `-12 dB / 0 / +12 dB`，范围与中心一目了然。
- **预设条**：Flat / 人声增强 / 低音增强 / 高音增强 / 温暖 / 明亮 / 摇滚 / 流行，点击走既有的 `actions.setEqGains`；当前值匹配某预设时高亮，手动改动任一档后显示「自定义」（0.5 dB 网格上用 0.25 的 epsilon 判定）。

增益契约完全没变（5 元 dB 数组，后端 `validate_gains_db` 校验），每个预设值都在 ±12 dB 内。点预设时会先取消待提交的防抖值，避免拖动中途切预设后被 75ms 后的旧值覆盖。

## 测试

`SettingsEqSection.test.tsx` 新增：友好名 + Hz 副标 + dB 刻度都渲染；匹配预设时对应 chip `aria-pressed=true` 且不显示「自定义」；不匹配时显示「自定义」；点预设以正确数组调用 `setEqGains`；拖动中点预设只提交预设值（防抖旧值不会再打回来）。

`pnpm vitest run src/components/Settings/SettingsEqSection.test.tsx src/locales` 全绿（21）；`node scripts/check-i18n.mjs` 通过（en/zh-CN 键一致）。

注：与 #240 / #242 等 PR 会同时改 `src/locales/*.json` 的不同段落，合并顺序上可能需要一次 trivial rebase。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
