### PR TITLE
fix(library): name the destination on the remote-repository connect button

### DIFF
--- a/src/components/Settings/RemoteLibraryWizard.test.tsx
+++ b/src/components/Settings/RemoteLibraryWizard.test.tsx
@@ -101,9 +101,28 @@ describe("RemoteLibraryWizard", () => {
     );
 
     expect(markup).toContain("settings.library.openRemoteLibrary");
+    expect(markup).toContain("settings.library.connectRemoteGoogleDrive");
     expect(markup).toContain("settings.library.displayName");
     expect(markup).not.toContain("Open Remote Library");
     expect(markup).not.toContain("Display name");
+  });
+
+  test("labels the primary action per provider instead of a generic open label", () => {
+    const value = createSettingsOverlayTestContextValue();
+
+    const dropboxMarkup = renderToStaticMarkup(
+      <SettingsOverlayContext value={value}>
+        <RemoteLibraryWizard onClose={() => {}} initialProvider="dropbox" />
+      </SettingsOverlayContext>,
+    );
+    expect(dropboxMarkup).toContain("settings.library.connectRemoteDropbox");
+
+    const webdavMarkup = renderToStaticMarkup(
+      <SettingsOverlayContext value={value}>
+        <RemoteLibraryWizard onClose={() => {}} initialProvider="webdav" />
+      </SettingsOverlayContext>,
+    );
+    expect(webdavMarkup).toContain("settings.library.connectRemoteWebdav");
   });
 
   test("renders reauthorization copy and preselects the requested provider", () => {
@@ -341,7 +360,9 @@ describe("RemoteLibraryWizard", () => {
 
     const openRemoteButtons = [...container.querySelectorAll("button")].filter(
       (button) =>
-        button.textContent?.includes("settings.library.openRemoteLibrary"),
+        button.textContent?.includes(
+          "settings.library.connectRemoteGoogleDrive",
+        ),
     );
     const connectButton = openRemoteButtons[openRemoteButtons.length - 1];
     expect(connectButton).toBeTruthy();
@@ -389,7 +410,7 @@ describe("RemoteLibraryWizard", () => {
     const buttons = [...container.querySelectorAll("button")];
     const closeButton = buttons[0];
     const openRemoteButtons = buttons.filter((button) =>
-      button.textContent?.includes("settings.library.openRemoteLibrary"),
+      button.textContent?.includes("settings.library.connectRemoteGoogleDrive"),
     );
     const connectButton = openRemoteButtons[openRemoteButtons.length - 1];
     expect(closeButton).toBeTruthy();
@@ -447,7 +468,7 @@ describe("RemoteLibraryWizard", () => {
     const buttons = [...container.querySelectorAll("button")];
     const closeButton = buttons[0];
     const openRemoteButtons = buttons.filter((button) =>
-      button.textContent?.includes("settings.library.openRemoteLibrary"),
+      button.textContent?.includes("settings.library.connectRemoteGoogleDrive"),
     );
     const connectButton = openRemoteButtons[openRemoteButtons.length - 1];
 
@@ -497,7 +518,9 @@ describe("RemoteLibraryWizard", () => {
 
     const openRemoteButtons = [...container.querySelectorAll("button")].filter(
       (button) =>
-        button.textContent?.includes("settings.library.openRemoteLibrary"),
+        button.textContent?.includes(
+          "settings.library.connectRemoteGoogleDrive",
+        ),
     );
     const connectButton = openRemoteButtons[openRemoteButtons.length - 1];
 
@@ -550,7 +573,9 @@ describe("RemoteLibraryWizard", () => {
 
     const openRemoteButtons = [...container.querySelectorAll("button")].filter(
       (button) =>
-        button.textContent?.includes("settings.library.openRemoteLibrary"),
+        button.textContent?.includes(
+          "settings.library.connectRemoteGoogleDrive",
+        ),
     );
     const connectButton = openRemoteButtons[openRemoteButtons.length - 1];
 
@@ -595,7 +620,9 @@ describe("RemoteLibraryWizard", () => {
 
     const openRemoteButtons = [...container.querySelectorAll("button")].filter(
       (button) =>
-        button.textContent?.includes("settings.library.openRemoteLibrary"),
+        button.textContent?.includes(
+          "settings.library.connectRemoteGoogleDrive",
+        ),
     );
     const connectButton = openRemoteButtons[openRemoteButtons.length - 1];
 

--- a/src/components/Settings/RemoteLibraryWizard.tsx
+++ b/src/components/Settings/RemoteLibraryWizard.tsx
@@ -10,6 +10,7 @@ import {
   runRemoteLibraryRegistrationFlow,
 } from "./remote-library-flow";
 import {
+  getRemoteProviderConnectLabel,
   getRemoteProviderDisplayName,
   getRemoteProviderLabel,
 } from "./remote-library-copy";
@@ -243,9 +244,6 @@ export function RemoteLibraryWizard({
   const descriptionKey = isReauthorizeFlow
     ? "settings.library.reauthorizeRemoteRepositoryDescription"
     : "settings.library.addRemoteLibraryDescription";
-  const connectKey = isReauthorizeFlow
-    ? "settings.library.reauthorizeRemoteRepository"
-    : "settings.library.openRemoteLibrary";
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
@@ -464,11 +462,11 @@ export function RemoteLibraryWizard({
                 ? t("settings.library.createRemoteLibraryAndStartMirror", {
                     defaultValue: "Create Remote Repository And Start Mirror",
                   })
-                : t(connectKey, {
-                    defaultValue: isReauthorizeFlow
-                      ? "Reauthorize remote repository"
-                      : "Open Remote Repository",
-                  })}
+                : isReauthorizeFlow
+                  ? t("settings.library.reauthorizeRemoteRepository", {
+                      defaultValue: "Reauthorize remote repository",
+                    })
+                  : getRemoteProviderConnectLabel(t, provider)}
           </button>
 
           {authorizationUrl && (

--- a/src/components/Settings/remote-library-copy.ts
+++ b/src/components/Settings/remote-library-copy.ts
@@ -28,6 +28,26 @@ export function getRemoteProviderLabel(
         });
 }
 
+// Primary action label for the add/open remote-repository flow. The label
+// names the destination so the button says where it is connecting to, rather
+// than the provider-agnostic "Open Remote Repository".
+export function getRemoteProviderConnectLabel(
+  t: TFunction,
+  provider: RemoteLibraryProvider,
+): string {
+  return provider === "google_drive"
+    ? t("settings.library.connectRemoteGoogleDrive", {
+        defaultValue: "Connect to Google Drive",
+      })
+    : provider === "dropbox"
+      ? t("settings.library.connectRemoteDropbox", {
+          defaultValue: "Connect to Dropbox",
+        })
+      : t("settings.library.connectRemoteWebdav", {
+          defaultValue: "Connect",
+        });
+}
+
 export function getRemoteProviderBrowserSignInOpenedMessage(
   t: TFunction,
   provider: RemoteLibraryProvider,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -331,7 +331,10 @@
       "remoteLibraryConnected": "Remote repository connected.",
       "remoteLibraryCreatedAndMirroring": "Remote repository created and now mirroring {{displayName}}.",
       "createRemoteLibraryAndStartMirror": "Create Remote Repository And Start Mirror",
-      "existingRemoteLibraries": "Existing Remote Repositories"
+      "existingRemoteLibraries": "Existing Remote Repositories",
+      "connectRemoteGoogleDrive": "Connect to Google Drive",
+      "connectRemoteDropbox": "Connect to Dropbox",
+      "connectRemoteWebdav": "Connect"
     },
     "stemMode": {
       "label": "Stem Separation Mode",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -331,7 +331,10 @@
       "remoteLibraryConnected": "远程资料库已连接。",
       "remoteLibraryCreatedAndMirroring": "远程资料库已创建，并正在镜像 {{displayName}}。",
       "createRemoteLibraryAndStartMirror": "创建远程资料库并开始镜像",
-      "existingRemoteLibraries": "已有远程资料库"
+      "existingRemoteLibraries": "已有远程资料库",
+      "connectRemoteGoogleDrive": "连接到 Google Drive",
+      "connectRemoteDropbox": "连接到 Dropbox",
+      "connectRemoteWebdav": "连接"
     },
     "stemMode": {
       "label": "音轨分离模式",


### PR DESCRIPTION
Fixes #238

实测反馈：Add Remote Repository 面板最显眼的连接按钮恒为 “Open Remote Repository”，文字应当取决于所选输入（WebDAV → Connect，Dropbox → Connect to Dropbox，Google Drive → Connect to Google Drive）。

## 根因

`RemoteLibraryWizard` 的主按钮标签只由 `mode`（open / mirror）与 `isReauthorizeFlow` 决定，**从不参与 `provider`**：默认 add + open_remote 路径恒解析 `settings.library.openRemoteLibrary`。

## 改动

- `remote-library-copy.ts` 新增 `getRemoteProviderConnectLabel(t, provider)`（放在这里是因为 i18n 完整性测试会扫描该文件里的静态 `t("literal")`）。
- 主按钮改为按 provider 取文案；`mirror_active_local`（创建远程库并开始镜像）与重新授权两个分支文案保持原样。
- 不复用 `settings.library.openRemoteLibrary`——它同时是「Open Remote Repository」**模式卡片**的标题，改它会连带改掉模式选择器。

## 测试

`RemoteLibraryWizard.test.tsx` 新增：默认（Google Drive）渲染 `connectRemoteGoogleDrive`；`initialProvider="dropbox"` / `"webdav"` 分别渲染各自的键。原有 6 个按钮定位断言同步更新到新键。

`pnpm vitest run src/components/Settings/RemoteLibraryWizard.test.tsx src/locales` 全绿（16）；`node scripts/check-i18n.mjs` 通过。

注：与 #243 等 PR 同时改 `src/locales/*.json` 的不同段落，合并时可能需要一次 trivial rebase。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
