### PR TITLE
fix(lyrics): add a Reset button to the lyrics offset control

### DIFF
--- a/src/components/Lyrics/LyricsOffsetControl.test.tsx
+++ b/src/components/Lyrics/LyricsOffsetControl.test.tsx
@@ -7,12 +7,19 @@ const { mockLyricsState } = vi.hoisted(() => ({
     songId: "song-1" as string | null,
     offsetMs: 0,
     adjustOffset: vi.fn(),
+    resetOffset: vi.fn(),
   },
 }));
 
 vi.mock("@/stores/lyrics-store", () => ({
   useLyricsStore: (selector: (state: typeof mockLyricsState) => unknown) =>
     selector(mockLyricsState),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
 }));
 
 describe("LyricsOffsetControl", () => {
@@ -68,5 +75,12 @@ describe("LyricsOffsetControl", () => {
     // display rests in the dim text color rather than the active highlight
     // color.
     expect(markup).not.toContain("text-[var(--color-control-primary)]");
+  });
+
+  test("renders a reset button mirroring the font-size control", () => {
+    const markup = renderToStaticMarkup(<LyricsOffsetControl />);
+
+    expect(markup).toContain("lyrics.offsetReset");
+    expect(markup).toContain("lyrics.offsetResetShort");
   });
 });

--- a/src/components/Lyrics/LyricsOffsetControl.tsx
+++ b/src/components/Lyrics/LyricsOffsetControl.tsx
@@ -1,4 +1,5 @@
 import type { HTMLAttributes } from "react";
+import { useTranslation } from "react-i18next";
 import { useLyricsStore } from "@/stores/lyrics-store";
 
 type LyricsOffsetControlProps = HTMLAttributes<HTMLDivElement>;
@@ -7,9 +8,11 @@ export function LyricsOffsetControl({
   className = "",
   ...props
 }: LyricsOffsetControlProps) {
+  const { t } = useTranslation();
   const songId = useLyricsStore((s) => s.songId);
   const offsetMs = useLyricsStore((s) => s.offsetMs);
   const adjustOffset = useLyricsStore((s) => s.adjustOffset);
+  const resetOffset = useLyricsStore((s) => s.resetOffset);
 
   if (!songId) return null;
 
@@ -21,7 +24,7 @@ export function LyricsOffsetControl({
       <button
         onClick={() => adjustOffset(songId, -500)}
         className="motion-surface rounded-full border border-[var(--color-border-light)] px-2.5 py-1 font-medium hover:border-[color-mix(in_srgb,var(--color-accent)_28%,var(--color-border-light))] hover:bg-[color-mix(in_srgb,var(--color-hover)_72%,transparent)] hover:text-[var(--color-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]/50"
-        aria-label="Adjust lyrics backward by 0.5 seconds"
+        aria-label={t("lyrics.offsetDecrease")}
       >
         -0.5s
       </button>
@@ -40,9 +43,16 @@ export function LyricsOffsetControl({
       <button
         onClick={() => adjustOffset(songId, 500)}
         className="motion-surface rounded-full border border-[var(--color-border-light)] px-2.5 py-1 font-medium hover:border-[color-mix(in_srgb,var(--color-accent)_28%,var(--color-border-light))] hover:bg-[color-mix(in_srgb,var(--color-hover)_72%,transparent)] hover:text-[var(--color-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]/50"
-        aria-label="Adjust lyrics forward by 0.5 seconds"
+        aria-label={t("lyrics.offsetIncrease")}
       >
         +0.5s
+      </button>
+      <button
+        onClick={() => void resetOffset(songId)}
+        className="motion-surface rounded-full border border-[var(--color-border-light)] px-2.5 py-1 font-medium hover:border-[color-mix(in_srgb,var(--color-accent)_28%,var(--color-border-light))] hover:bg-[color-mix(in_srgb,var(--color-hover)_72%,transparent)] hover:text-[var(--color-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]/50"
+        aria-label={t("lyrics.offsetReset")}
+      >
+        {t("lyrics.offsetResetShort")}
       </button>
     </div>
   );

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -237,7 +237,11 @@
     "fontSizeResetShort": "Reset",
     "followPlaying": "Follow playing lyric",
     "matchedToast": "Lyrics matched to \"{{song}}\"",
-    "unmatchedToast": "Lyrics file could not be matched to a song: {{file}}"
+    "unmatchedToast": "Lyrics file could not be matched to a song: {{file}}",
+    "offsetDecrease": "Adjust lyrics backward by 0.5 seconds",
+    "offsetIncrease": "Adjust lyrics forward by 0.5 seconds",
+    "offsetReset": "Reset lyrics offset",
+    "offsetResetShort": "Reset"
   },
   "songEdit": {
     "title": "Edit Song Info",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -237,7 +237,11 @@
     "fontSizeResetShort": "重置",
     "followPlaying": "跟随正在播放的歌词",
     "matchedToast": "歌词已匹配到「{{song}}」",
-    "unmatchedToast": "歌词文件无法匹配到歌曲：{{file}}"
+    "unmatchedToast": "歌词文件无法匹配到歌曲：{{file}}",
+    "offsetDecrease": "歌词后移 0.5 秒",
+    "offsetIncrease": "歌词前移 0.5 秒",
+    "offsetReset": "重置歌词偏移",
+    "offsetResetShort": "重置"
   },
   "songEdit": {
     "title": "编辑歌曲信息",

--- a/src/stores/lyrics-store.test.ts
+++ b/src/stores/lyrics-store.test.ts
@@ -400,6 +400,38 @@ describe("lyrics-store adjustOffset", () => {
   });
 });
 
+describe("lyrics-store resetOffset", () => {
+  beforeEach(resetStore);
+
+  test("no-ops when the offset is already zero", async () => {
+    useLyricsStore.setState({ offsetMs: 0 });
+
+    await useLyricsStore.getState().resetOffset("song-1");
+
+    expect(mockSetLyricsOffset).not.toHaveBeenCalled();
+  });
+
+  test("persists a zero offset and clears offsetMs", async () => {
+    useLyricsStore.setState({ offsetMs: 1500 });
+    mockSetLyricsOffset.mockResolvedValue(undefined);
+
+    await useLyricsStore.getState().resetOffset("song-1");
+
+    expect(mockSetLyricsOffset).toHaveBeenCalledWith("song-1", 0);
+    expect(useLyricsStore.getState().offsetMs).toBe(0);
+  });
+
+  test("resets a negative offset back to zero", async () => {
+    useLyricsStore.setState({ offsetMs: -500 });
+    mockSetLyricsOffset.mockResolvedValue(undefined);
+
+    await useLyricsStore.getState().resetOffset("song-1");
+
+    expect(mockSetLyricsOffset).toHaveBeenCalledWith("song-1", 0);
+    expect(useLyricsStore.getState().offsetMs).toBe(0);
+  });
+});
+
 describe("lyrics-store setActiveLineIndex", () => {
   beforeEach(resetStore);
 

--- a/src/stores/lyrics-store.ts
+++ b/src/stores/lyrics-store.ts
@@ -63,6 +63,7 @@ interface LyricsState {
   fetchLyrics: (songId: string) => Promise<void>;
   setOffset: (songId: string, ms: number) => Promise<void>;
   adjustOffset: (songId: string, deltaMs: number) => Promise<void>;
+  resetOffset: (songId: string) => Promise<void>;
   saveManualLyrics: (songId: string, text: string) => Promise<boolean>;
   setActiveLineIndex: (index: number) => void;
   setActiveWordIndex: (index: number) => void;
@@ -185,6 +186,14 @@ export const useLyricsStore = create<LyricsState>((set, get) => ({
       }
       notifyError(e);
     }
+  },
+
+  resetOffset: async (songId) => {
+    const currentOffset = get().offsetMs;
+    if (currentOffset === 0) return;
+    // Route through adjustOffset so the reset shares its optimistic update
+    // and backend-failure recovery instead of duplicating them here.
+    await get().adjustOffset(songId, -currentOffset);
   },
 
   saveManualLyrics: async (songId, text) => {


### PR DESCRIPTION
Fixes #233

实测反馈：歌词主窗口的字号控件有 Reset，相邻的时间偏移控件却没有 —— 想归零只能反复点 ±0.5s。

## 改动

- `lyrics-store` 新增 `resetOffset`：偏移已为 0 时直接返回（不产生 IPC 写入），否则**走 `adjustOffset`** —— 复用它已有的乐观更新与失败恢复（后端失败时重新拉取权威偏移、并防止切歌期间污染新歌曲），而不是复制一套。
- `LyricsOffsetControl` 加第四个 Reset 按钮，class / 尺寸与字号控件的 Reset 完全一致。
- 该控件是唯一还在用硬编码英文 aria-label 的歌词控件，顺手把文案接入 i18n（`lyrics.offsetDecrease` / `offsetIncrease` / `offsetReset` / `offsetResetShort`，en + zh-CN）。

`utilityControlsPinned = offsetMs !== 0 || lyricsFontStep !== 0` 本来就会在偏移非 0 时把该控件钉住显示，所以 Reset 在需要它的时候必然可见。

## 测试

- `lyrics-store.test.ts`：偏移为 0 时点击不写 IPC；正/负偏移都归零并持久化 `(songId, 0)`。
- `LyricsOffsetControl.test.tsx`：补上 `react-i18next` mock（组件现在用 `useTranslation`，否则原有 SSR 断言会崩），新增断言 Reset 按钮与 aria-label 渲染。

`pnpm vitest run src/stores/lyrics-store.test.ts src/components/Lyrics src/locales` 全绿（146）；`node scripts/check-i18n.mjs` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
