### PR TITLE
fix(runtime): make the ONNX Runtime install succeed and report one truth

### DIFF
--- a/src-tauri/src/separator/artifacts.rs
+++ b/src-tauri/src/separator/artifacts.rs
@@ -435,8 +435,16 @@ fn collect_zip_members(archive_path: &Path) -> Result<ArchiveMembers> {
 }
 
 /// Verify every extracted file against the catalog's declared digests. All
-/// declared files must exist with matching size and SHA-256; extra files
-/// are rejected so an artifact directory only ever contains declared content.
+/// declared files must exist with matching size and SHA-256.
+///
+/// RATIONALE: undeclared extra members are tolerated. The archive's own
+/// SHA-256 (`archive_digest`) is verified against the catalog before a single
+/// byte is extracted, so every member — declared or not — is exactly what the
+/// publisher signed; rejecting extras added no integrity guarantee and instead
+/// bricked installs whenever the build pipeline shipped a new metadata file
+/// (`build-manifest.json`, which the generator omits from its own file list).
+/// The declared-file checks below stay strict, and the returned records still
+/// cover only declared files.
 pub fn verify_extracted_files(
     dest_dir: &Path,
     declared: &BTreeMap<String, CatalogFileDigest>,
@@ -446,12 +454,6 @@ pub fn verify_extracted_files(
         .iter()
         .map(|path| path.to_string_lossy().replace('\\', "/"))
         .collect();
-
-    for path in &extracted_set {
-        if !declared.contains_key(path) {
-            bail!("archive contains undeclared file {path}");
-        }
-    }
 
     let mut records = Vec::new();
     for (path, digest) in declared {
@@ -612,7 +614,7 @@ mod tests {
     }
 
     #[test]
-    fn verify_extracted_rejects_undeclared_and_missing_files() {
+    fn verify_extracted_tolerates_undeclared_but_rejects_missing_files() {
         let dir = tempfile::tempdir().expect("tempdir");
         fs::write(dir.path().join("lib.dylib"), b"lib").expect("write");
 
@@ -625,14 +627,22 @@ mod tests {
             },
         );
 
-        // Undeclared extra file.
-        let error = verify_extracted_files(
+        // Undeclared extra members ride along with the archive-level digest
+        // (real ORT archives ship build-manifest.json, which the catalog
+        // generator omits). They must not fail an otherwise valid install,
+        // and they must not appear in the installed-file records.
+        fs::write(dir.path().join("build-manifest.json"), b"{}").expect("write");
+        let records = verify_extracted_files(
             dir.path(),
             &declared,
-            &[PathBuf::from("lib.dylib"), PathBuf::from("extra.txt")],
+            &[
+                PathBuf::from("lib.dylib"),
+                PathBuf::from("build-manifest.json"),
+            ],
         )
-        .expect_err("undeclared file must be rejected");
-        assert!(error.to_string().contains("undeclared"));
+        .expect("undeclared extras must be tolerated");
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].path, "lib.dylib");
 
         // Declared file missing from extraction.
         declared.insert(

--- a/src/components/Settings/LibrarySetup.render.test.tsx
+++ b/src/components/Settings/LibrarySetup.render.test.tsx
@@ -7,6 +7,8 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 const mockOpen = vi.hoisted(() => vi.fn());
 const mockCreateLocalLibrary = vi.hoisted(() => vi.fn());
 const mockRunRemoteLibraryRegistrationFlow = vi.hoisted(() => vi.fn());
+const mockSetStemMode = vi.hoisted(() => vi.fn());
+const mockSetModelVariant = vi.hoisted(() => vi.fn());
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -23,7 +25,8 @@ vi.mock("@/lib/tauri", () => ({
   setLanguage: vi.fn().mockResolvedValue(undefined),
   createLocalLibrary: mockCreateLocalLibrary,
   registerLocalLibrary: vi.fn(),
-  setStemMode: vi.fn(),
+  setStemMode: mockSetStemMode,
+  setModelVariant: mockSetModelVariant,
   cancelRemoteAuth: vi.fn(),
 }));
 
@@ -33,6 +36,7 @@ vi.mock("@/stores/settings-store", () => ({
       selector({
         language: "en",
         stemMode: "four_stem",
+        modelVariant: "htdemucs",
         patchAppSettings: vi.fn(),
         hydrateAppSettings: vi.fn(),
       }),
@@ -40,6 +44,7 @@ vi.mock("@/stores/settings-store", () => ({
       getState: () => ({
         language: "en",
         stemMode: "four_stem",
+        modelVariant: "htdemucs",
         patchAppSettings: vi.fn(),
         hydrateAppSettings: vi.fn(),
       }),
@@ -74,6 +79,10 @@ describe("LibrarySetup destructive error surfaces", () => {
     mockOpen.mockReset();
     mockCreateLocalLibrary.mockReset();
     mockRunRemoteLibraryRegistrationFlow.mockReset();
+    mockSetStemMode.mockReset();
+    mockSetStemMode.mockResolvedValue(undefined);
+    mockSetModelVariant.mockReset();
+    mockSetModelVariant.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -153,6 +162,48 @@ describe("LibrarySetup destructive error surfaces", () => {
 
     expect(container.innerHTML).toContain("auth failed");
     expect(container.innerHTML).toContain("text-[var(--color-destructive)]");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  test("persists the model chosen during first run so the first separation downloads it", async () => {
+    const onComplete = vi.fn();
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<LibrarySetup onComplete={onComplete} />);
+    });
+
+    const clickButtonContaining = async (text: string) => {
+      const button = Array.from(container.querySelectorAll("button")).find(
+        (candidate) => candidate.textContent?.includes(text),
+      );
+      expect(button, `no button containing ${text}`).toBeTruthy();
+      await act(async () => {
+        button?.click();
+      });
+    };
+
+    await clickButtonContaining("English");
+
+    mockOpen.mockResolvedValue("/tmp/karaoke");
+    mockCreateLocalLibrary.mockResolvedValue(undefined);
+    await clickButtonContaining("Create new local library");
+
+    // Stem mode → model step.
+    await clickButtonContaining("setup.continue");
+    expect(container.innerHTML).toContain("setup.chooseModel");
+    expect(container.innerHTML).toContain("settings.modelVariant.htdemucs");
+    expect(container.innerHTML).toContain("settings.modelVariant.htdemucsFt");
+
+    await clickButtonContaining("settings.modelVariant.htdemucsFt");
+    await clickButtonContaining("setup.getStarted");
+
+    expect(mockSetStemMode).toHaveBeenCalledWith("four_stem");
+    expect(mockSetModelVariant).toHaveBeenCalledWith("htdemucs_ft");
+    expect(onComplete).toHaveBeenCalled();
 
     await act(async () => {
       root.unmount();

--- a/src/components/Settings/LibrarySetup.tsx
+++ b/src/components/Settings/LibrarySetup.tsx
@@ -12,19 +12,25 @@ import {
   Mic2,
   ChevronLeft,
   Check,
+  Sparkles,
 } from "lucide-react";
 import { getErrorMessage } from "@/lib/errors";
 import * as api from "@/lib/tauri";
 import i18next, { SUPPORTED_LANGUAGES, detectSystemLanguage } from "@/lib/i18n";
 import { useSettingsStore } from "@/stores/settings-store";
-import type { RemoteLibraryProvider } from "@/types/ipc";
+import type { ModelVariant, RemoteLibraryProvider } from "@/types/ipc";
 import { runRemoteLibraryRegistrationFlow } from "./remote-library-flow";
 import {
   getRemoteLibraryConnectedMessage,
   getRemoteProviderDisplayName,
 } from "./remote-library-copy";
 
-type Step = "language" | "library" | "remoteProvider" | "stemMode";
+type Step =
+  | "language"
+  | "library"
+  | "remoteProvider"
+  | "stemMode"
+  | "modelVariant";
 type LibraryChoiceKind = "create_local" | "open_local" | "open_remote";
 
 interface RemoteProviderChoice {
@@ -94,7 +100,13 @@ interface LibrarySetupProps {
 }
 
 function StepIndicator({ current }: { current: Step }) {
-  const steps: Step[] = ["language", "library", "remoteProvider", "stemMode"];
+  const steps: Step[] = [
+    "language",
+    "library",
+    "remoteProvider",
+    "stemMode",
+    "modelVariant",
+  ];
   const currentIndex = steps.indexOf(current);
 
   return (
@@ -117,6 +129,7 @@ export function LibrarySetup({ onComplete }: LibrarySetupProps) {
   const { t } = useTranslation();
   const settingsLanguage = useSettingsStore((s) => s.language);
   const settingsStemMode = useSettingsStore((s) => s.stemMode);
+  const settingsModelVariant = useSettingsStore((s) => s.modelVariant);
   const patchAppSettings = useSettingsStore((s) => s.patchAppSettings);
   const hydrateAppSettings = useSettingsStore((s) => s.hydrateAppSettings);
   const [step, setStep] = useState<Step>("language");
@@ -141,6 +154,8 @@ export function LibrarySetup({ onComplete }: LibrarySetupProps) {
   const [selectedStemModeDraft, setSelectedStemModeDraft] = useState<
     "two_stem" | "four_stem" | null
   >(null);
+  const [selectedModelVariantDraft, setSelectedModelVariantDraft] =
+    useState<ModelVariant | null>(null);
   const remoteAuthSessionIdRef = useRef<string | null>(null);
   const selectedLanguage =
     selectedLanguageDraft ??
@@ -148,6 +163,8 @@ export function LibrarySetup({ onComplete }: LibrarySetupProps) {
     i18next.resolvedLanguage ??
     detectSystemLanguage();
   const selectedStemMode = selectedStemModeDraft ?? settingsStemMode;
+  const selectedModelVariant =
+    selectedModelVariantDraft ?? settingsModelVariant;
 
   const resolveSingleDirectory = (selected: string | string[] | null) =>
     typeof selected === "string" ? selected : (selected?.[0] ?? null);
@@ -282,7 +299,10 @@ export function LibrarySetup({ onComplete }: LibrarySetupProps) {
 
   const handleFinish = async () => {
     try {
-      const settings = await api.setStemMode(selectedStemMode);
+      await api.setStemMode(selectedStemMode);
+      // The chosen variant is what the first separation auto-downloads, so it
+      // must be persisted before the user reaches the library.
+      const settings = await api.setModelVariant(selectedModelVariant);
       hydrateAppSettings(settings);
     } catch {
       // non-fatal
@@ -838,6 +858,94 @@ export function LibrarySetup({ onComplete }: LibrarySetupProps) {
             </div>
 
             <button
+              onClick={() => setStep("modelVariant")}
+              className="w-full rounded-lg bg-[var(--color-control-primary)] px-5 py-3 text-[14px] font-medium text-[var(--color-control-primary-foreground)] transition-opacity hover:opacity-90"
+            >
+              {t("setup.continue")}
+            </button>
+
+            <button
+              onClick={() => setStep("library")}
+              className="flex items-center justify-center gap-1 text-[13px] text-[var(--color-text-dim)] transition-colors hover:text-[var(--color-text)]"
+            >
+              <ChevronLeft size={14} />
+              {t("setup.back")}
+            </button>
+          </>
+        )}
+
+        {step === "modelVariant" && (
+          <>
+            <div className="flex flex-col items-center gap-4">
+              <div className="flex items-center justify-center">
+                <Sparkles
+                  size={32}
+                  className="text-[var(--color-control-primary)]"
+                />
+              </div>
+              <h1 className="text-2xl font-bold text-[var(--color-text)]">
+                {t("setup.chooseModel")}
+              </h1>
+              <p className="text-[14px] leading-relaxed text-[var(--color-text-dim)]">
+                {t("setup.modelDescription")}
+              </p>
+            </div>
+
+            <div className="space-y-3">
+              {(
+                [
+                  {
+                    variant: "htdemucs",
+                    title: t("settings.modelVariant.htdemucs"),
+                    subtitle: t("settings.modelVariant.htdemucsDescription"),
+                  },
+                  {
+                    variant: "htdemucs_ft",
+                    title: t("settings.modelVariant.htdemucsFt"),
+                    subtitle: t("settings.modelVariant.htdemucsFtDescription"),
+                  },
+                ] satisfies ReadonlyArray<{
+                  variant: ModelVariant;
+                  title: string;
+                  subtitle: string;
+                }>
+              ).map((option) => (
+                <button
+                  key={option.variant}
+                  onClick={() => setSelectedModelVariantDraft(option.variant)}
+                  className={`flex w-full items-center gap-3 rounded-lg border px-5 py-4 text-left transition-colors ${
+                    selectedModelVariant === option.variant
+                      ? "border-[var(--color-control-selected-border)] bg-[var(--color-control-selected-bg)]"
+                      : "border-[var(--color-border-light)] bg-[var(--color-sidebar)] hover:bg-[var(--color-hover)]"
+                  }`}
+                >
+                  <Sparkles
+                    size={20}
+                    className="shrink-0 text-[var(--color-control-primary)]"
+                  />
+                  <div className="flex-1">
+                    <div className="text-[14px] font-medium text-[var(--color-text)]">
+                      {option.title}
+                    </div>
+                    <div className="text-[12px] text-[var(--color-text-dim)]">
+                      {option.subtitle}
+                    </div>
+                  </div>
+                  {selectedModelVariant === option.variant && (
+                    <Check
+                      size={16}
+                      className="shrink-0 text-[var(--color-control-primary)]"
+                    />
+                  )}
+                </button>
+              ))}
+            </div>
+
+            <p className="text-[12px] text-[var(--color-text-dimmer)]">
+              {t("setup.modelDownloadHint")}
+            </p>
+
+            <button
               onClick={handleFinish}
               className="w-full rounded-lg bg-[var(--color-control-primary)] px-5 py-3 text-[14px] font-medium text-[var(--color-control-primary-foreground)] transition-opacity hover:opacity-90"
             >
@@ -845,7 +953,7 @@ export function LibrarySetup({ onComplete }: LibrarySetupProps) {
             </button>
 
             <button
-              onClick={() => setStep("library")}
+              onClick={() => setStep("stemMode")}
               className="flex items-center justify-center gap-1 text-[13px] text-[var(--color-text-dim)] transition-colors hover:text-[var(--color-text)]"
             >
               <ChevronLeft size={14} />

--- a/src/components/Settings/SettingsModelVariantSection.test.tsx
+++ b/src/components/Settings/SettingsModelVariantSection.test.tsx
@@ -62,7 +62,7 @@ describe("SettingsModelVariantSection", () => {
     expect(html).toContain("model-v2.1.0");
   });
 
-  test("shows a distinct message and retry button for a corrupt runtime", () => {
+  test("explains why model downloads are unavailable without owning the runtime install", () => {
     const html = render({
       runtimeStatus: {
         ...readyRuntime,
@@ -72,27 +72,42 @@ describe("SettingsModelVariantSection", () => {
     });
 
     expect(html).toContain("settings.runtime.corrupt");
-    expect(html).toContain("settings.runtime.retryButton");
-    expect(html).toContain("checksum mismatch on libonnxruntime");
-    expect(html).not.toContain("settings.runtime.installRequired");
+    // Installing/repairing the runtime belongs to the ONNX Runtime card.
+    expect(html).not.toContain("settings.runtime.retryButton");
+    expect(html).not.toContain("settings.runtime.installButton");
   });
 
-  test("shows a distinct message for a failed runtime download", () => {
-    const html = render({
-      runtimeStatus: { ...readyRuntime, state: "failed", error: null },
-    });
-
-    expect(html).toContain("settings.runtime.downloadFailed");
-    expect(html).toContain("settings.runtime.retryButton");
-  });
-
-  test("keeps the generic install message for a missing runtime", () => {
+  test("keeps the variant picker and model-update button visible while the runtime is missing", () => {
     const html = render({
       runtimeStatus: { ...readyRuntime, state: "missing" },
     });
 
-    expect(html).toContain("settings.runtime.installRequired");
-    expect(html).toContain("settings.runtime.installButton");
+    // The old behavior replaced this whole card with a runtime install CTA,
+    // which is why there was no way to check for model updates.
+    expect(html).toContain("settings.modelVariant.htdemucs");
+    expect(html).toContain("settings.modelVariant.htdemucsFt");
+    expect(html).toContain("settings.modelUpdate.checkButton");
+    expect(html).toContain("settings.modelVariant.runtimeRequired");
+    expect(html).not.toContain("settings.runtime.installButton");
+  });
+
+  test("surfaces runtime download progress while it is being provisioned", () => {
+    const html = render({
+      runtimeStatus: { ...readyRuntime, state: "downloading" },
+    });
+
+    expect(html).toContain("settings.runtime.downloading");
+    expect(html).toContain("settings.modelUpdate.checkButton");
+  });
+
+  test("disables the variant buttons until the runtime can load models", () => {
+    const html = render({
+      runtimeStatus: { ...readyRuntime, state: "missing" },
+    });
+
+    const disabledVariantButtons = (html.match(/<button disabled=""/g) ?? [])
+      .length;
+    expect(disabledVariantButtons).toBeGreaterThanOrEqual(2);
   });
 
   test("renders the update check button when the runtime is ready", () => {

--- a/src/components/Settings/SettingsModelVariantSection.tsx
+++ b/src/components/Settings/SettingsModelVariantSection.tsx
@@ -84,62 +84,23 @@ export function SettingsModelVariantSection() {
     return t("settings.modelVariant.notDownloaded");
   };
 
-  // B3: Model download controls are disabled when runtime is missing.
+  // Model *downloads* need a loaded runtime; choosing which variant to use
+  // does not. The runtime is provisioned automatically before the first
+  // separation, and its manual install/repair CTA lives in the ONNX Runtime
+  // card — so this card no longer hides itself (and the model-update button
+  // with it) whenever the runtime is not ready yet.
   const controlsDisabled =
     meta.isInitializing || state.downloadingModel !== null || !runtimeReady;
 
-  // B3: Show runtime install CTA when runtime is missing. Corrupt installs
-  // and failed downloads get their own message so the user is never stuck
-  // in an unexplained install loop.
-  if (!runtimeReady && state.runtimeStatus?.state !== "downloading") {
-    const runtimeMessage =
-      runtimeState === "corrupt"
+  const runtimeNotice = runtimeReady
+    ? null
+    : runtimeState === "downloading"
+      ? t("settings.runtime.downloading")
+      : runtimeState === "corrupt"
         ? t("settings.runtime.corrupt")
         : runtimeState === "failed"
           ? t("settings.runtime.downloadFailed")
-          : t("settings.runtime.installRequired");
-    const runtimeButtonLabel =
-      runtimeState === "corrupt" || runtimeState === "failed"
-        ? t("settings.runtime.retryButton")
-        : t("settings.runtime.installButton");
-
-    return (
-      <SettingsSectionCard
-        title={t("settings.modelVariant.label")}
-        description={t("settings.modelVariant.description")}
-      >
-        <div className="flex flex-col gap-2">
-          <p className="text-[12px] text-[var(--color-text-dim)]">
-            {runtimeMessage}
-          </p>
-          {state.runtimeStatus?.error ? (
-            <p className="text-[11px] text-[var(--color-danger,#e5484d)] opacity-90">
-              {state.runtimeStatus.error}
-            </p>
-          ) : null}
-          <button
-            onClick={() => void actions.downloadRuntime()}
-            className="self-start rounded-md bg-[var(--color-control-primary)] px-3 py-1.5 text-[12px] text-[var(--color-control-primary-foreground)] transition-colors hover:bg-[color-mix(in_srgb,var(--color-control-primary)_88%,white)]"
-          >
-            {runtimeButtonLabel}
-          </button>
-        </div>
-      </SettingsSectionCard>
-    );
-  }
-
-  if (state.runtimeStatus?.state === "downloading") {
-    return (
-      <SettingsSectionCard
-        title={t("settings.modelVariant.label")}
-        description={t("settings.modelVariant.description")}
-      >
-        <p className="text-[12px] text-[var(--color-text-dim)]">
-          {t("settings.runtime.downloading")}
-        </p>
-      </SettingsSectionCard>
-    );
-  }
+          : t("settings.modelVariant.runtimeRequired");
 
   const update = state.modelUpdate;
   const updatableModels =
@@ -152,6 +113,12 @@ export function SettingsModelVariantSection() {
       title={t("settings.modelVariant.label")}
       description={t("settings.modelVariant.description")}
     >
+      {runtimeNotice ? (
+        <p className="mb-2 text-[12px] text-[var(--color-text-dim)]">
+          {runtimeNotice}
+        </p>
+      ) : null}
+
       <div className="flex gap-2">
         <ModelVariantOption
           selected={state.modelVariant === "htdemucs"}

--- a/src/components/Settings/SettingsOverlay.state.test.ts
+++ b/src/components/Settings/SettingsOverlay.state.test.ts
@@ -644,6 +644,61 @@ describe("createSettingsOverlayActions - runtime updates", () => {
     expect(runtimeStatus?.state).toBe("candidate_ready_restart_required");
     expect(runtimeStatus?.candidate_version).toBe("v1.28.0");
     expect(runtimeStatus?.restart_required).toBe(true);
+    expect(harness.getSnapshot().state.runtimeUpdate).toBeNull();
+  });
+
+  test("downloadRuntime discards the stale check report after installing", async () => {
+    const harness = createHarness();
+
+    vi.mocked(harness.dependencies.api.checkRuntimeUpdates).mockResolvedValue({
+      generation: 9,
+      release_id: "2026-08-01-001",
+      target_triple: "aarch64-apple-darwin",
+      state: "not_installed",
+      installed_version: null,
+      available_version: "v1.27.1",
+      available_bytes: 42_000_000,
+      restart_required: false,
+    });
+    vi.mocked(
+      harness.dependencies.api.getRuntimeBootstrapStatus,
+    ).mockResolvedValue({
+      state: "missing",
+      version: "v1.27.1",
+      runtime_path: "",
+      downloaded_bytes: null,
+      total_bytes: null,
+      active_artifact_id: null,
+      target_triple: "aarch64-apple-darwin",
+      candidate_version: null,
+      restart_required: false,
+      error: null,
+    });
+
+    await harness.actions.checkRuntimeUpdates();
+    expect(harness.getSnapshot().state.runtimeUpdate?.report?.state).toBe(
+      "not_installed",
+    );
+
+    vi.mocked(harness.dependencies.api.downloadRuntime).mockResolvedValue({
+      state: "ready",
+      version: "v1.27.1",
+      runtime_path: "/tmp/runtime",
+      downloaded_bytes: null,
+      total_bytes: null,
+      active_artifact_id: "rt-1.27.1",
+      target_triple: "aarch64-apple-darwin",
+      candidate_version: null,
+      restart_required: false,
+      error: null,
+    });
+
+    await harness.actions.downloadRuntime();
+
+    // A "not installed" report next to a "ready" status line is a
+    // contradiction the user cannot resolve, so the install clears it.
+    expect(harness.getSnapshot().state.runtimeStatus?.state).toBe("ready");
+    expect(harness.getSnapshot().state.runtimeUpdate).toBeNull();
   });
 
   test("setUpdatePolicy routes through the settings store and mirrors the result", async () => {

--- a/src/components/Settings/SettingsOverlay.state.ts
+++ b/src/components/Settings/SettingsOverlay.state.ts
@@ -226,6 +226,10 @@ export function createSettingsOverlayActions(
           restart_required: status.restart_required,
           error: status.error?.message ?? null,
         },
+        // The install just changed what is on disk, so any earlier check
+        // report is stale — keeping it would let the card claim the runtime is
+        // "not installed" right next to a "ready" status line.
+        runtimeUpdate: null,
       });
       // Refresh model statuses too since model actions may now be enabled.
       await refreshModelStatuses();
@@ -240,10 +244,10 @@ export function createSettingsOverlayActions(
   // `candidate_ready_restart_required`. We mirror that state and let the
   // restart banner / button drive activation.
   const updateRuntimeAction = async () => {
+    // The staged candidate supersedes the check report; downloadRuntimeAction
+    // already clears it so a later manual check stays honest instead of
+    // re-offering the staged update.
     await downloadRuntimeAction();
-    // The staged candidate supersedes the check report; clearing it keeps a
-    // later manual check honest instead of re-offering the staged update.
-    patchState({ runtimeUpdate: null });
   };
 
   const checkRuntimeUpdatesAction = async () => {

--- a/src/components/Settings/SettingsRuntimeSection.test.tsx
+++ b/src/components/Settings/SettingsRuntimeSection.test.tsx
@@ -159,4 +159,66 @@ describe("SettingsRuntimeSection", () => {
 
     expect(html).toContain("settings.runtime.downloadingCandidate");
   });
+
+  test("owns the install CTA when the runtime is missing", () => {
+    const html = render({
+      runtimeStatus: { ...readyRuntime, state: "missing" },
+    });
+
+    expect(html).toContain("settings.runtime.statusMissing");
+    expect(html).toContain("settings.runtime.installRequired");
+    expect(html).toContain("settings.runtime.installButton");
+    expect(html).toContain('data-testid="runtime-install-button"');
+  });
+
+  test("offers a repair CTA with the error text for a corrupt runtime", () => {
+    const html = render({
+      runtimeStatus: {
+        ...readyRuntime,
+        state: "corrupt",
+        error: "checksum mismatch on libonnxruntime",
+      },
+    });
+
+    expect(html).toContain("settings.runtime.corrupt");
+    expect(html).toContain("settings.runtime.retryButton");
+    expect(html).toContain("checksum mismatch on libonnxruntime");
+    expect(html).not.toContain("settings.runtime.installRequired");
+  });
+
+  test("offers a retry CTA after a failed runtime download", () => {
+    const html = render({
+      runtimeStatus: { ...readyRuntime, state: "failed", error: null },
+    });
+
+    expect(html).toContain("settings.runtime.downloadFailed");
+    expect(html).toContain("settings.runtime.retryButton");
+  });
+
+  test("never claims the runtime is up to date when the check says it is not installed", () => {
+    const update: RuntimeUpdateView = {
+      status: "checked",
+      error: null,
+      report: {
+        generation: 4,
+        release_id: "2026-08-01-001",
+        target_triple: "aarch64-apple-darwin",
+        state: "not_installed",
+        installed_version: null,
+        available_version: "v1.27.1",
+        available_bytes: 42_000_000,
+        restart_required: false,
+      },
+    };
+    const html = render({
+      runtimeStatus: { ...readyRuntime, state: "missing" },
+      runtimeUpdate: update,
+    });
+
+    // The old fall-through printed "The runtime is up to date." for every
+    // non-update verdict, so a failed install looked healthy.
+    expect(html).not.toContain("settings.runtime.upToDate");
+    expect(html).toContain("settings.runtime.statusMissing");
+    expect(html).toContain("settings.runtime.installButton");
+  });
 });

--- a/src/components/Settings/SettingsRuntimeSection.tsx
+++ b/src/components/Settings/SettingsRuntimeSection.tsx
@@ -79,6 +79,24 @@ export function SettingsRuntimeSection() {
       report?.state === "installed_without_identity") &&
     !restartRequired;
   const downloadingCandidate = runtimeState === "downloading_candidate";
+  const isDownloading = runtimeState === "downloading";
+
+  // The runtime normally installs itself the first time a song is separated.
+  // This CTA is the manual escape hatch for the states that cannot recover on
+  // their own, and it lives here — next to the runtime status and version —
+  // rather than inside the AI Model card.
+  const needsInstall =
+    isMissing || runtimeState === "corrupt" || runtimeState === "failed";
+  const installLabel =
+    runtimeState === "corrupt" || runtimeState === "failed"
+      ? t("settings.runtime.retryButton")
+      : t("settings.runtime.installButton");
+  const installHint =
+    runtimeState === "corrupt"
+      ? t("settings.runtime.corrupt")
+      : runtimeState === "failed"
+        ? t("settings.runtime.downloadFailed")
+        : t("settings.runtime.installRequired");
 
   return (
     <SettingsSectionCard
@@ -98,7 +116,28 @@ export function SettingsRuntimeSection() {
             {runtime.error}
           </p>
         ) : null}
+        {needsInstall ? (
+          <p className="text-[11px] text-[var(--color-text-dim)]">
+            {installHint}
+          </p>
+        ) : null}
+        {needsInstall && runtime?.error ? (
+          <p className="text-[11px] text-[var(--color-danger,#e5484d)] opacity-90">
+            {runtime.error}
+          </p>
+        ) : null}
       </div>
+
+      {needsInstall ? (
+        <button
+          onClick={() => void actions.downloadRuntime()}
+          disabled={meta.isInitializing || isDownloading}
+          data-testid="runtime-install-button"
+          className="self-start rounded-md bg-[var(--color-control-primary)] px-3 py-1.5 text-[12px] text-[var(--color-control-primary-foreground)] transition-colors hover:bg-[color-mix(in_srgb,var(--color-control-primary)_88%,white)] disabled:opacity-50"
+        >
+          {isDownloading ? t("settings.runtime.downloading") : installLabel}
+        </button>
+      ) : null}
 
       {restartRequired ? (
         <button
@@ -125,9 +164,17 @@ export function SettingsRuntimeSection() {
               ? t("settings.runtime.checking")
               : t("settings.runtime.checkButton")}
           </button>
-          {update?.status === "checked" && !updateAvailable ? (
+          {/* Only a genuine up_to_date verdict may claim the runtime is
+              current. Reporting "up to date" for not_installed is what made a
+              failed install look like a healthy one. */}
+          {report?.state === "up_to_date" && !updateAvailable ? (
             <span className="text-[11px] text-[var(--color-text-dim)]">
               {t("settings.runtime.upToDate")}
+            </span>
+          ) : null}
+          {report?.state === "not_installed" ? (
+            <span className="text-[11px] text-[var(--color-text-dim)]">
+              {t("settings.runtime.statusMissing")}
             </span>
           ) : null}
         </div>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -54,7 +54,11 @@
     "fourStemSubtitle": "Vocals + Drums + Bass + Other",
     "fourStemDetail": "More control over individual instruments, ~2× disk space",
     "getStarted": "Get Started",
-    "back": "Back"
+    "back": "Back",
+    "continue": "Continue",
+    "chooseModel": "Choose AI Model",
+    "modelDescription": "This model separates vocals from the music. You can change it later in settings.",
+    "modelDownloadHint": "The model and its runtime download automatically the first time you separate a song."
   },
   "sidebar": {
     "library": "LIBRARY",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -54,7 +54,11 @@
     "fourStemSubtitle": "人声 + 鼓 + 贝斯 + 其他",
     "fourStemDetail": "可以独立控制各个乐器，约2倍磁盘占用",
     "getStarted": "开始使用",
-    "back": "返回"
+    "back": "返回",
+    "continue": "继续",
+    "chooseModel": "选择 AI 模型",
+    "modelDescription": "该模型用于将人声从伴奏中分离。之后可在设置中更改。",
+    "modelDownloadHint": "首次分离歌曲时会自动下载模型及其运行时。"
   },
   "sidebar": {
     "library": "曲库",


### PR DESCRIPTION
Fixes #236

实测反馈：安装 ONNX Runtime 报 `archive contains undeclared file build-manifest.json`，但「Check for updates」显示 “The runtime is up to date.”，完全无法判断装上没装上；runtime 安装放在 AI Model 卡片下不合理，也因此看不到「Check for model updates」；期望 runtime 在分离第一首歌时自动下载，且下载哪个模型取自 onboarding 的选择。

## 根因（已实测取证）

**1. 契约不一致，不是解压回归。** 下载线上归档核对：

```
$ shasum -a 256 onnxruntime-1.27.1-openkara-aarch64-apple-darwin-reduced.tar.gz
bf8fea238ff272dcbb11ea1114e33e42414ff107a41d211443c659c43122abaf   # == catalog archive_digest ✅
$ tar tzf ...
LICENSE.onnxruntime / NOTICE.onnxruntime / build-manifest.json / libonnxruntime.dylib / provenance.json / sbom.spdx.json
```

归档 6 个文件，catalog 的 `extracted_file_digests` 只声明 5 个（缺 `build-manifest.json`），而 `verify_extracted_files` 把「多出未声明文件」当硬失败 → 字节完全正确的归档被拒。影响全部 10 条 runtime 记录（两代、所有平台）。上游 manifest 生成器修复另开 #228。

**2. 三个互不校准的真相源。** 只有安装路径会真正解压+严格校验，失败仅存在内存态；`get_runtime_bootstrap_status` 只看 slot 记录 + legacy 文件（存在即 Ready），`check_runtime_updates` 只比对已记录身份与 catalog 摘要、从不解压。UI 又把「除 update_available 外的任何检查结果」都渲染成 “up to date”（含 `not_installed`）。

**3.** `SettingsModelVariantSection` 在 runtime 未就绪时整卡片提前返回，把模型选择器和模型更新按钮一起藏了。

**4.** 首次分离前的自动装配（`ensure_runtime_and_model_blocking`）本来就有，只是被 1 卡住。

**5.** onboarding 实际**没有**模型选择步骤，自动下载用的是设置里的 `model_variant`（默认 htdemucs；两个变体本身与 catalog 的非弃用 spectral 模型一致，没有过期选项）。

## 改动

- `verify_extracted_files` 容忍未声明的附带文件（已声明文件仍严格校验 size + SHA-256，记录也只含已声明文件）。解压前 `archive_digest` 已端到端校验整个归档，逐文件拒绝多余文件没有任何完整性收益；路径穿越/符号链接/大小上限等解压守卫保持不变。
- UI 只在 `report.state === "up_to_date"` 时说「已是最新」，`not_installed` 显示「未安装」；安装成功后清掉过期的检查报告（否则会出现「已就绪」+「未安装」并存）。
- Runtime 安装/修复 CTA 移到 ONNX Runtime 卡片；AI Model 卡片不再自我替换，变体选择与「Check for model updates」始终可见，仅下载动作按 runtime 就绪状态禁用，并给出未就绪原因提示。
- onboarding 新增「选择 AI 模型」一步（标准 / 微调实验版），选择在进入主界面前持久化 —— 正是首次分离自动下载使用的值。

## 测试

- `cargo test --lib separator::artifacts`：原「拒绝未声明文件」的用例改为断言容忍附带文件（`build-manifest.json`）且不进入安装记录，缺声明文件/大小/摘要不符仍然失败。
- `SettingsRuntimeSection.test.tsx`：missing/corrupt/failed 三态各自的 CTA 与文案；`not_installed` 检查结果**不得**渲染「已是最新」。
- `SettingsModelVariantSection.test.tsx`：runtime 缺失时变体选择器与模型更新按钮仍在、且不再持有 runtime 安装按钮；下载中显示进度文案。
- `SettingsOverlay.state.test.ts`：安装成功后 `runtimeUpdate` 被清空。
- `LibrarySetup.render.test.tsx`：走完 onboarding 断言 `setStemMode` + `setModelVariant("htdemucs_ft")` 都被调用。

`pnpm vitest run src/components/Settings src/locales` 全绿（286）；`node scripts/check-i18n.mjs` 通过。

⚠️ 未在「全新安装」机器上端到端跑过首次分离自动装配（本机已有 runtime）。建议合并前用一台干净环境验证一次 #236 的验收点 4。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
