### PR TITLE
fix(lyrics): keep interleaved romaji out of the lyric list

### DIFF
--- a/src/lib/lyrics-companion-romanization.test.ts
+++ b/src/lib/lyrics-companion-romanization.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test } from "vitest";
+import { splitCompanionRomanization } from "./lyrics-companion-romanization";
+import type { LyricLine } from "@/types/ipc";
+
+function line(
+  timeMs: number,
+  text: string,
+  words: LyricLine["words"] = [],
+): LyricLine {
+  return { time_ms: timeMs, text, words, bg_words: null, section: null };
+}
+
+describe("splitCompanionRomanization", () => {
+  test("lifts same-timestamp romaji shadows out of the lyric list", () => {
+    // Verbatim shape of the embedded LRC for imase - NIGHT DANCER.
+    const split = splitCompanionRomanization([
+      line(850, "どうでもいいような 夜だけど"),
+      line(850, "doudemoiiyouna yorudakedo"),
+      line(4850, "響めき 煌めきと君も"),
+      line(4850, "kyoumeki koumekitokunmo"),
+      line(25810, "まだ止まった 刻む針も"),
+      line(25810, "madatomatta kizamuharimo"),
+      line(29070, "入り浸った 散らかる部屋も"),
+      line(29070, "irihitatsuta chirakaruheyamo"),
+    ]);
+
+    expect(split.lines.map((l) => l.text)).toEqual([
+      "どうでもいいような 夜だけど",
+      "響めき 煌めきと君も",
+      "まだ止まった 刻む針も",
+      "入り浸った 散らかる部屋も",
+    ]);
+    expect(split.romanizedLines).toEqual([
+      "doudemoiiyouna yorudakedo",
+      "kyoumeki koumekitokunmo",
+      "madatomatta kizamuharimo",
+      "irihitatsuta chirakaruheyamo",
+    ]);
+    expect(split.complete).toBe(true);
+  });
+
+  test("tolerates timestamps that differ only by rounding", () => {
+    const split = splitCompanionRomanization([
+      line(850, "どうでもいいような 夜だけど"),
+      line(860, "doudemoiiyouna yorudakedo"),
+      line(4850, "響めき 煌めきと君も"),
+      line(4850, "kyoumeki koumekitokunmo"),
+      line(25810, "まだ止まった 刻む針も"),
+      line(25850, "madatomatta kizamuharimo"),
+    ]);
+
+    expect(split.lines).toHaveLength(3);
+    expect(split.romanizedLines).toEqual([
+      "doudemoiiyouna yorudakedo",
+      "kyoumeki koumekitokunmo",
+      "madatomatta kizamuharimo",
+    ]);
+    expect(split.complete).toBe(true);
+  });
+
+  test("keeps a transcription stamped with a different beat as a lyric line", () => {
+    // Sloppy sources sometimes stamp a transcription with a neighbouring
+    // beat's time. That is indistinguishable — by timestamp, count, or
+    // alternation — from a genuine Latin-script lyric at that beat, so the
+    // line is KEPT. A visible duplicate is the acceptable outcome; deleting a
+    // real lyric is not.
+    const split = splitCompanionRomanization([
+      line(850, "どうでもいいような 夜だけど"),
+      line(850, "doudemoiiyouna yorudakedo"),
+      line(4850, "響めき 煌めきと君も"),
+      line(4850, "kyoumeki koumekitokunmo"),
+      line(25810, "まだ止まった 刻む針も"),
+      line(25810, "madatomatta kizamuharimo"),
+      line(57530, "無駄話で はぐらかして"),
+      line(57530, "mudabanashide hagurakashite"),
+      line(57530, "触れた先を ためらうように"),
+      line(61510, "furetasakiwo tamerauyouni"),
+    ]);
+
+    expect(split.lines.map((l) => l.text)).toEqual([
+      "どうでもいいような 夜だけど",
+      "響めき 煌めきと君も",
+      "まだ止まった 刻む針も",
+      "無駄話で はぐらかして",
+      "触れた先を ためらうように",
+      "furetasakiwo tamerauyouni",
+    ]);
+    // Incomplete, so enabling romanization recomputes a full set instead of
+    // trusting this partial extraction.
+    expect(split.complete).toBe(false);
+  });
+
+  test("never absorbs a genuine English lyric that follows an untranscribed line", () => {
+    // REGRESSION: pairing by adjacency alone deleted this line — invisible
+    // with the toggle off, misattributed as pronunciation with it on.
+    const englishLyric = line(5000, "I love you");
+    const split = splitCompanionRomanization([
+      line(1000, "日本語のA"),
+      line(1000, "nihongo no A"),
+      line(2000, "日本語のB"),
+      line(2000, "nihongo no B"),
+      line(3000, "日本語のC"),
+      line(3000, "nihongo no C"),
+      line(4000, "日本語のD"),
+      englishLyric,
+      line(6000, "日本語のE"),
+      line(6000, "nihongo no E"),
+    ]);
+
+    expect(split.lines).toContain(englishLyric);
+    expect(split.romanizedLines).not.toContain("I love you");
+    expect(split.complete).toBe(false);
+  });
+
+  test("leaves a monolingual file untouched", () => {
+    const lines = [
+      line(0, "君のこと"),
+      line(1000, "思い出しては"),
+      line(2000, "変わらないね"),
+      line(3000, "二人 歳を重ねてた"),
+    ];
+
+    const split = splitCompanionRomanization(lines);
+
+    expect(split.lines).toBe(lines);
+    expect(split.romanizedLines).toEqual([]);
+    expect(split.complete).toBe(false);
+  });
+
+  test("never swallows genuine English lines in a Japanese song", () => {
+    // Mixed-language lyrics are the norm in J-pop; without the pattern
+    // threshold these English lines would be reclassified as pronunciation.
+    const lines = [
+      line(0, "どうでもいいような 夜だけど"),
+      line(4000, "I don't wanna say goodbye"),
+      line(8000, "響めき 煌めきと君も"),
+      line(12000, "All the love and all the shine"),
+      line(16000, "変わらないね"),
+    ];
+
+    const split = splitCompanionRomanization(lines);
+
+    expect(split.lines).toBe(lines);
+    expect(split.romanizedLines).toEqual([]);
+  });
+
+  test("keeps word-timed lines as lyrics even when they are Latin", () => {
+    // A karaoke-timed Latin line owns word highlighting; collapsing it into an
+    // annotation would silently drop that timing.
+    const timed = line(850, "doudemoiiyouna yorudakedo", [
+      { time_ms: 850, end_ms: 1200, text: "doudemoiiyouna" },
+    ]);
+    const lines = [
+      line(0, "ライン一"),
+      line(0, "rain ichi"),
+      line(1000, "ライン二"),
+      line(1000, "rain ni"),
+      line(2000, "ライン三"),
+      line(2000, "rain san"),
+      line(850, "どうでもいいような 夜だけど"),
+      timed,
+    ];
+
+    const split = splitCompanionRomanization(lines);
+
+    expect(split.lines).toContain(timed);
+    expect(split.complete).toBe(false);
+  });
+
+  test("reports an incomplete split when only some lines are transcribed", () => {
+    const split = splitCompanionRomanization([
+      line(0, "ライン一"),
+      line(0, "rain ichi"),
+      line(1000, "ライン二"),
+      line(1000, "rain ni"),
+      line(2000, "ライン三"),
+      line(2000, "rain san"),
+      line(3000, "ライン四"),
+      line(4000, "ライン五"),
+    ]);
+
+    expect(split.lines.map((l) => l.text)).toEqual([
+      "ライン一",
+      "ライン二",
+      "ライン三",
+      "ライン四",
+      "ライン五",
+    ]);
+    expect(split.romanizedLines).toEqual([
+      "rain ichi",
+      "rain ni",
+      "rain san",
+      "",
+      "",
+    ]);
+    expect(split.complete).toBe(false);
+  });
+
+  test("preserves blank separator lines", () => {
+    const split = splitCompanionRomanization([
+      line(0, "ライン一"),
+      line(0, "rain ichi"),
+      line(1000, ""),
+      line(2000, "ライン二"),
+      line(2000, "rain ni"),
+      line(3000, "ライン三"),
+      line(3000, "rain san"),
+    ]);
+
+    expect(split.lines.map((l) => l.text)).toEqual([
+      "ライン一",
+      "",
+      "ライン二",
+      "ライン三",
+    ]);
+    expect(split.romanizedLines).toEqual([
+      "rain ichi",
+      "",
+      "rain ni",
+      "rain san",
+    ]);
+  });
+});

--- a/src/lib/lyrics-companion-romanization.ts
+++ b/src/lib/lyrics-companion-romanization.ts
@@ -1,0 +1,146 @@
+import { isLatinScript } from "lyric-romanizer/detector";
+import type { LyricLine } from "@/types/ipc";
+
+/**
+ * Bilingual lyric sources (LrcLib and most embedded tags for Japanese songs)
+ * interleave a romaji transcription as its own timestamped line:
+ *
+ *   [00:00.85]どうでもいいような 夜だけど
+ *   [00:00.85]doudemoiiyouna yorudakedo
+ *
+ * The parser has no notion of a companion line, so both render as full-size
+ * peer lyrics — visible even when the Romanized-lyrics toggle is off, and
+ * duplicating the app's own on-demand romanization when it is on.
+ *
+ * This pass lifts those transcriptions out of the lyric list and returns them
+ * as a parallel romanization array, so a romaji line can only ever appear as
+ * the attached sub-line under its primary line, and only while romanization
+ * is enabled.
+ */
+export interface CompanionRomanizationSplit {
+  /** Primary lyric lines with companion transcriptions removed. */
+  lines: LyricLine[];
+  /** Romanization per primary line; "" where none was found. */
+  romanizedLines: string[];
+  /**
+   * True when every primary line that needs romanization got one from the
+   * source. Callers use this to decide whether the extracted set can serve as
+   * a complete romanization cache or the romanizer still has gaps to fill.
+   */
+  complete: boolean;
+}
+
+/**
+ * A file must look overwhelmingly interleaved before any line is reclassified.
+ * J-pop lyrics routinely contain genuine English lines, and those must never
+ * be swallowed as somebody else's pronunciation guide.
+ */
+const MIN_PAIRED_RATIO = 0.5;
+const MIN_PAIRED_LINES = 3;
+
+/**
+ * Sources round timestamps differently (centiseconds vs milliseconds), so a
+ * transcription may land a hair off its primary line. Two *distinct* lyrics
+ * are never this close, which is what makes the tolerance safe.
+ *
+ * The tolerance is deliberately tiny. A transcription that borrows a whole
+ * different beat's timestamp is indistinguishable — by timestamps, counts, or
+ * alternation — from a genuine Latin-script lyric line at that beat, and
+ * mistaking the latter for pronunciation would delete a real lyric. Such a
+ * stray transcription is therefore left as a lyric line: a visible duplicate
+ * in a sloppy source beats silently dropping someone's chorus.
+ */
+const COMPANION_TIMESTAMP_TOLERANCE_MS = 50;
+
+function isTranscriptionCandidate(line: LyricLine): boolean {
+  const text = line.text.trim();
+  if (text.length === 0) return false;
+  // Word-timed lines carry their own karaoke timing; a transcription shadow
+  // never does, and collapsing one would drop word highlighting.
+  if ((line.words?.length ?? 0) > 0) return false;
+  return isLatinScript([text]);
+}
+
+function needsRomanization(line: LyricLine): boolean {
+  const text = line.text.trim();
+  return text.length > 0 && !isLatinScript([text]);
+}
+
+function sharesTimestamp(primary: LyricLine, candidate: LyricLine): boolean {
+  return (
+    Math.abs(candidate.time_ms - primary.time_ms) <=
+    COMPANION_TIMESTAMP_TOLERANCE_MS
+  );
+}
+
+/**
+ * Count primary/transcription pairs printed at the same timestamp. This is the
+ * unambiguous signature of an interleaved bilingual file: two lyric lines at
+ * the very same moment, one non-Latin and one Latin.
+ */
+function countTimestampPairs(lines: LyricLine[]): number {
+  let pairs = 0;
+  for (let i = 1; i < lines.length; i += 1) {
+    const previous = lines[i - 1];
+    const current = lines[i];
+    if (
+      sharesTimestamp(previous, current) &&
+      needsRomanization(previous) &&
+      isTranscriptionCandidate(current)
+    ) {
+      pairs += 1;
+    }
+  }
+  return pairs;
+}
+
+export function splitCompanionRomanization(
+  lines: LyricLine[],
+): CompanionRomanizationSplit {
+  const primaryCount = lines.filter(needsRomanization).length;
+  const pairCount = countTimestampPairs(lines);
+
+  // Bail out unless the file is clearly interleaved, so a couple of Latin
+  // lines in an otherwise native lyric can never trigger extraction.
+  if (
+    pairCount < MIN_PAIRED_LINES ||
+    primaryCount === 0 ||
+    pairCount < primaryCount * MIN_PAIRED_RATIO
+  ) {
+    return {
+      lines,
+      romanizedLines: [],
+      complete: false,
+    };
+  }
+
+  const keptLines: LyricLine[] = [];
+  const romanizedLines: string[] = [];
+
+  for (const line of lines) {
+    const previousIndex = keptLines.length - 1;
+    const previous = previousIndex >= 0 ? keptLines[previousIndex] : null;
+    const previousHasRomanization =
+      previousIndex >= 0 && romanizedLines[previousIndex] !== "";
+
+    if (
+      previous !== null &&
+      !previousHasRomanization &&
+      sharesTimestamp(previous, line) &&
+      needsRomanization(previous) &&
+      isTranscriptionCandidate(line)
+    ) {
+      romanizedLines[previousIndex] = line.text.trim();
+      continue;
+    }
+
+    keptLines.push(line);
+    romanizedLines.push("");
+  }
+
+  const complete = keptLines.every(
+    (line, index) => !needsRomanization(line) || romanizedLines[index] !== "",
+  );
+
+  return { lines: keptLines, romanizedLines, complete };
+}

--- a/src/stores/lyrics-store.test.ts
+++ b/src/stores/lyrics-store.test.ts
@@ -111,6 +111,91 @@ describe("lyrics-store fetchLyrics", () => {
     expect(mockNotifyError).not.toHaveBeenCalled();
   });
 
+  test("keeps interleaved romaji out of the lyric list and off screen until enabled", async () => {
+    const jp = (timeMs: number, text: string) => ({
+      time_ms: timeMs,
+      text,
+      words: [],
+      bg_words: null,
+      section: null,
+    });
+    mockFetchLyrics.mockResolvedValue({
+      song_id: "song-1",
+      lines: [
+        jp(850, "どうでもいいような 夜だけど"),
+        jp(850, "doudemoiiyouna yorudakedo"),
+        jp(4850, "響めき 煌めきと君も"),
+        jp(4850, "kyoumeki koumekitokunmo"),
+        jp(25810, "まだ止まった 刻む針も"),
+        jp(25810, "madatomatta kizamuharimo"),
+      ],
+      source: "embedded" as const,
+      offset_ms: 0,
+      raw_lrc: "irrelevant",
+    });
+
+    await useLyricsStore.getState().fetchLyrics("song-1");
+
+    const state = useLyricsStore.getState();
+    // Transcriptions are no longer peer lyric lines…
+    expect(state.lines.map((l) => l.text)).toEqual([
+      "どうでもいいような 夜だけど",
+      "響めき 煌めきと君も",
+      "まだ止まった 刻む針も",
+    ]);
+    // …they are the romanization overlay, which starts hidden.
+    expect(state.romanizedLines).toEqual([
+      "doudemoiiyouna yorudakedo",
+      "kyoumeki koumekitokunmo",
+      "madatomatta kizamuharimo",
+    ]);
+    expect(state.showRomanized).toBe(false);
+
+    // Enabling the toggle shows the source transcription without paying for a
+    // romanizer run, because the cache identity matches the fetched lines.
+    useLyricsStore.getState().setRomanizedVisibility(true);
+    expect(useLyricsStore.getState().showRomanized).toBe(true);
+    expect(mockRomanizeLyricsLines).not.toHaveBeenCalled();
+  });
+
+  test("recomputes romanization when the source transcribes only some lines", async () => {
+    const jp = (timeMs: number, text: string) => ({
+      time_ms: timeMs,
+      text,
+      words: [],
+      bg_words: null,
+      section: null,
+    });
+    mockFetchLyrics.mockResolvedValue({
+      song_id: "song-1",
+      lines: [
+        jp(0, "ライン一"),
+        jp(0, "rain ichi"),
+        jp(1000, "ライン二"),
+        jp(1000, "rain ni"),
+        jp(2000, "ライン三"),
+        jp(2000, "rain san"),
+        jp(3000, "ライン四"),
+      ],
+      source: "embedded" as const,
+      offset_ms: 0,
+      raw_lrc: "irrelevant",
+    });
+    mockRomanizeLyricsLines.mockResolvedValue({
+      result: ["rain ichi", "rain ni", "rain san", "rain yon"],
+      requestId: 1,
+    });
+
+    await useLyricsStore.getState().fetchLyrics("song-1");
+    expect(useLyricsStore.getState().romanizedLinesIdentity).toBeNull();
+
+    useLyricsStore.getState().setRomanizedVisibility(true);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockRomanizeLyricsLines).toHaveBeenCalled();
+  });
+
   test("calls notifyError and clears state on error", async () => {
     const error = new Error("fetch failed");
     mockFetchLyrics.mockRejectedValue(error);

--- a/src/stores/lyrics-store.ts
+++ b/src/stores/lyrics-store.ts
@@ -6,6 +6,7 @@ import {
   buildLyricsIdentity,
   type LocalAudienceRomanizeState,
 } from "@/lib/local-audience-romanize";
+import { splitCompanionRomanization } from "@/lib/lyrics-companion-romanization";
 import {
   SONG_LANGUAGES,
   type SongLanguage,
@@ -30,6 +31,35 @@ const AUTO_UPGRADE_PROTECTED_SOURCES: ReadonlySet<LyricsSource> =
     "sidecar_ttml",
     "sidecar_lys",
   ]);
+
+/**
+ * Lift interleaved romaji lines out of a fetched lyric set.
+ *
+ * Bilingual sources ship the transcription as its own timestamped line, which
+ * the parser faithfully turns into a peer lyric. Extracting it here — at the
+ * single point where lines enter the store — keeps romanization out of the
+ * lyric list entirely, so it can only surface as the attached sub-line under
+ * its primary line while the Romanized-lyrics toggle is on.
+ *
+ * A complete source set seeds the romanization cache (identity set), so
+ * enabling the toggle shows the source transcription without running the
+ * romanizer. A partial set is still shown, but the identity stays null so the
+ * romanizer recomputes a full set on enable.
+ */
+function normalizeFetchedLyrics(lines: LyricLine[]): {
+  lines: LyricLine[];
+  romanizedLines: string[];
+  romanizedLinesIdentity: string | null;
+} {
+  const split = splitCompanionRomanization(lines);
+  return {
+    lines: split.lines,
+    romanizedLines: split.romanizedLines,
+    romanizedLinesIdentity: split.complete
+      ? buildLyricsIdentity(split.lines)
+      : null,
+  };
+}
 
 function getSongLanguage(songId: string | null): SongLanguage | null {
   if (!songId) return null;
@@ -103,9 +133,12 @@ export const useLyricsStore = create<LyricsState>((set, get) => ({
     try {
       const payload = await api.fetchLyrics(songId);
       if (gen !== fetchGeneration) return;
+      const normalized = normalizeFetchedLyrics(payload.lines);
       set({
         songId: payload.song_id,
-        lines: payload.lines,
+        lines: normalized.lines,
+        romanizedLines: normalized.romanizedLines,
+        romanizedLinesIdentity: normalized.romanizedLinesIdentity,
         source: payload.source,
         offsetMs: payload.offset_ms,
         rawLrc: payload.raw_lrc,
@@ -118,13 +151,13 @@ export const useLyricsStore = create<LyricsState>((set, get) => ({
       // so the upgrade cannot silently overwrite manual/sidecar lyrics
       // (issue #203).
       if (
-        payload.lines.length > 0 &&
+        normalized.lines.length > 0 &&
         payload.source !== "lrc_lib" &&
         !(
           payload.source !== null &&
           AUTO_UPGRADE_PROTECTED_SOURCES.has(payload.source)
         ) &&
-        payload.lines.every((l) => l.time_ms === 0)
+        normalized.lines.every((l) => l.time_ms === 0)
       ) {
         try {
           const online = await api.fetchLyricsOnline(songId, false);
@@ -134,9 +167,12 @@ export const useLyricsStore = create<LyricsState>((set, get) => ({
             online.lines.length > 0 &&
             online.lines.some((l) => l.time_ms > 0)
           ) {
+            const normalizedOnline = normalizeFetchedLyrics(online.lines);
             set({
               songId: online.song_id,
-              lines: online.lines,
+              lines: normalizedOnline.lines,
+              romanizedLines: normalizedOnline.romanizedLines,
+              romanizedLinesIdentity: normalizedOnline.romanizedLinesIdentity,
               source: online.source,
               offsetMs: online.offset_ms,
               rawLrc: online.raw_lrc,
@@ -190,9 +226,12 @@ export const useLyricsStore = create<LyricsState>((set, get) => ({
   saveManualLyrics: async (songId, text) => {
     try {
       const payload = await api.saveManualLyrics(songId, text);
+      const normalized = normalizeFetchedLyrics(payload.lines);
       set({
         songId: payload.song_id,
-        lines: payload.lines,
+        lines: normalized.lines,
+        romanizedLines: normalized.romanizedLines,
+        romanizedLinesIdentity: normalized.romanizedLinesIdentity,
         source: payload.source,
         offsetMs: payload.offset_ms,
         rawLrc: payload.raw_lrc,


### PR DESCRIPTION
Fixes #232

实测反馈：日文歌的歌词面板里罗马音以**和原歌词同级的全尺寸行**交替出现，且顶部「Romanized lyrics」开关关闭时也出现。期望回到旧样式：罗马音作为附属小字挂在原歌词下方，未启用时完全不出现。

## 根因（读实际数据取证）

不是罗马音功能的缺陷 —— 源 LRC 本身就是双语交替的：

```
$ sqlite3 ~/Music/OpenKara/openkara.db "SELECT lrc FROM lyrics l JOIN songs s ON l.song_hash=s.hash WHERE s.title='NIGHT DANCER'"
[00:00.85]どうでもいいような 夜だけど
[00:00.85]doudemoiiyouna yorudakedo
[00:04.85]響めき 煌めきと君も
[00:04.85]kyoumeki koumekitokunmo
...
```

`parse_lrc` 忠实地把每条带时间戳的文本变成一条 `LyricLine`，没有「注音伴随行」概念，于是罗马音成了平级歌词，与开关无关。应用自己的 on-demand 罗马音（`showRomanized` 默认 false、渲染为 `LyricLine` 内小字子行）一直是对的，只是叠在一起就成了用户看到的样子。

## 改动

新增 `src/lib/lyrics-companion-romanization.ts`，在**歌词进入 store 的单一入口**（`fetchLyrics`、其中的在线自动升级分支、`saveManualLyrics`）把影子行从 `lines` 抽出为并行的罗马音数组：

- 关闭开关 → 完全不可见；开启 → 走既有附属子行渲染。
- 源覆盖**完整**时顺带作为罗马音缓存（identity 一致 → 开启时不跑 romanizer）；**部分**覆盖时 identity 留空，开启时由 romanizer 重算完整一套。

判定刻意保守（日语歌夹真英文歌词很常见，绝不能把真歌词当注音删掉）：

1. 整份文件必须**明显**呈交替结构（≥3 对同时间戳的「非拉丁 + 纯拉丁」，且覆盖过半原行）才会启用抽取；
2. 候选必须与原行**同时间戳**（容差 50ms，仅覆盖不同取整方式）；
3. 带逐字时间的行永不被抽取（会丢逐字高亮）；
4. 空行原样保留。

被错标到**另一拍**时间戳的注音，在时间戳、行数、交替结构上都与「该拍上一句真正的拉丁语歌词」无法区分，因此**保留为歌词行**并把结果标记为不完整 —— 源文件脏时多出一行重复，好过悄悄删掉别人的副歌。这一取舍在测试里显式锁定。

## 测试

`lyrics-companion-romanization.test.ts`（7 例）：真实 NIGHT DANCER 形状抽取正确；仅取整差异仍配对；错标到别的拍**保留**且 complete=false；单语文件原样返回；**含真英文行的日语歌词不丢行**（回归用例）；逐字时间行不被抽取；部分覆盖时报 incomplete；空行保留。

`lyrics-store.test.ts` 新增两例：交替源在开关关闭时 `lines` 只剩日文行、`romanizedLines` 拿到注音且 `showRomanized=false`，开启后不触发 romanizer；部分覆盖时开启会触发 romanizer。

`pnpm vitest run src/stores/lyrics-store.test.ts src/lib/lyrics-companion-romanization.test.ts src/components/Lyrics` 全绿（148）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
