### PR TITLE
fix(shell): reveal the main window when the frontend handshake never arrives

### DIFF
--- a/src-tauri/src/app_runtime.rs
+++ b/src-tauri/src/app_runtime.rs
@@ -367,7 +367,57 @@ pub fn setup_app<R: Runtime>(app: &mut tauri::App<R>) -> Result<(), Box<dyn std:
         );
     }
 
+    // Last statement on purpose: the deadline must start when the event loop
+    // starts, not when setup starts. See `spawn_window_reveal_watchdog`.
+    spawn_window_reveal_watchdog(app);
+
     Ok(())
+}
+
+/// Deadline for the native reveal watchdog, measured from the end of
+/// `setup_app`.
+///
+/// RATIONALE: the main window starts hidden and the reveal is a frontend
+/// handshake (`window_ready`), but macOS suspends animation frames *and* JS
+/// timers in a WKWebView whose window has never been shown. With both
+/// suspended no frontend path out of the hidden state survives, and the app
+/// runs as an invisible process the user can only kill from Activity Monitor.
+///
+/// 2 s is chosen against the healthy handshake budget: after the event loop
+/// starts it costs at most about 900 ms (the 750 ms native-`setTheme` guard in
+/// `useThemeRuntime` plus the 120 ms reveal backstop, on top of two local IPC
+/// reads), so the flash-free path keeps better than 2x headroom to win.
+const WINDOW_REVEAL_WATCHDOG: Duration = Duration::from_secs(2);
+
+/// Reveals the main window if the frontend handshake never arrives.
+///
+/// Spawned as the last step of `setup_app` because Tauri runs the setup hook
+/// on the main thread before the event loop starts: `window_ready` cannot be
+/// served until setup returns, so an earlier deadline would charge startup
+/// work (an ONNX Runtime load, a library scan) against the frontend's budget
+/// and fire on healthy launches.
+fn spawn_window_reveal_watchdog<R: Runtime>(app: &tauri::App<R>) {
+    let Some(window) = app.get_webview_window("main") else {
+        return;
+    };
+
+    thread::spawn(move || {
+        thread::sleep(WINDOW_REVEAL_WATCHDOG);
+
+        // An unreadable visibility state must not be the reason the app stays
+        // invisible, so a failed query counts as hidden.
+        if window.is_visible().unwrap_or(false) {
+            return;
+        }
+
+        tracing::warn!(
+            "main window still hidden after {:?}; revealing without the frontend handshake",
+            WINDOW_REVEAL_WATCHDOG
+        );
+        if let Err(error) = window.show() {
+            tracing::warn!("reveal watchdog could not show the main window: {error}");
+        }
+    });
 }
 
 /// Background startup check for runtime updates, governed by the update

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -1,11 +1,27 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { afterAll, describe, expect, test, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { ErrorBoundary } from "./ErrorBoundary";
+
+const mockWindowReady = vi.fn(() => Promise.resolve());
+vi.mock("@/lib/tauri", () => ({
+  windowReady: () => mockWindowReady(),
+}));
 
 const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 afterAll(() => {
   consoleSpy.mockRestore();
 });
+
+beforeEach(() => {
+  mockWindowReady.mockClear();
+});
+
+function Boom(): never {
+  throw new Error("kaboom");
+}
 
 describe("ErrorBoundary", () => {
   test("renders children when no error is thrown", () => {
@@ -37,5 +53,26 @@ describe("ErrorBoundary", () => {
 
     expect(instance.state.hasError).toBe(false);
     expect(instance.state.error).toBeNull();
+  });
+
+  test("reveals the hidden main window when a child crashes", () => {
+    render(
+      <ErrorBoundary>
+        <Boom />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("Something went wrong")).toBeTruthy();
+    expect(mockWindowReady).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not touch the window on a healthy render", () => {
+    render(
+      <ErrorBoundary>
+        <div>child content</div>
+      </ErrorBoundary>,
+    );
+
+    expect(mockWindowReady).not.toHaveBeenCalled();
   });
 });

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
+import { windowReady } from "@/lib/tauri";
 
 interface ErrorBoundaryProps {
   children: ReactNode;
@@ -24,6 +25,12 @@ export class ErrorBoundary extends Component<
 
   componentDidCatch(error: Error, info: ErrorInfo) {
     console.error("Uncaught error:", error, info.componentStack);
+    // The main window starts hidden and is revealed by the `window_ready`
+    // handshake, which a crash on the way to the first screen never reaches.
+    // The native watchdog covers this too, but it only knows the window is
+    // stuck after its deadline — the boundary knows now, so the panel below
+    // becomes visible immediately instead of after a blank pause.
+    void windowReady();
   }
 
   private handleReload = () => {


### PR DESCRIPTION
## Summary

The main window starts hidden and the only `window.show()` outside the single-instance handler is the `window_ready` command, which the frontend calls from a `requestAnimationFrame` callback with a 120 ms `setTimeout` backstop. macOS suspends animation frames **and** JS timers in a WKWebView whose window has never been shown, so on launches where the app is not activated neither path runs: the page loads, timer-driven JS stays frozen, `window_ready` never arrives, and the app becomes an invisible process the user can only kill from Activity Monitor.

## Changes

- **`spawn_window_reveal_watchdog`** (`src-tauri/src/app_runtime.rs`), called as the last statement of `setup_app`. After 2 s it warns and shows `main` if the window is still hidden. An unreadable `is_visible()` counts as hidden — a failed query must not be the reason the app stays invisible.
  - *Last statement on purpose*: Tauri runs the setup hook on the main thread before the event loop starts, so `window_ready` cannot be served while setup is still running. An earlier deadline would charge a slow ONNX Runtime load against the frontend's budget and fire on healthy launches.
  - *2 s on purpose*: the healthy handshake costs at most ~900 ms after the event loop starts (750 ms native-`setTheme` guard in `useThemeRuntime` + 120 ms reveal backstop, plus two local IPC reads). 2 s keeps better than 2× headroom for the flash-free path while meeting the issue's "within ~1-2 s" bar.
- **`ErrorBoundary.componentDidCatch`** now also calls `windowReady()`. The watchdog covers a render crash too, but the boundary knows at the instant of the crash, so the crash panel that component already renders becomes visible immediately instead of after a blank pause.

### Deliberate deviation from the proposal: no unconditional `on_page_load` reveal

`:root` defaults to the dark token set (`src/styles/globals.css:58`) and `useThemeRuntime` writes `data-theme` only after settings hydrate — which is exactly why `startupThemeReady` gates the reveal today. `PageLoadEvent::Finished` fires *before* the settings IPC round trip resolves in essentially every launch, so an unconditional page-load reveal would stop being a fallback and become the primary reveal path, showing a dark shell that then flips to light for every light-theme user.

A single native watchdog closes every failure mode the layered design covers — frozen timers, a JS crash before mount, a bundle that never loads, a navigation that never completes — because it does not depend on the webview reaching any particular state. The layered version only buys a faster reveal in one of those four cases, and pays for it with the flash-free launch.

## Test plan

Both launch paths were smoke-tested against the debug binary with `HOME` redirected to a scratch directory, so the real app data directory was untouched:

| Scenario | Result |
| --- | --- |
| Dev server down (page never loads) | `03:51:28.616 INFO OpenKara starting` → `03:51:30.736 WARN main window still hidden after 2s; revealing without the frontend handshake` — window revealed, no follow-up "could not show" warning |
| Dev server up (healthy launch) | No warning, no error in the whole run — the frontend handshake won |

- [x] Watchdog fires at the deadline with the dev server down
- [x] Watchdog stays silent on a healthy launch
- [x] `pnpm vitest run src/components src/runtime` — 943 passed (104 files), including two new `ErrorBoundary` cases: a crashing child calls `windowReady` once, a healthy render never does
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `node --run lint`, `node --run format`, `cargo fmt --check`, patch coverage — clean (pre-push gates)

## Related issues

Closes #260
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thedavidweng/openkara/pull/266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->