### PR TITLE
fix(shell): isolate ObjC exceptions in the macOS window shell bridge

### DIFF
--- a/src-tauri/src/macos/window_shell.m
+++ b/src-tauri/src/macos/window_shell.m
@@ -160,68 +160,84 @@ bool ok_window_shell_configure_main_window(
 
     __block BOOL configured = NO;
     openkara_run_on_main_thread_sync(^{
-        NSView *view = (__bridge NSView *)ns_view_ptr;
-        NSWindow *window = view.window;
-        if (window == nil) {
-            return;
+        // RATIONALE: This block runs inside a Rust→C callback. An NSException that
+        // escapes it unwinds through `extern "C"`, which Rust converts into
+        // `panic_cannot_unwind` — the process aborts before any window reaches the
+        // screen and the crash log keeps only "panic in a function that cannot
+        // unwind", not the AppKit reason. AppKit raising on new OS releases is a
+        // recurring pattern, so the chrome pass must degrade instead of abort:
+        // `configured = NO` is the existing "use the default mac shell profile"
+        // signal that `window_shell.rs` already recovers through.
+        @try {
+            NSView *view = (__bridge NSView *)ns_view_ptr;
+            NSWindow *window = view.window;
+            if (window == nil) {
+                return;
+            }
+
+            window.titleVisibility = NSWindowTitleHidden;
+            window.titlebarAppearsTransparent = YES;
+            window.tabbingMode = NSWindowTabbingModeDisallowed;
+            window.titlebarSeparatorStyle = NSTitlebarSeparatorStyleNone;
+            // RATIONALE: With full-size content view + a WKWebView filling the client
+            // area, movableByWindowBackground makes AppKit treat broad "background"
+            // hits (including scrollbar gutters) as window moves. We already expose a
+            // narrow drag affordance via data-tauri-drag-region in the web toolbar,
+            // and the packaged app must keep `core:window:allow-start-dragging` in the
+            // default capability or that affordance becomes a dead button.
+            window.movableByWindowBackground = NO;
+
+            // RATIONALE: windowBackgroundColor is near-white under the Light system
+            // appearance, so it painted a white frame behind the WKWebView before
+            // the document's own dark background composited — the white flash seen
+            // at launch. Pin the native backing to the app shell's dark surface
+            // (#121212) so nothing brighter than the UI can ever be exposed.
+            window.backgroundColor = [NSColor colorWithSRGBRed:(18.0 / 255.0)
+                                                        green:(18.0 / 255.0)
+                                                         blue:(18.0 / 255.0)
+                                                        alpha:1.0];
+
+            NSWindowStyleMask styleMask = [window styleMask];
+            if ((styleMask & NSWindowStyleMaskFullSizeContentView) == 0) {
+                [window setStyleMask:(styleMask | NSWindowStyleMaskFullSizeContentView)];
+            }
+
+            [window setToolbar:nil];
+
+            CGFloat resolvedLeadingInset = traffic_light_inset_leading;
+            CGFloat resolvedSidebarHeaderHeight = sidebar_header_height;
+            if (tier_tag != OKWindowShellTierMac) {
+                return;
+            }
+            if (!openkara_layout_native_traffic_lights(
+                window,
+                MAX(sidebar_header_height, OKWindowShellSidebarHeaderHeight),
+                &resolvedLeadingInset,
+                &resolvedSidebarHeaderHeight
+            )) {
+                return;
+            }
+            openkara_configure_traffic_light_zoom_action(window);
+
+            CGFloat resolvedToolbarHeight = toolbar_height;
+
+            if (profile_out != NULL) {
+                NSOperatingSystemVersion version =
+                    [[NSProcessInfo processInfo] operatingSystemVersion];
+                profile_out->macos_major_version = version.majorVersion;
+                profile_out->tier_tag = tier_tag;
+                profile_out->toolbar_height = (NSInteger)lround(resolvedToolbarHeight);
+                profile_out->traffic_light_inset_leading = (NSInteger)lround(resolvedLeadingInset);
+                profile_out->sidebar_header_height = (NSInteger)lround(resolvedSidebarHeaderHeight);
+            }
+
+            configured = YES;
+        } @catch (NSException *exception) {
+            // Re-assert the postcondition instead of relying on `configured = YES`
+            // staying the last statement of the @try.
+            configured = NO;
+            NSLog(@"openkara window shell configuration failed: %@", exception);
         }
-
-        window.titleVisibility = NSWindowTitleHidden;
-        window.titlebarAppearsTransparent = YES;
-        window.tabbingMode = NSWindowTabbingModeDisallowed;
-        window.titlebarSeparatorStyle = NSTitlebarSeparatorStyleNone;
-        // RATIONALE: With full-size content view + a WKWebView filling the client
-        // area, movableByWindowBackground makes AppKit treat broad "background"
-        // hits (including scrollbar gutters) as window moves. We already expose a
-        // narrow drag affordance via data-tauri-drag-region in the web toolbar,
-        // and the packaged app must keep `core:window:allow-start-dragging` in the
-        // default capability or that affordance becomes a dead button.
-        window.movableByWindowBackground = NO;
-
-        // RATIONALE: windowBackgroundColor is near-white under the Light system
-        // appearance, so it painted a white frame behind the WKWebView before
-        // the document's own dark background composited — the white flash seen
-        // at launch. Pin the native backing to the app shell's dark surface
-        // (#121212) so nothing brighter than the UI can ever be exposed.
-        window.backgroundColor = [NSColor colorWithSRGBRed:(18.0 / 255.0)
-                                                    green:(18.0 / 255.0)
-                                                     blue:(18.0 / 255.0)
-                                                    alpha:1.0];
-
-        NSWindowStyleMask styleMask = [window styleMask];
-        if ((styleMask & NSWindowStyleMaskFullSizeContentView) == 0) {
-            [window setStyleMask:(styleMask | NSWindowStyleMaskFullSizeContentView)];
-        }
-
-        [window setToolbar:nil];
-
-        CGFloat resolvedLeadingInset = traffic_light_inset_leading;
-        CGFloat resolvedSidebarHeaderHeight = sidebar_header_height;
-        if (tier_tag != OKWindowShellTierMac) {
-            return;
-        }
-        if (!openkara_layout_native_traffic_lights(
-            window,
-            MAX(sidebar_header_height, OKWindowShellSidebarHeaderHeight),
-            &resolvedLeadingInset,
-            &resolvedSidebarHeaderHeight
-        )) {
-            return;
-        }
-        openkara_configure_traffic_light_zoom_action(window);
-
-        CGFloat resolvedToolbarHeight = toolbar_height;
-
-        if (profile_out != NULL) {
-            NSOperatingSystemVersion version = [[NSProcessInfo processInfo] operatingSystemVersion];
-            profile_out->macos_major_version = version.majorVersion;
-            profile_out->tier_tag = tier_tag;
-            profile_out->toolbar_height = (NSInteger)lround(resolvedToolbarHeight);
-            profile_out->traffic_light_inset_leading = (NSInteger)lround(resolvedLeadingInset);
-            profile_out->sidebar_header_height = (NSInteger)lround(resolvedSidebarHeaderHeight);
-        }
-
-        configured = YES;
     });
 
     return configured;


### PR DESCRIPTION
## Summary

`ok_window_shell_configure_main_window` applies AppKit chrome inside a Rust→C callback. An `NSException` raised by any of those calls unwound straight through the `extern "C"` boundary, so Rust aborted the process with `panic_cannot_unwind` — before a window ever reached the screen, and with the AppKit reason swallowed (the crash log only says "panic in a function that cannot unwind").

The degradation path already existed: `configured == false` makes `apply_main_window_shell` return `Ok(None)` and `initialize_main_window` falls back to the deterministic mac shell profile. The bridge just never got the chance to use it.

## Changes

- Wrap the configuration block body of `ok_window_shell_configure_main_window` in `@try` / `@catch (NSException *)`.
- The `@catch` logs through `NSLog` and re-asserts `configured = NO`, so the failure postcondition is local to the error path instead of a property of `configured = YES` staying the last statement.
- No `@finally`: the three early `return`s inside the block stay legal under `@try`, and ARC (`-fobjc-arc`) emits the cleanup.

Scope stays on `window_shell.m`. `ok_window_shell_detect_profile` only reads `NSProcessInfo` and runs no block, so it is not in this risk class. `airplay_bridge.m` and `import_picker.m` cross the same boundary and are tracked for the 1.0 readiness pass rather than folded in here.

## Test plan

`cargo test` cannot reach an ObjC exception and the in-app probe needs a full launch, so the real bridge was compiled — with a temporary raising probe (`setValue:forKey:` on an undefined key) inserted into the configuration block — into a standalone AppKit harness that builds an `NSWindow` and calls `ok_window_shell_configure_main_window` with its content view:

| Bridge | Result |
| --- | --- |
| `main` (unhardened) | `*** Terminating app due to uncaught exception 'NSUnknownKeyException'` → SIGABRT, exit 134 |
| this branch | `openkara window shell configuration failed: …` logged, call returns `false`, process alive |

The probe and the harness are throwaway; neither is committed.

- [x] Exception-isolation harness — pre-change aborts, post-change degrades
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo build` — bridge compiles and links
- [x] `cargo nextest run -E 'test(window_shell)'` — 2 passed
- [x] `node --run lint`, `node --run format`, `cargo fmt --check` — clean (pre-push gates)
- [ ] Full `cargo nextest run` — left to CI; this change adds no Rust code

## Related issues

Closes #261
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thedavidweng/openkara/pull/265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->