### PR TITLE
fix(hooks): skip the pre-push gates when a push only deletes remote refs

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -25,14 +25,24 @@ pre-commit:
 # Mirrors CI checks (ci.yml) so local pushes fail the same way CI would.
 # pre-commit only formats staged files; these checks verify the entire repo
 # to catch files that slipped through a prior --no-verify or partial staging.
+#
+# Every command runs through skip-delete-only-push.sh: a push that only
+# deletes remote refs transfers no commits, so there is nothing for these
+# repo-wide gates to verify (use_stdin feeds the guard git's ref lines; a
+# deletion is the zero local sha). Without the guard, deleting a stale branch
+# cost a full coverage run — or a --no-verify reflex.
 pre-push:
   parallel: true
   commands:
     format-check:
-      run: node --run format
+      use_stdin: true
+      run: sh scripts/git-hooks/skip-delete-only-push.sh 'node --run format'
     cargo-fmt-check:
-      run: cd src-tauri && cargo fmt --check
+      use_stdin: true
+      run: sh scripts/git-hooks/skip-delete-only-push.sh 'cd src-tauri && cargo fmt --check'
     lint:
-      run: node --run lint
+      use_stdin: true
+      run: sh scripts/git-hooks/skip-delete-only-push.sh 'node --run lint'
     patch-coverage:
-      run: pnpm test:coverage && pnpm check:patch-coverage
+      use_stdin: true
+      run: sh scripts/git-hooks/skip-delete-only-push.sh 'pnpm test:coverage && pnpm check:patch-coverage'

--- a/scripts/git-hooks/skip-delete-only-push.sh
+++ b/scripts/git-hooks/skip-delete-only-push.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Run a pre-push gate command, unless the push only deletes remote refs.
+#
+# git feeds pre-push one "<local ref> <local sha> <remote ref> <remote sha>"
+# line per ref on stdin, and a deletion carries the zero sha as its local sha.
+# A deletion-only push transfers no commits, so the repo-wide gates have
+# nothing to verify — running minutes of tests to delete a stale branch only
+# teaches people to reach for --no-verify, which is the habit these gates
+# exist to prevent. A push that deletes AND updates refs still runs the gates.
+#
+# lefthook must pass `use_stdin: true` for the ref lines to arrive here. Empty
+# stdin therefore runs the gates: if that wiring is ever lost, the failure
+# mode must be "gates run unnecessarily", never "gates silently skipped".
+#
+# Usage (from lefthook.yml): sh scripts/git-hooks/skip-delete-only-push.sh '<command>'
+
+ZERO_SHA=0000000000000000000000000000000000000000
+
+refs=0
+deletions=0
+while read -r _local_ref local_sha _remote_ref _remote_sha; do
+  refs=$((refs + 1))
+  if [ "$local_sha" = "$ZERO_SHA" ]; then
+    deletions=$((deletions + 1))
+  fi
+done
+
+if [ "$refs" -gt 0 ] && [ "$refs" -eq "$deletions" ]; then
+  echo "skipped: this push only deletes remote refs, nothing to verify" >&2
+  exit 0
+fi
+
+exec sh -c "$1"


### PR DESCRIPTION
清理两个仓库的残留远端分支时撞出来的：OpenKara 的 pre-push 门禁对 `git push origin --delete <branch>` 也跑全量 format + lint + 覆盖率。删除推送不传输任何提交，门禁没有可验证的对象——这几分钟的空转正是把人推向 `--no-verify` 习惯的那种摩擦，而这些门禁存在的意义恰恰是防那个习惯。

## 机制（先实验后实现）

git 给 pre-push 的 stdin 每个 ref 一行 `<local ref> <local sha> <remote ref> <remote sha>`，删除的 local sha 是全零。用本地裸仓库假远端对 lefthook v2.1.10 实测了三件事：

1. `use_stdin: true` 能把这些行原样交给命令，`parallel: true` 下每个命令都拿到独立副本；
2. **`{push_files}` 不可用**：删除推送时它仍解析成当前分支相对 upstream 的陈旧 diff（实测列出了无关文件），按它跳过会误判；
3. 混合推送（同一批里既有删除又有更新）stdin 同时包含两种行，可精确区分。

于是每个门禁命令套一层 `scripts/git-hooks/skip-delete-only-push.sh`：读 stdin，**当且仅当所有 ref 都是删除**时退出 0，否则 `exec` 原命令。空 stdin 视为要跑门禁——如果将来 `use_stdin` 接线丢了，失败模式是「门禁白跑」，绝不会是「门禁被静默跳过」。

## 验证（对本地 scratch 远端端到端）

| 场景 | 结果 |
|---|---|
| 仅删除 (`push --delete victim`) | 四个门禁全部跳过，0.3s |
| 带提交推送 | 四个门禁全部执行并通过（24.6s，含覆盖率） |
| 混合（`push HEAD:keeper :victim`） | 四个门禁全部执行并通过（42.7s） |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
