### PR TITLE
chore(separation): align stale test names, docs, and dead helper with the merged #166 architecture

### DIFF
--- a/docs/references/contracts/model-bootstrap.md
+++ b/docs/references/contracts/model-bootstrap.md
@@ -71,7 +71,7 @@
   已无法加载波形模型（`model::ensure_spectral_core_metadata` 会拒绝），因此这些
   工件只在清单解析层保留，不再有推理层读取逻辑。
 - 每次成功安装都会在模型旁写入 `<model>.identity.json`
-  （schema `openkara.app/installed-model-v1`），记录 generation、release ID、
+  （schema `openkara.app/installed-artifact-v1`），记录 generation、release ID、
   artifact ID、上游 tag、digest、字节数与兼容 runtime 列表。
 - 就绪判定：文件 digest 匹配内嵌 pin，**或** 匹配其 identity 记录（因此从更
   新 generation 安装的模型在旧二进制/离线状态下仍可用）。identity 记录损坏

--- a/src-tauri/src/commands/runtime_bootstrap.rs
+++ b/src-tauri/src/commands/runtime_bootstrap.rs
@@ -753,4 +753,37 @@ mod tests {
             assert!(ensure_runtime_ready(&status).is_err());
         }
     }
+
+    #[test]
+    fn staging_candidate_rejects_runtime_that_does_not_support_a_model() {
+        // The manifest validator guarantees same-generation runtime/model
+        // reciprocity, so this defensive gate should never fire in practice.
+        // It must still bail loudly — rather than stage a runtime that cannot
+        // serve an installed model — if that invariant is ever violated. We
+        // reduce the catalog to a single active runtime for the current target
+        // and strip its supported-model list so the gate is the only reachable
+        // outcome; the bail happens before any download, so no I/O is needed.
+        let mut catalog = catalog::embedded_catalog().clone();
+        let mut runtime = catalog.manifest.artifacts.runtimes[0].clone();
+        runtime.target_triple = Some(catalog::current_target_triple().to_owned());
+        runtime.deprecation = catalog::CatalogDeprecation::default();
+        runtime.runtime.supported_model_artifact_ids.clear();
+        catalog.manifest.artifacts.runtimes = vec![runtime];
+
+        let status = Arc::new(Mutex::new(snapshot_from_inventory(&empty_inventory())));
+        let mut emit = |_event: &'static str, _snapshot: RuntimeBootstrapStatusSnapshot| {};
+
+        let error = download_and_stage_candidate_blocking(
+            std::path::Path::new("/nonexistent/openkara-compat-gate"),
+            &catalog,
+            &status,
+            &mut emit,
+        )
+        .expect_err("an incompatible runtime must be rejected before staging");
+
+        assert!(
+            error.to_string().contains("does not support model"),
+            "unexpected error: {error}"
+        );
+    }
 }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -916,7 +916,7 @@ mod tests {
     }
 
     #[test]
-    fn effective_stem_mode_defaults_to_two_stem() {
+    fn effective_stem_mode_defaults_to_four_stem() {
         let config = AppConfig::default();
         assert_eq!(config.effective_stem_mode(), StemMode::FourStem);
     }

--- a/src-tauri/src/separator/bootstrap.rs
+++ b/src-tauri/src/separator/bootstrap.rs
@@ -4,14 +4,13 @@ use crate::separator::catalog::{
     VerifiedCatalog,
 };
 use crate::separator::verified_manifest::{
-    sha256_hex, verified_manifest_matches, verified_manifest_path, write_verified_manifest,
+    verified_manifest_matches, verified_manifest_path, write_verified_manifest,
 };
 use anyhow::{bail, Context, Result};
 use std::sync::OnceLock;
 use std::{
     fs,
     path::{Path, PathBuf},
-    time::{SystemTime, UNIX_EPOCH},
 };
 
 /// Everything needed to install and verify one model artifact. Descriptors
@@ -215,50 +214,6 @@ pub fn resolve_existing_model_path(
     )
 }
 
-pub fn install_verified_model_bytes(
-    destination: &Path,
-    payload: &[u8],
-    expected_sha256: &str,
-) -> Result<()> {
-    let actual_sha256 = sha256_hex(payload);
-    if actual_sha256 != expected_sha256 {
-        bail!(
-            "downloaded model checksum mismatch: expected {expected_sha256}, got {actual_sha256}"
-        );
-    }
-
-    let parent = destination.parent().with_context(|| {
-        format!(
-            "model destination {} is missing a parent directory",
-            destination.display()
-        )
-    })?;
-    fs::create_dir_all(parent).with_context(|| {
-        format!(
-            "failed to create model destination directory {}",
-            parent.display()
-        )
-    })?;
-
-    let temp_path = temporary_download_path(destination);
-    fs::write(&temp_path, payload).with_context(|| {
-        format!(
-            "failed to write temporary model download {}",
-            temp_path.display()
-        )
-    })?;
-    fs::rename(&temp_path, destination).with_context(|| {
-        format!(
-            "failed to move verified model from {} to {}",
-            temp_path.display(),
-            destination.display()
-        )
-    })?;
-    write_verified_manifest(destination, expected_sha256)?;
-
-    Ok(())
-}
-
 /// Download and install a model through the shared artifact plumbing:
 /// stream to a temp file with fixed memory, verify the download digest,
 /// extract archived deliveries safely, verify the installed `.onnx` digest,
@@ -365,13 +320,4 @@ fn verify_model_install(path: &Path, expected_sha256: &str) -> Result<bool> {
         write_verified_manifest(path, expected_sha256)?;
     }
     Ok(ok)
-}
-
-fn temporary_download_path(destination: &Path) -> PathBuf {
-    let timestamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system time should be after unix epoch")
-        .as_nanos();
-
-    destination.with_extension(format!("download.{timestamp}.tmp"))
 }

--- a/src-tauri/src/separator/runtime_bootstrap.rs
+++ b/src-tauri/src/separator/runtime_bootstrap.rs
@@ -7,8 +7,8 @@
 //!
 //! - **active** — the runtime the app loads at startup.
 //! - **candidate** — a verified update staged for activation on the next
-//!   launch. A runtime loaded by the current process is never replaced in
-//!   place (issue #168 invariant 9).
+//!   launch, upholding the never-replaced-in-place invariant: a runtime
+//!   loaded by the current process is never overwritten under its own path.
 //! - **previous** — the last verified generation, kept for explicit
 //!   recovery when a candidate fails to activate.
 //!

--- a/src-tauri/src/separator/spectral.rs
+++ b/src-tauri/src/separator/spectral.rs
@@ -14,9 +14,12 @@
 //! This is the *pure DSP* layer only: the forward transform ([`SpectralPlans::spec`]),
 //! the inverse transform ([`SpectralPlans::ispec`]), and the neural-core
 //! [`magnitude`] view helper, all validated against the pinned golden vectors
-//! at every intermediate stage. There is **no** production model / ORT session
-//! path here — that arrives with issue #172 PR 2 once `openkara-models#23`
-//! publishes spectral-core artifacts.
+//! at every intermediate stage. The production model / ORT session path that
+//! consumes these transforms lives in the sibling [`spectral_session`] module
+//! (issue #172 PR 2, once `openkara-models#23` published spectral-core
+//! artifacts).
+//!
+//! [`spectral_session`]: super::spectral_session
 //!
 //! # Contract semantics (mirrored operation-by-operation from the reference)
 //!

--- a/src-tauri/tests/phase6_catalog.rs
+++ b/src-tauri/tests/phase6_catalog.rs
@@ -45,7 +45,7 @@ fn install_records_identity_and_delete_removes_it() {
     let managed_path = bootstrap::managed_model_path_for(&temp_dir, descriptor);
     let payload = b"fake-model-payload";
 
-    bootstrap::install_verified_model_bytes(&managed_path, payload, &sha256_hex(payload))
+    support::install_verified_model_bytes(&managed_path, payload, &sha256_hex(payload))
         .expect("verified payload should install");
     let mut identity = descriptor.identity.clone();
     identity.archive_sha256 = sha256_hex(payload);
@@ -78,7 +78,7 @@ fn identity_verified_model_stays_ready_when_pin_moves() {
     let newer_payload = b"newer-generation-model";
     let newer_sha = sha256_hex(newer_payload);
 
-    bootstrap::install_verified_model_bytes(&managed_path, newer_payload, &newer_sha)
+    support::install_verified_model_bytes(&managed_path, newer_payload, &newer_sha)
         .expect("verified payload should install");
     let mut identity = descriptor.identity.clone();
     identity.generation += 1;

--- a/src-tauri/tests/phase6_model_bootstrap.rs
+++ b/src-tauri/tests/phase6_model_bootstrap.rs
@@ -91,7 +91,7 @@ fn install_verified_model_bytes_writes_model_to_nested_runtime_directory() {
         .join("htdemucs.onnx");
     let payload = b"fake-model";
 
-    bootstrap::install_verified_model_bytes(&destination, payload, &sha256_hex(payload))
+    support::install_verified_model_bytes(&destination, payload, &sha256_hex(payload))
         .expect("verified payload should install");
 
     assert_eq!(
@@ -116,7 +116,7 @@ fn install_verified_model_bytes_rejects_checksum_mismatch_without_creating_desti
         .join("models")
         .join("htdemucs.onnx");
 
-    let error = bootstrap::install_verified_model_bytes(&destination, b"fake-model", "not-a-sha")
+    let error = support::install_verified_model_bytes(&destination, b"fake-model", "not-a-sha")
         .expect_err("checksum mismatch should fail");
 
     assert!(error.to_string().contains("checksum mismatch"));
@@ -235,12 +235,8 @@ fn startup_bootstrap_uses_existing_verified_manifest_for_managed_model() {
     let development_path = temp_dir.join("dev").join("htdemucs.onnx");
     let managed_bytes = b"managed-model";
 
-    bootstrap::install_verified_model_bytes(
-        &managed_path,
-        managed_bytes,
-        &sha256_hex(managed_bytes),
-    )
-    .expect("verified model should install with manifest");
+    support::install_verified_model_bytes(&managed_path, managed_bytes, &sha256_hex(managed_bytes))
+        .expect("verified model should install with manifest");
 
     let startup = derive_startup_model_bootstrap(
         &temp_dir,
@@ -307,7 +303,7 @@ fn delete_model_file_removes_verification_manifest() {
     let managed_path = bootstrap::managed_model_path(&temp_dir);
     let payload = b"fake-model";
 
-    bootstrap::install_verified_model_bytes(&managed_path, payload, &sha256_hex(payload))
+    support::install_verified_model_bytes(&managed_path, payload, &sha256_hex(payload))
         .expect("verified model should install with manifest");
     let manifest_filename = format!(
         "{}.verified.json",

--- a/src-tauri/tests/support/mod.rs
+++ b/src-tauri/tests/support/mod.rs
@@ -1,5 +1,8 @@
+use anyhow::{bail, Context, Result};
+use openkara_lib::separator::verified_manifest::{sha256_hex, write_verified_manifest};
 use std::{
-    path::PathBuf,
+    fs,
+    path::{Path, PathBuf},
     sync::atomic::{AtomicU64, Ordering},
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -20,4 +23,45 @@ pub fn unique_temp_path(prefix: &str) -> PathBuf {
         "openkara-{prefix}-{pid}-{timestamp}-{sequence}",
         pid = std::process::id()
     ))
+}
+
+/// Materialize a verified managed install from an in-memory payload: verify the
+/// payload against `expected_sha256`, write the model bytes, then persist the
+/// startup verification manifest — the exact on-disk shape a real streaming
+/// install leaves behind. Used by the phase6 integration tests to stage a
+/// trusted install without exercising the network download path.
+// Not every integration-test binary that pulls in this shared support module
+// stages a managed install, so this helper is dead code in some of them.
+#[allow(dead_code)]
+pub fn install_verified_model_bytes(
+    destination: &Path,
+    payload: &[u8],
+    expected_sha256: &str,
+) -> Result<()> {
+    let actual_sha256 = sha256_hex(payload);
+    if actual_sha256 != expected_sha256 {
+        // Reject before touching the filesystem so a mismatch never leaves a
+        // partial install behind.
+        bail!(
+            "downloaded model checksum mismatch: expected {expected_sha256}, got {actual_sha256}"
+        );
+    }
+
+    let parent = destination.parent().with_context(|| {
+        format!(
+            "model destination {} is missing a parent directory",
+            destination.display()
+        )
+    })?;
+    fs::create_dir_all(parent).with_context(|| {
+        format!(
+            "failed to create model destination directory {}",
+            parent.display()
+        )
+    })?;
+    fs::write(destination, payload)
+        .with_context(|| format!("failed to write model fixture {}", destination.display()))?;
+    write_verified_manifest(destination, expected_sha256)?;
+
+    Ok(())
 }


### PR DESCRIPTION
## Closeout of epic #166

Epic #166 requires that every superseded remnant of the pre-merge architecture be deleted. An adversarial 8-verifier audit of the epic's Definition of Done ran against `origin/main`; it passed overall but surfaced five stale remnants. This hygiene PR clears all of them.

### Findings fixed

1. **Stale test name vs. asserted default (the #182 / #185 reversal).** The `config.rs` unit test `effective_stem_mode_defaults_to_two_stem` already asserted `StemMode::FourStem` — the default was deliberately flipped to four-stem by #182 / PR #185 (commit `bd90d76`). Renamed the test to `effective_stem_mode_defaults_to_four_stem`. The `StemMode` enum doc comments already documented four-stem as the default, so no further wording changes were needed.

2. **Contract-doc schema drift.** `docs/references/contracts/model-bootstrap.md` described the installed-identity schema as `openkara.app/installed-model-v1`, but the code's single identity record uses `openkara.app/installed-artifact-v1` (`separator/catalog.rs`). Corrected the doc. This was the only stale occurrence in `docs/references/contracts/` (the other mention in the same file was already correct).

3. **Unreferenced buffering helper (dead production path).** `separator::bootstrap::install_verified_model_bytes` buffered a whole model payload in memory and had no production caller — only the `phase6_*` integration tests used it, purely to stage a verified managed install on disk. Deleted it (plus the now-orphaned private `temporary_download_path` helper and dead imports) and moved an equivalent fixture into the tests' own support module (`tests/support/mod.rs`), implemented over the public `verified_manifest` API. The streaming installer `download_and_install_model` remains the only production install path (no full-payload buffer at any point).

4. **Stale module-doc line in `separator/spectral.rs`.** The header still carried the PR-1-era claim that there is "no production model / ORT session path here." That path landed in the sibling `spectral_session.rs`; reworded the sentence to point at it.

5. **Stale module-doc line in `separator/runtime_bootstrap.rs`.** The never-replaced-in-place rule was attributed to "issue #168 invariant 9," but the epic lists it as application invariant 5. Reworded to reference the rule by name rather than a brittle list number.

### Optional item (added)

Added a unit test `staging_candidate_rejects_runtime_that_does_not_support_a_model` covering the previously-untested defensive runtime/model-compat bail in `commands/runtime_bootstrap.rs::download_and_stage_candidate_blocking` (the "does not support model" error path). The bail fires before any download, so the test needs no network or filesystem fixture — it reduces the embedded catalog to a single active runtime for the current target with an empty supported-model list and asserts the guard bails.

### Verification

- `cd src-tauri && cargo test -q` — full suite green (lib: 1062 passed / 0 failed; all integration binaries pass, including the real-inference separation tests).
- Docs-only non-Rust change (one markdown file), so no frontend build was required.

Refs #166
