### PR TITLE
fix(setup): make the first-run flow honest about what it is asking

### DIFF
--- a/src/components/Settings/LibrarySetup.render.test.tsx
+++ b/src/components/Settings/LibrarySetup.render.test.tsx
@@ -103,6 +103,34 @@ describe("LibrarySetup destructive error surfaces", () => {
     });
   }
 
+  test("counts the remote-provider screen as part of the library step", async () => {
+    const root = createRoot(container);
+    await advanceToLibraryStep(root);
+
+    const remote = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Use remote repository"),
+    );
+    await act(async () => {
+      remote?.click();
+    });
+
+    // Three real stages, and picking a provider must not advance past the
+    // library dot - the provider screen is a branch of that step, not a step.
+    const dots = Array.from(
+      container.querySelectorAll("div.rounded-full.h-1\\.5, div.h-1\\.5"),
+    ).filter((dot) => dot.className.includes("rounded-full"));
+    expect(dots).toHaveLength(3);
+    expect(
+      dots.filter((dot) =>
+        dot.className.includes("bg-[var(--color-control-primary)]"),
+      ),
+    ).toHaveLength(2);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   test("renders library-step errors with the destructive text token", async () => {
     const root = createRoot(container);
     await advanceToLibraryStep(root);
@@ -132,7 +160,7 @@ describe("LibrarySetup destructive error surfaces", () => {
     await advanceToLibraryStep(root);
 
     const remoteButton = Array.from(container.querySelectorAll("button")).find(
-      (button) => button.textContent?.includes("Open remote repository"),
+      (button) => button.textContent?.includes("Use remote repository"),
     );
     expect(remoteButton).toBeTruthy();
     await act(async () => {
@@ -192,17 +220,18 @@ describe("LibrarySetup destructive error surfaces", () => {
     mockCreateLocalLibrary.mockResolvedValue(undefined);
     await clickButtonContaining("Create new local library");
 
-    // Stem mode → model step.
-    await clickButtonContaining("setup.continue");
-    expect(container.innerHTML).toContain("setup.chooseModel");
-    expect(container.innerHTML).toContain("settings.modelVariant.htdemucs");
-    expect(container.innerHTML).toContain("settings.modelVariant.htdemucsFt");
+    // Stem mode is the last step: the model choice is not a first-run question.
+    expect(container.innerHTML).not.toContain("settings.modelVariant.htdemucs");
 
-    await clickButtonContaining("settings.modelVariant.htdemucsFt");
+    // Back returns to the library step rather than the deleted model step.
+    await clickButtonContaining("setup.back");
+    expect(container.innerHTML).toContain("Create new local library");
+    await clickButtonContaining("Create new local library");
+
     await clickButtonContaining("setup.getStarted");
 
     expect(mockSetStemMode).toHaveBeenCalledWith("four_stem");
-    expect(mockSetModelVariant).toHaveBeenCalledWith("htdemucs_ft");
+    expect(mockSetModelVariant).not.toHaveBeenCalled();
     expect(onComplete).toHaveBeenCalled();
 
     await act(async () => {

--- a/src/components/Settings/LibrarySetup.tsx
+++ b/src/components/Settings/LibrarySetup.tsx
@@ -13,25 +13,19 @@ import {
   ChevronLeft,
   Check,
   Search,
-  Sparkles,
 } from "lucide-react";
 import { getErrorMessage } from "@/lib/errors";
 import * as api from "@/lib/tauri";
 import i18next, { SUPPORTED_LANGUAGES, detectSystemLanguage } from "@/lib/i18n";
 import { useSettingsStore } from "@/stores/settings-store";
-import type { ModelVariant, RemoteLibraryProvider } from "@/types/ipc";
+import type { RemoteLibraryProvider } from "@/types/ipc";
 import { runRemoteLibraryRegistrationFlow } from "./remote-library-flow";
 import {
   getRemoteLibraryConnectedMessage,
   getRemoteProviderDisplayName,
 } from "./remote-library-copy";
 
-type Step =
-  | "language"
-  | "library"
-  | "remoteProvider"
-  | "stemMode"
-  | "modelVariant";
+type Step = "language" | "library" | "remoteProvider" | "stemMode";
 type LibraryChoiceKind = "create_local" | "open_local" | "open_remote";
 
 interface RemoteProviderChoice {
@@ -66,7 +60,7 @@ export const librarySetupChoices: LibraryChoice[] = [
   {
     kind: "open_remote",
     icon: Globe,
-    title: "setup.openRemoteLibrary",
+    title: "setup.useRemoteRepository",
     description: "setup.openRemoteLibraryDescription",
   },
 ];
@@ -101,14 +95,13 @@ interface LibrarySetupProps {
 }
 
 function StepIndicator({ current }: { current: Step }) {
-  const steps: Step[] = [
-    "language",
-    "library",
-    "remoteProvider",
-    "stemMode",
-    "modelVariant",
-  ];
-  const currentIndex = steps.indexOf(current);
+  const steps: Step[] = ["language", "library", "stemMode"];
+  // The remote-provider screen is a branch of the library step, not a stage of
+  // its own. Giving it a dot promised a step most users never reach and left
+  // the indicator permanently one short.
+  const currentIndex = steps.indexOf(
+    current === "remoteProvider" ? "library" : current,
+  );
 
   return (
     <div className="flex items-center justify-center gap-2">
@@ -142,7 +135,6 @@ export function LibrarySetup({ onComplete }: LibrarySetupProps) {
   const { t } = useTranslation();
   const settingsLanguage = useSettingsStore((s) => s.language);
   const settingsStemMode = useSettingsStore((s) => s.stemMode);
-  const settingsModelVariant = useSettingsStore((s) => s.modelVariant);
   const patchAppSettings = useSettingsStore((s) => s.patchAppSettings);
   const hydrateAppSettings = useSettingsStore((s) => s.hydrateAppSettings);
   const [step, setStep] = useState<Step>("language");
@@ -168,8 +160,6 @@ export function LibrarySetup({ onComplete }: LibrarySetupProps) {
   const [selectedStemModeDraft, setSelectedStemModeDraft] = useState<
     "two_stem" | "four_stem" | null
   >(null);
-  const [selectedModelVariantDraft, setSelectedModelVariantDraft] =
-    useState<ModelVariant | null>(null);
   const remoteAuthSessionIdRef = useRef<string | null>(null);
   const selectedLanguage =
     selectedLanguageDraft ??
@@ -177,8 +167,6 @@ export function LibrarySetup({ onComplete }: LibrarySetupProps) {
     i18next.resolvedLanguage ??
     detectSystemLanguage();
   const selectedStemMode = selectedStemModeDraft ?? settingsStemMode;
-  const selectedModelVariant =
-    selectedModelVariantDraft ?? settingsModelVariant;
 
   const resolveSingleDirectory = (selected: string | string[] | null) =>
     typeof selected === "string" ? selected : (selected?.[0] ?? null);
@@ -313,10 +301,7 @@ export function LibrarySetup({ onComplete }: LibrarySetupProps) {
 
   const handleFinish = async () => {
     try {
-      await api.setStemMode(selectedStemMode);
-      // The chosen variant is what the first separation auto-downloads, so it
-      // must be persisted before the user reaches the library.
-      const settings = await api.setModelVariant(selectedModelVariant);
+      const settings = await api.setStemMode(selectedStemMode);
       hydrateAppSettings(settings);
     } catch {
       // non-fatal
@@ -360,7 +345,12 @@ export function LibrarySetup({ onComplete }: LibrarySetupProps) {
                   />
                 </div>
               )}
-              <div className="max-h-[22rem] space-y-3 overflow-y-auto">
+              {/* Height follows the window instead of a fixed 22rem, which
+                  was shorter than the viewport on every desktop size and left
+                  the list looking cut off with empty space below it. The bottom
+                  fade is the scroll affordance: without it the clipped row reads
+                  as a broken layout rather than "more below". */}
+              <div className="max-h-[60vh] space-y-3 overflow-y-auto [mask-image:linear-gradient(to_bottom,#000_calc(100%-2.5rem),transparent)]">
                 {SUPPORTED_LANGUAGES.filter((lang) => {
                   const q = languageFilter.trim().toLowerCase();
                   if (!q) return true;
@@ -432,11 +422,11 @@ export function LibrarySetup({ onComplete }: LibrarySetupProps) {
                           : handleOpenRemote
                     }
                     disabled={disabled}
-                    className="flex w-full items-center gap-3 rounded-lg border border-[var(--color-border-light)] bg-[var(--color-sidebar)] px-5 py-4 text-left transition-colors hover:bg-[var(--color-hover)] disabled:opacity-50"
+                    className="flex w-full items-start gap-3 rounded-lg border border-[var(--color-border-light)] bg-[var(--color-sidebar)] px-5 py-4 text-left transition-colors hover:bg-[var(--color-hover)] disabled:opacity-50"
                   >
                     <Icon
                       size={20}
-                      className={`shrink-0 ${
+                      className={`mt-0.5 shrink-0 ${
                         choice.kind === "open_remote"
                           ? "text-[var(--color-control-primary)]"
                           : choice.kind === "create_local"
@@ -452,7 +442,7 @@ export function LibrarySetup({ onComplete }: LibrarySetupProps) {
                               ? "Create new local library"
                               : choice.kind === "open_local"
                                 ? "Open existing local library"
-                                : "Open remote repository",
+                                : "Use remote repository",
                         })}
                       </div>
                       <div className="text-[12px] text-[var(--color-text-dim)]">
@@ -835,7 +825,7 @@ export function LibrarySetup({ onComplete }: LibrarySetupProps) {
             <div className="space-y-3">
               <button
                 onClick={() => setSelectedStemModeDraft("two_stem")}
-                className={`flex w-full items-center gap-3 rounded-lg border px-5 py-4 text-left transition-colors ${
+                className={`flex w-full items-start gap-3 rounded-lg border px-5 py-4 text-left transition-colors ${
                   selectedStemMode === "two_stem"
                     ? "border-[var(--color-control-selected-border)] bg-[var(--color-control-selected-bg)]"
                     : "border-[var(--color-border-light)] bg-[var(--color-sidebar)] hover:bg-[var(--color-hover)]"
@@ -843,7 +833,7 @@ export function LibrarySetup({ onComplete }: LibrarySetupProps) {
               >
                 <Mic2
                   size={20}
-                  className="shrink-0 text-[var(--color-control-primary)]"
+                  className="mt-0.5 shrink-0 text-[var(--color-control-primary)]"
                 />
                 <div className="flex-1">
                   <div className="text-[14px] font-medium text-[var(--color-text)]">
@@ -859,14 +849,14 @@ export function LibrarySetup({ onComplete }: LibrarySetupProps) {
                 {selectedStemMode === "two_stem" && (
                   <Check
                     size={16}
-                    className="shrink-0 text-[var(--color-control-primary)]"
+                    className="mt-0.5 shrink-0 text-[var(--color-control-primary)]"
                   />
                 )}
               </button>
 
               <button
                 onClick={() => setSelectedStemModeDraft("four_stem")}
-                className={`flex w-full items-center gap-3 rounded-lg border px-5 py-4 text-left transition-colors ${
+                className={`flex w-full items-start gap-3 rounded-lg border px-5 py-4 text-left transition-colors ${
                   selectedStemMode === "four_stem"
                     ? "border-[var(--color-control-selected-border)] bg-[var(--color-control-selected-bg)]"
                     : "border-[var(--color-border-light)] bg-[var(--color-sidebar)] hover:bg-[var(--color-hover)]"
@@ -874,7 +864,7 @@ export function LibrarySetup({ onComplete }: LibrarySetupProps) {
               >
                 <Layers
                   size={20}
-                  className="shrink-0 text-[var(--color-control-primary)]"
+                  className="mt-0.5 shrink-0 text-[var(--color-control-primary)]"
                 />
                 <div className="flex-1">
                   <div className="text-[14px] font-medium text-[var(--color-text)]">
@@ -890,94 +880,10 @@ export function LibrarySetup({ onComplete }: LibrarySetupProps) {
                 {selectedStemMode === "four_stem" && (
                   <Check
                     size={16}
-                    className="shrink-0 text-[var(--color-control-primary)]"
+                    className="mt-0.5 shrink-0 text-[var(--color-control-primary)]"
                   />
                 )}
               </button>
-            </div>
-
-            <button
-              onClick={() => setStep("modelVariant")}
-              className="w-full rounded-lg bg-[var(--color-control-primary)] px-5 py-3 text-[14px] font-medium text-[var(--color-control-primary-foreground)] transition-opacity hover:opacity-90"
-            >
-              {t("setup.continue")}
-            </button>
-
-            <button
-              onClick={() => setStep("library")}
-              className="flex items-center justify-center gap-1 text-[13px] text-[var(--color-text-dim)] transition-colors hover:text-[var(--color-text)]"
-            >
-              <ChevronLeft size={14} />
-              {t("setup.back")}
-            </button>
-          </>
-        )}
-
-        {step === "modelVariant" && (
-          <>
-            <div className="flex flex-col items-center gap-4">
-              <div className="flex items-center justify-center">
-                <Sparkles
-                  size={32}
-                  className="text-[var(--color-control-primary)]"
-                />
-              </div>
-              <h1 className="text-2xl font-bold text-[var(--color-text)]">
-                {t("setup.chooseModel")}
-              </h1>
-              <p className="text-[14px] leading-relaxed text-[var(--color-text-dim)]">
-                {t("setup.modelDescription")}
-              </p>
-            </div>
-
-            <div className="space-y-3">
-              {(
-                [
-                  {
-                    variant: "htdemucs",
-                    title: t("settings.modelVariant.htdemucs"),
-                    subtitle: t("settings.modelVariant.htdemucsDescription"),
-                  },
-                  {
-                    variant: "htdemucs_ft",
-                    title: t("settings.modelVariant.htdemucsFt"),
-                    subtitle: t("settings.modelVariant.htdemucsFtDescription"),
-                  },
-                ] satisfies ReadonlyArray<{
-                  variant: ModelVariant;
-                  title: string;
-                  subtitle: string;
-                }>
-              ).map((option) => (
-                <button
-                  key={option.variant}
-                  onClick={() => setSelectedModelVariantDraft(option.variant)}
-                  className={`flex w-full items-center gap-3 rounded-lg border px-5 py-4 text-left transition-colors ${
-                    selectedModelVariant === option.variant
-                      ? "border-[var(--color-control-selected-border)] bg-[var(--color-control-selected-bg)]"
-                      : "border-[var(--color-border-light)] bg-[var(--color-sidebar)] hover:bg-[var(--color-hover)]"
-                  }`}
-                >
-                  <Sparkles
-                    size={20}
-                    className="shrink-0 text-[var(--color-control-primary)]"
-                  />
-                  <div className="flex-1">
-                    <div className="text-[14px] font-medium text-[var(--color-text)]">
-                      {option.title}
-                    </div>
-                    <div className="text-[12px] text-[var(--color-text-dim)]">
-                      {option.subtitle}
-                    </div>
-                  </div>
-                  {selectedModelVariant === option.variant && (
-                    <Check
-                      size={16}
-                      className="shrink-0 text-[var(--color-control-primary)]"
-                    />
-                  )}
-                </button>
-              ))}
             </div>
 
             <p className="text-[12px] text-[var(--color-text-dimmer)]">
@@ -992,7 +898,7 @@ export function LibrarySetup({ onComplete }: LibrarySetupProps) {
             </button>
 
             <button
-              onClick={() => setStep("stemMode")}
+              onClick={() => setStep("library")}
               className="flex items-center justify-center gap-1 text-[13px] text-[var(--color-text-dim)] transition-colors hover:text-[var(--color-text)]"
             >
               <ChevronLeft size={14} />

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -29,6 +29,7 @@
     "chooseLanguage": "Sprache wählen",
     "openRemoteLibrary": "Remote-Anbieter wählen",
     "openRemoteLibraryDescription": "Verbinden Sie Google Drive, Dropbox oder WebDAV mit Ihrem Remote-Repository.",
+    "useRemoteRepository": "Remote-Repository verwenden",
     "remoteProvider": {
       "googleDrive": {
         "title": "Google Drive",
@@ -55,9 +56,6 @@
     "fourStemDetail": "Mehr Kontrolle über einzelne Instrumente, ~2× Speicherplatz",
     "getStarted": "Los geht’s",
     "back": "Zurück",
-    "continue": "Weiter",
-    "chooseModel": "KI-Modell wählen",
-    "modelDescription": "Dieses Modell trennt den Gesang von der Musik. Sie können es später in den Einstellungen ändern.",
     "modelDownloadHint": "Das Modell und seine Laufzeit werden beim ersten Trennen eines Songs automatisch heruntergeladen."
   },
   "sidebar": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -29,6 +29,7 @@
     "chooseLanguage": "Choose a language",
     "openRemoteLibrary": "Choose a remote provider",
     "openRemoteLibraryDescription": "Connect Google Drive, Dropbox, or WebDAV to your remote repository.",
+    "useRemoteRepository": "Use remote repository",
     "remoteProvider": {
       "googleDrive": {
         "title": "Google Drive",
@@ -55,9 +56,6 @@
     "fourStemDetail": "More control over individual instruments, ~2× disk space",
     "getStarted": "Get Started",
     "back": "Back",
-    "continue": "Continue",
-    "chooseModel": "Choose AI Model",
-    "modelDescription": "This model separates vocals from the music. You can change it later in settings.",
     "modelDownloadHint": "The model and its runtime download automatically the first time you separate a song."
   },
   "sidebar": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -29,6 +29,7 @@
     "chooseLanguage": "Elige un idioma",
     "openRemoteLibrary": "Elige un proveedor remoto",
     "openRemoteLibraryDescription": "Conecta Google Drive, Dropbox o WebDAV a tu repositorio remoto.",
+    "useRemoteRepository": "Usar repositorio remoto",
     "remoteProvider": {
       "googleDrive": {
         "title": "Google Drive",
@@ -55,9 +56,6 @@
     "fourStemDetail": "Más control sobre cada instrumento, ~2× de espacio en disco",
     "getStarted": "Comenzar",
     "back": "Atrás",
-    "continue": "Continuar",
-    "chooseModel": "Elige el modelo de IA",
-    "modelDescription": "Este modelo separa la voz de la música. Puedes cambiarlo más tarde en los ajustes.",
     "modelDownloadHint": "El modelo y su runtime se descargan automáticamente la primera vez que separas una canción."
   },
   "sidebar": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -29,6 +29,7 @@
     "chooseLanguage": "Choisissez une langue",
     "openRemoteLibrary": "Choisissez un fournisseur distant",
     "openRemoteLibraryDescription": "Connectez Google Drive, Dropbox ou WebDAV à votre dépôt distant.",
+    "useRemoteRepository": "Utiliser un dépôt distant",
     "remoteProvider": {
       "googleDrive": {
         "title": "Google Drive",
@@ -55,9 +56,6 @@
     "fourStemDetail": "Plus de contrôle sur chaque instrument, espace disque ~2×",
     "getStarted": "Commencer",
     "back": "Retour",
-    "continue": "Continuer",
-    "chooseModel": "Choisissez le modèle d'IA",
-    "modelDescription": "Ce modèle sépare les voix de la musique. Vous pourrez le modifier plus tard dans les réglages.",
     "modelDownloadHint": "Le modèle et son runtime se téléchargent automatiquement la première fois que vous séparez une chanson."
   },
   "sidebar": {

--- a/src/locales/id.json
+++ b/src/locales/id.json
@@ -29,6 +29,7 @@
     "chooseLanguage": "Pilih bahasa",
     "openRemoteLibrary": "Pilih penyedia jarak jauh",
     "openRemoteLibraryDescription": "Hubungkan Google Drive, Dropbox, atau WebDAV ke repositori jarak jauh Anda.",
+    "useRemoteRepository": "Gunakan repositori jarak jauh",
     "remoteProvider": {
       "googleDrive": {
         "title": "Google Drive",
@@ -55,9 +56,6 @@
     "fourStemDetail": "Lebih banyak kontrol atas tiap instrumen, ~2× ruang disk",
     "getStarted": "Mulai",
     "back": "Kembali",
-    "continue": "Lanjutkan",
-    "chooseModel": "Pilih Model AI",
-    "modelDescription": "Model ini memisahkan vokal dari musik. Anda dapat mengubahnya nanti di pengaturan.",
     "modelDownloadHint": "Model dan runtime-nya diunduh otomatis saat pertama kali Anda memisahkan sebuah lagu."
   },
   "sidebar": {

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -29,6 +29,7 @@
     "chooseLanguage": "Scegli una lingua",
     "openRemoteLibrary": "Scegli un provider remoto",
     "openRemoteLibraryDescription": "Connetti Google Drive, Dropbox o WebDAV al tuo repository remoto.",
+    "useRemoteRepository": "Usa repository remoto",
     "remoteProvider": {
       "googleDrive": {
         "title": "Google Drive",
@@ -55,9 +56,6 @@
     "fourStemDetail": "Maggiore controllo sui singoli strumenti, spazio su disco ~2×",
     "getStarted": "Inizia",
     "back": "Indietro",
-    "continue": "Continua",
-    "chooseModel": "Scegli il modello IA",
-    "modelDescription": "Questo modello separa la voce dalla musica. Potrai cambiarlo in seguito nelle impostazioni.",
     "modelDownloadHint": "Il modello e il suo runtime si scaricano automaticamente la prima volta che separi una canzone."
   },
   "sidebar": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -29,6 +29,7 @@
     "chooseLanguage": "言語を選択",
     "openRemoteLibrary": "リモートプロバイダーを選択",
     "openRemoteLibraryDescription": "Google ドライブ、Dropbox、または WebDAV をリモートリポジトリに接続します。",
+    "useRemoteRepository": "リモートリポジトリを使う",
     "remoteProvider": {
       "googleDrive": {
         "title": "Google ドライブ",
@@ -55,9 +56,6 @@
     "fourStemDetail": "各楽器を個別に調整可能、ディスク使用量は約2倍",
     "getStarted": "始める",
     "back": "戻る",
-    "continue": "続ける",
-    "chooseModel": "AI モデルを選択",
-    "modelDescription": "このモデルが音楽からボーカルを分離します。後から設定で変更できます。",
     "modelDownloadHint": "モデルとそのランタイムは、初めて楽曲を分離するときに自動でダウンロードされます。"
   },
   "sidebar": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -29,6 +29,7 @@
     "chooseLanguage": "언어 선택",
     "openRemoteLibrary": "원격 제공자 선택",
     "openRemoteLibraryDescription": "Google Drive, Dropbox 또는 WebDAV를 원격 저장소로 연결하세요.",
+    "useRemoteRepository": "원격 저장소 사용",
     "remoteProvider": {
       "googleDrive": {
         "title": "Google Drive",
@@ -55,9 +56,6 @@
     "fourStemDetail": "개별 악기 조절 가능, 디스크 공간 약 2배",
     "getStarted": "시작하기",
     "back": "뒤로",
-    "continue": "계속",
-    "chooseModel": "AI 모델 선택",
-    "modelDescription": "이 모델은 음악에서 보컬을 분리해요. 나중에 설정에서 바꿀 수 있어요.",
     "modelDownloadHint": "모델과 런타임은 처음 노래를 분리할 때 자동으로 다운로드돼요."
   },
   "sidebar": {

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -29,6 +29,7 @@
     "chooseLanguage": "Kies een taal",
     "openRemoteLibrary": "Kies een externe provider",
     "openRemoteLibraryDescription": "Verbind Google Drive, Dropbox of WebDAV met je externe opslag.",
+    "useRemoteRepository": "Externe repository gebruiken",
     "remoteProvider": {
       "googleDrive": {
         "title": "Google Drive",
@@ -55,9 +56,6 @@
     "fourStemDetail": "Meer controle over losse instrumenten, ~2× schijfruimte",
     "getStarted": "Aan de slag",
     "back": "Terug",
-    "continue": "Doorgaan",
-    "chooseModel": "Kies AI-model",
-    "modelDescription": "Dit model scheidt de zang van de muziek. Je kunt dit later wijzigen in de instellingen.",
     "modelDownloadHint": "Het model en de runtime worden automatisch gedownload wanneer je voor het eerst een nummer scheidt."
   },
   "sidebar": {

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -29,6 +29,7 @@
     "chooseLanguage": "Wybierz język",
     "openRemoteLibrary": "Wybierz dostawcę zdalnego",
     "openRemoteLibraryDescription": "Połącz Google Drive, Dropbox lub WebDAV ze swoim zdalnym repozytorium.",
+    "useRemoteRepository": "Użyj zdalnego repozytorium",
     "remoteProvider": {
       "googleDrive": {
         "title": "Google Drive",
@@ -55,9 +56,6 @@
     "fourStemDetail": "Większa kontrola nad poszczególnymi instrumentami, ~2× więcej miejsca na dysku",
     "getStarted": "Rozpocznij",
     "back": "Wstecz",
-    "continue": "Dalej",
-    "chooseModel": "Wybierz model AI",
-    "modelDescription": "Ten model oddziela wokal od muzyki. Możesz go później zmienić w ustawieniach.",
     "modelDownloadHint": "Model i jego środowisko uruchomieniowe pobiorą się automatycznie przy pierwszym rozdzielaniu utworu."
   },
   "sidebar": {

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -29,6 +29,7 @@
     "chooseLanguage": "Escolha um idioma",
     "openRemoteLibrary": "Escolha um provedor remoto",
     "openRemoteLibraryDescription": "Conecte o Google Drive, o Dropbox ou o WebDAV ao seu repositório remoto.",
+    "useRemoteRepository": "Usar repositório remoto",
     "remoteProvider": {
       "googleDrive": {
         "title": "Google Drive",
@@ -55,9 +56,6 @@
     "fourStemDetail": "Mais controle sobre instrumentos individuais, ~2× de espaço em disco",
     "getStarted": "Começar",
     "back": "Voltar",
-    "continue": "Continuar",
-    "chooseModel": "Escolha o modelo de IA",
-    "modelDescription": "Este modelo separa o vocal da música. Você pode alterá-lo depois nas configurações.",
     "modelDownloadHint": "O modelo e seu runtime são baixados automaticamente na primeira vez que você separa uma música."
   },
   "sidebar": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -29,6 +29,7 @@
     "chooseLanguage": "Выберите язык",
     "openRemoteLibrary": "Выберите удалённого провайдера",
     "openRemoteLibraryDescription": "Подключите Google Drive, Dropbox или WebDAV в качестве удалённого репозитория.",
+    "useRemoteRepository": "Использовать удалённый репозиторий",
     "remoteProvider": {
       "googleDrive": {
         "title": "Google Drive",
@@ -55,9 +56,6 @@
     "fourStemDetail": "Больше контроля над отдельными инструментами, ~2× места на диске",
     "getStarted": "Начать",
     "back": "Назад",
-    "continue": "Продолжить",
-    "chooseModel": "Выберите модель ИИ",
-    "modelDescription": "Эта модель отделяет вокал от музыки. Её можно изменить позже в настройках.",
     "modelDownloadHint": "Модель и её среда выполнения загружаются автоматически при первом разделении песни."
   },
   "sidebar": {

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -29,6 +29,7 @@
     "chooseLanguage": "เลือกภาษา",
     "openRemoteLibrary": "เลือกผู้ให้บริการระยะไกล",
     "openRemoteLibraryDescription": "เชื่อมต่อ Google Drive, Dropbox หรือ WebDAV เข้ากับที่เก็บระยะไกลของคุณ",
+    "useRemoteRepository": "ใช้ที่เก็บระยะไกล",
     "remoteProvider": {
       "googleDrive": {
         "title": "Google Drive",
@@ -55,9 +56,6 @@
     "fourStemDetail": "ควบคุมเครื่องดนตรีแต่ละชิ้นได้มากขึ้น ใช้พื้นที่ดิสก์ราว 2 เท่า",
     "getStarted": "เริ่มต้นใช้งาน",
     "back": "ย้อนกลับ",
-    "continue": "ดำเนินการต่อ",
-    "chooseModel": "เลือกโมเดล AI",
-    "modelDescription": "โมเดลนี้ใช้แยกเสียงร้องออกจากดนตรี คุณสามารถเปลี่ยนได้ภายหลังในการตั้งค่า",
     "modelDownloadHint": "โมเดลและรันไทม์จะดาวน์โหลดโดยอัตโนมัติเมื่อคุณแยกเสียงเพลงเป็นครั้งแรก"
   },
   "sidebar": {

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -29,6 +29,7 @@
     "chooseLanguage": "Bir dil seçin",
     "openRemoteLibrary": "Bir uzak sağlayıcı seçin",
     "openRemoteLibraryDescription": "Uzak deponuza Google Drive, Dropbox veya WebDAV bağlayın.",
+    "useRemoteRepository": "Uzak depoyu kullan",
     "remoteProvider": {
       "googleDrive": {
         "title": "Google Drive",
@@ -55,9 +56,6 @@
     "fourStemDetail": "Tek tek enstrümanlar üzerinde daha fazla denetim, ~2× disk alanı",
     "getStarted": "Başla",
     "back": "Geri",
-    "continue": "Devam",
-    "chooseModel": "Yapay Zeka Modelini Seçin",
-    "modelDescription": "Bu model vokalleri müzikten ayırır. Daha sonra ayarlardan değiştirebilirsiniz.",
     "modelDownloadHint": "Model ve çalışma zamanı, bir şarkıyı ilk kez ayırdığınızda otomatik olarak indirilir."
   },
   "sidebar": {

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -29,6 +29,7 @@
     "chooseLanguage": "Chọn ngôn ngữ",
     "openRemoteLibrary": "Chọn nhà cung cấp từ xa",
     "openRemoteLibraryDescription": "Kết nối Google Drive, Dropbox hoặc WebDAV với kho lưu trữ từ xa của bạn.",
+    "useRemoteRepository": "Dùng kho lưu trữ từ xa",
     "remoteProvider": {
       "googleDrive": {
         "title": "Google Drive",
@@ -55,9 +56,6 @@
     "fourStemDetail": "Kiểm soát từng nhạc cụ tốt hơn, tốn khoảng 2× dung lượng đĩa",
     "getStarted": "Bắt đầu",
     "back": "Quay lại",
-    "continue": "Tiếp tục",
-    "chooseModel": "Chọn mô hình AI",
-    "modelDescription": "Mô hình này tách giọng hát khỏi phần nhạc. Bạn có thể thay đổi sau trong phần cài đặt.",
     "modelDownloadHint": "Mô hình và runtime của nó sẽ tự động tải xuống trong lần đầu bạn tách một bài hát."
   },
   "sidebar": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -29,6 +29,7 @@
     "chooseLanguage": "选择语言",
     "openRemoteLibrary": "选择远程服务商",
     "openRemoteLibraryDescription": "连接 Google Drive、Dropbox 或 WebDAV 作为你的远程资料库。",
+    "useRemoteRepository": "使用远程资料库",
     "remoteProvider": {
       "googleDrive": {
         "title": "Google Drive",
@@ -55,9 +56,6 @@
     "fourStemDetail": "可以独立控制各个乐器，约2倍磁盘占用",
     "getStarted": "开始使用",
     "back": "返回",
-    "continue": "继续",
-    "chooseModel": "选择 AI 模型",
-    "modelDescription": "该模型用于将人声从伴奏中分离。之后可在设置中更改。",
     "modelDownloadHint": "首次分离歌曲时会自动下载模型及其运行时。"
   },
   "sidebar": {

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -29,6 +29,7 @@
     "chooseLanguage": "選擇語言",
     "openRemoteLibrary": "選擇遠端服務商",
     "openRemoteLibraryDescription": "連接 Google Drive、Dropbox 或 WebDAV 作為你的遠端儲存庫。",
+    "useRemoteRepository": "使用遠端資料庫",
     "remoteProvider": {
       "googleDrive": {
         "title": "Google Drive",
@@ -55,9 +56,6 @@
     "fourStemDetail": "可更精細地控制個別樂器，約 2× 磁碟空間",
     "getStarted": "開始使用",
     "back": "返回",
-    "continue": "繼續",
-    "chooseModel": "選擇 AI 模型",
-    "modelDescription": "此模型會將人聲從音樂中分離出來。你之後可以在設定中變更。",
     "modelDownloadHint": "首次分離歌曲時，會自動下載模型及其執行環境。"
   },
   "sidebar": {


### PR DESCRIPTION
## Summary

Walked the onboarding on a real 1280×800 window and screenshotted every step. Four defects, one of them reported directly: the language list looks like its bottom half is cut off.

## What was wrong, and what changed

**1. The language list was capped at a hardcoded `max-h-[22rem]`** — shorter than the viewport at every desktop size. It clipped a row through the middle and left ~350 px of empty space *below* the clip, which reads as a broken layout rather than a scrollable list. It now follows the window height (`max-h-[60vh]`) and fades out at the bottom, so the clipped row reads as "more below". 8 languages visible instead of 4½.

**2. The AI-model step is deleted.** "Standard vs Fine-tuned (Experimental) — may produce artifacts in accompaniment tracks" is not a question a first-time karaoke user can answer, and the correct answer was already the default. The setting already exists in Settings for anyone who cares. Its only genuinely useful content — that the model and runtime download on first separation — moves to the step before it, so nothing is lost. Onboarding drops from 4 steps to 3.

Dropping the step also drops the `setModelVariant` call: `ModelVariant::Htdemucs` is already `#[default]` in `config.rs`, so the persisted result is identical.

**3. The step indicator promised five stages.** The remote-provider screen is a branch of the library step, so a local-library user — the common case — could never fill more than four of five dots. It now shows the three real stages, with the provider screen counting as the library step.

**4. `setup.openRemoteLibrary` was doing double duty** as both the library-step button label and the provider-screen heading, so the third option read "Choose a remote provider" beside two nouns ("Create new library", "Use existing library"). It gets its own key, translated in all 18 locales.

**Also:** icons in every choice list were `items-center` against two- and three-line blocks, so they floated between lines instead of aligning with the title.

## Deliberately not changed

**The 4-stem default.** For a karaoke app 2-stem is faster and half the disk, so defaulting to 4-stem looked wrong — until I checked the README, where "4-Stem Mixer" is a headline feature. That default is a product stance, not an oversight, so it stays.

**"2-Stem" / "4-Stem" as titles.** Jargon, but each carries a subtitle that states the actual meaning ("Vocals + Accompaniment"), which is where a user's eye lands anyway.

## Test plan

- [x] Before/after screenshots of every step at 1280×800
- [x] `LibrarySetup.render.test.tsx`: the flow now ends at stem mode and asserts the model step is gone and `setModelVariant` is never called; a new case asserts the provider screen renders 3 dots with 2 filled; Back from stem mode returns to the library step
- [x] `pnpm vitest run` — 2077 passed
- [x] `node --run check:i18n` — all 18 locales match the reference
- [x] `node --run lint` clean; patch coverage 100%