### PR TITLE
feat(shell): persist main window geometry across launches

### DIFF
--- a/packaging/flatpak/generated/cargo-sources.json
+++ b/packaging/flatpak/generated/cargo-sources.json
@@ -6086,6 +6086,19 @@
   {
     "type": "archive",
     "archive-type": "tar-gzip",
+    "url": "https://static.crates.io/crates/tauri-plugin-window-state/tauri-plugin-window-state-2.4.1.crate",
+    "sha256": "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704",
+    "dest": "cargo/vendor/tauri-plugin-window-state-2.4.1"
+  },
+  {
+    "type": "inline",
+    "contents": "{\"package\":\"73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704\",\"files\":{}}",
+    "dest": "cargo/vendor/tauri-plugin-window-state-2.4.1",
+    "dest-filename": ".cargo-checksum.json"
+  },
+  {
+    "type": "archive",
+    "archive-type": "tar-gzip",
     "url": "https://static.crates.io/crates/tauri-runtime/tauri-runtime-2.11.3.crate",
     "sha256": "b0b4bc95aed361b0019067d189a1174a603d460d0f6c72606512d59fc9c12ec8",
     "dest": "cargo/vendor/tauri-runtime-2.11.3"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3086,6 +3086,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
+ "tauri-plugin-window-state",
  "tempfile",
  "thiserror 2.0.19",
  "tiny_http",
@@ -5065,6 +5066,21 @@ dependencies = [
  "url",
  "windows-sys 0.60.2",
  "zip 4.6.1",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.13.1",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.19",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -63,6 +63,7 @@ image = { version = "0.25.10", default-features = false, features = ["jpeg", "pn
 realfft = "3.5.0"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 tracing-appender = "0.2.3"
+tauri-plugin-window-state = "2.4.1"
 
 [dev-dependencies]
 filetime = "0.2.29"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -223,7 +223,29 @@ pub fn run() {
     #[cfg(desktop)]
     let builder = builder
         .plugin(tauri_plugin_updater::Builder::new().build())
-        .plugin(tauri_plugin_process::init());
+        .plugin(tauri_plugin_process::init())
+        // Window geometry (#263). The flags are spelled out rather than
+        // `StateFlags::all()` because the other three fight designs the app
+        // already committed to: VISIBLE would `show()` during restore and race
+        // the hidden-start reveal handshake (and could persist "hidden" from a
+        // crashed run), FULLSCREEN would reintroduce the AppKit full-screen
+        // state the zoom-button retarget in `window_shell.m` deliberately
+        // avoids, and DECORATIONS would make the saved file a second writer for
+        // a titlebar the native shell pass configures on every launch.
+        //
+        // The fullscreen player is denied: it is created on the monitor the
+        // user picked with geometry derived from that monitor, so a restored
+        // frame would override the selection.
+        .plugin(
+            tauri_plugin_window_state::Builder::new()
+                .with_state_flags(
+                    tauri_plugin_window_state::StateFlags::SIZE
+                        | tauri_plugin_window_state::StateFlags::POSITION
+                        | tauri_plugin_window_state::StateFlags::MAXIMIZED,
+                )
+                .with_denylist(&["fullscreen-player"])
+                .build(),
+        );
 
     #[cfg(target_os = "macos")]
     let builder = builder


### PR DESCRIPTION
## Summary

The main window was created at a fixed 1280×800 with `center: true` on every launch, so user resizes and repositions were discarded on restart. `tauri-plugin-window-state` restores size, position, and maximized state.

## Changes

- Register `tauri-plugin-window-state` 2.4.1 inside the existing `#[cfg(desktop)]` plugin block, with **`SIZE | POSITION | MAXIMIZED`**.
- `with_denylist(&["fullscreen-player"])`.
- Regenerate `packaging/flatpak/generated/cargo-sources.json` for the new crate.

### Why the flags are spelled out instead of `StateFlags::all()`

Each excluded flag fights a design the app already committed to:

- **`VISIBLE`** — `restore_state` calls `show()` + `set_focus()` when this flag is set. That races the hidden-start reveal handshake, and would persist "hidden" from a crashed run.
- **`FULLSCREEN`** — the green traffic light is deliberately retargeted to `performZoom:` in `window_shell.m` because the product needs its toolbar and window controls to stay available. Restoring real AppKit full screen reintroduces exactly the state that design avoids.
- **`DECORATIONS`** — the native shell pass owns the titlebar on every launch; a saved decoration state would be a second writer for the same property.

The fullscreen player is denied because `openFullscreenPlayer` computes `x/y/width/height` from the monitor the user picked, divided by that monitor's scale factor — a restored frame would override the selection. A denylist entry beats `with_filter` here since the exclusion is a fixed label.

No capability change: the plugin's `save_window_state` / `restore_state` / `filename` commands are never invoked from the frontend.

### Two behaviours confirmed by reading the crate, not assumed

- Position restore is already monitor-aware — it only applies a saved position when some `available_monitors()` entry intersects the saved frame, so an unplugged display degrades to "let the OS place it" rather than an off-screen window.
- On first launch the cache has no entry and `restore_state` short-circuits on `state != WindowState::default()`, so `center: true` still wins; saved state takes over from the second launch.

## Test plan

No unit test — this is plugin configuration, and a test asserting that the flags passed are the flags passed proves nothing. Verified instead by an end-to-end round trip against a scratch `HOME`, with a throwaway probe (not committed) reporting geometry and forcing a graceful `AppHandle::exit(0)`:

| Step | Observed |
| --- | --- |
| Seed `.window-state.json` with `903x641 @ (137,149)`, launch | window comes up `904x642 @ (136,150)` — the 1 px drift is logical/physical rounding on a 2× display |
| Resize to `1111x777` logical, then exit through `RunEvent::Exit` | file rewritten to `2222x1554 @ (444,666)` |
| Inspect saved file | `main` is the only key |

The window still starts hidden and reveals through the normal handshake in every run.

A measured correction to the plan I recorded on the issue: `on_window_ready` fires **after** the `setup` hook, not before — a geometry read inside `setup_app` still saw `2560x1602`. The conclusion is unchanged, since the native shell pass only mutates the titlebar, style mask, and traffic-light layout, none of which move or resize the window.

- [x] Geometry restore round trip (seed → launch → resize → graceful exit → save)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `pnpm test:coverage` — 2075 passed after regenerating the Flatpak Cargo sources (3 packaging tests correctly caught the missing crate first)

## Related issues

Closes #263
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thedavidweng/openkara/pull/267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->