### PR TITLE
fix(library): record the two-stem downgrade before deleting what it replaces

### DIFF
--- a/src-tauri/src/cache/stems.rs
+++ b/src-tauri/src/cache/stems.rs
@@ -450,13 +450,23 @@ pub fn downgrade_to_two_stem(
         anyhow::bail!("song {song_hash} does not have a local file path");
     };
     let source_abs = library_root.resolve(song_path);
+    // Write through a temp file so the final path only ever holds a complete
+    // accompaniment. Nothing references it until the UPDATE below, so this is
+    // about not leaving debris rather than about correctness.
+    let accomp_tmp = accomp_abs.with_extension("ogg.tmp");
     write_stem_with_metadata(
         &source_abs,
-        &accomp_abs,
+        &accomp_tmp,
         &stem_title(&song, &source_abs, "Instrumental")?,
         &mixed_audio,
     )
     .context("failed to write accompaniment.ogg")?;
+    fs::rename(&accomp_tmp, &accomp_abs).with_context(|| {
+        format!(
+            "failed to move accompaniment into place at {}",
+            accomp_abs.display()
+        )
+    })?;
 
     // Net disk reclaimed = bytes of the deleted individual stems minus the bytes
     // of the accompaniment.ogg we just wrote in their place. Reporting only the
@@ -467,19 +477,32 @@ pub fn downgrade_to_two_stem(
     let accompaniment_bytes = file_size_or_zero(&accomp_abs);
     let freed_bytes = deleted_bytes.saturating_sub(accompaniment_bytes);
 
-    fs::remove_file(&drums_abs)
-        .with_context(|| format!("failed to remove {}", drums_abs.display()))?;
-    fs::remove_file(&bass_abs)
-        .with_context(|| format!("failed to remove {}", bass_abs.display()))?;
-    fs::remove_file(&other_abs)
-        .with_context(|| format!("failed to remove {}", other_abs.display()))?;
-
+    // Record the downgrade BEFORE deleting the stems it replaces, so every
+    // interruption point leaves a consistent state instead of a recoverable
+    // one. Killed after the delete but before the update, the old order left
+    // the row pointing at files that no longer exist, `cache_entry_files_exist`
+    // rejected the whole entry, and the user lost the vocals track and several
+    // minutes of inference. In this order the worst case is leftover files that
+    // no row references - which `scan_for_orphans` already reports through the
+    // existing integrity check.
     connection
         .execute(
             "UPDATE stems SET accomp_path = ?2, drums_path = NULL, bass_path = NULL, other_path = NULL WHERE song_hash = ?1",
             params![song_hash, accomp_rel],
         )
         .context("failed to update stem cache entry for downgrade")?;
+
+    // Past this point the downgrade has succeeded. A failed unlink only leaves
+    // an unreferenced file behind, so it must not be reported to the caller as
+    // a failed downgrade.
+    for path in [&drums_abs, &bass_abs, &other_abs] {
+        if let Err(error) = fs::remove_file(path) {
+            tracing::warn!(
+                "downgraded {song_hash} but could not remove {}: {error}",
+                path.display()
+            );
+        }
+    }
 
     let updated_entry = StemCacheEntry {
         song_hash: entry.song_hash,

--- a/src-tauri/tests/phase3_stems_cache.rs
+++ b/src-tauri/tests/phase3_stems_cache.rs
@@ -566,3 +566,49 @@ fn streaming_ogg_writer_atomic_promotion() {
 
     cleanup_dir(&output_dir);
 }
+
+/// #251: the downgrade is recorded before the stems it replaces are deleted, so
+/// the worst an interruption can leave behind is unreferenced files. This pins
+/// the property that makes that ordering safe: a two-stem entry stays usable
+/// even when the old individual stems are still sitting on disk.
+///
+/// Under the previous order the analogous interruption left the row pointing at
+/// files that no longer existed, which invalidated the whole entry and cost the
+/// user the vocals track plus several minutes of inference.
+#[test]
+fn two_stem_entry_stays_usable_with_leftover_individual_stems() {
+    let connection = Connection::open_in_memory().expect("in-memory database should open");
+    cache::apply_migrations(&connection).expect("migrations should succeed");
+    let library = unique_library_root();
+    let library_root_path = library.root().to_owned();
+    let song = tagged_song_in_library(&library, "song-downgrade-leftovers");
+    cache::upsert_song(&connection, &song).expect("song insert should succeed");
+
+    populate_stem_cache(
+        &connection,
+        &library,
+        &song,
+        "song-downgrade-leftovers",
+        StemMode::FourStem,
+        "htdemucs",
+    );
+
+    let (updated_entry, _) =
+        stems::downgrade_to_two_stem(&connection, &library, "song-downgrade-leftovers")
+            .expect("downgrade should succeed");
+    assert!(updated_entry.drums_path.is_none());
+
+    // Stand in for being killed between the row update and the deletes.
+    let stem_dir = library.resolve("stems/song-downgrade-leftovers");
+    for name in ["drums.ogg", "bass.ogg", "other.ogg"] {
+        std::fs::write(stem_dir.join(name), b"leftover").expect("leftover stem should be written");
+    }
+
+    assert!(
+        stems::cache_entry_files_valid(&library, &updated_entry),
+        "the two-stem entry must stay usable; the leftovers are unreferenced and \
+         the integrity scan reports them as orphaned managed files"
+    );
+
+    cleanup_dir(&library_root_path);
+}


### PR DESCRIPTION
## The issue's premise was wrong, and the real hole is worse

The issue assumes the downgrade overwrites an existing accompaniment. It does not. `cache_entry_files_exist` says so directly — *"An empty accomp_path means FourStem mode where no accompaniment file is written"* (`src-tauri/src/cache/stems.rs:239`). A four-stem entry has an empty `accomp_path` and no `accompaniment.ogg` on disk, so the downgrade writes to a path **nothing references**.

That collapses the interruption matrix to one harmful window, and it is not the one the issue named:

| Killed at | Result |
| --- | --- |
| mid-write of the accompaniment | an unreferenced truncated file; the row is still four-stem and all three stems exist, so `cache_entry_files_exist` passes and a retry overwrites it. Harmless. |
| **after the deletes, before the `UPDATE`** | the row points at files that no longer exist → `cache_entry_files_exist` rejects the entry → **the user loses the vocals track and several minutes of inference** |
| after the `UPDATE` | done |

So the cost was never orphan files. It was the whole separation.

## Fix: order the sequence so every prefix is consistent

Update the row **first**, then delete. That makes each interruption point land on a valid state rather than a recoverable one — no journal, no completion marker, no startup convergence pass, which is what the issue's proposed design exists to support.

The leftover stems after the update are referenced by no row, which means **`scan_for_orphans` (`library/integrity.rs:468`, whose scan set already includes `stems`) reports them through the existing integrity check.** The acceptance criteria's "no orphan files" is satisfied by machinery already in the repo, not by new code.

Two smaller consequences:

- Deletes after the update are logged rather than propagated. At that point the downgrade *has* succeeded; a failed `unlink` only leaves a file the orphan scan already reports, so failing the whole operation would misreport it to the caller.
- The accompaniment is written to a temp file and renamed into place. Nothing references it until the update, so this is about not leaving debris rather than about correctness — the honest framing, rather than claiming it fixes an atomicity bug it does not.

`freed_bytes` keeps the #207 net accounting, still computed before the deletes.

## Test plan

One new test pins the property that makes the ordering safe: a two-stem entry stays usable when the old individual stems are still on disk — the exact state a kill between the update and the deletes now leaves. Under the previous order the analogous state invalidated the entry.

I first tried to force the failure directly by making the stem directory read-only, and dropped it: POSIX `unlink` needs write permission on the directory, so a read-only directory also blocks creating the temp file, and the test failed in the write step instead of the delete step. Asserting the resulting state is both simpler and closer to what actually matters. I also did not re-test `scan_for_orphans` — that is existing behaviour with its own coverage.

- [x] `cargo nextest run` — 1231 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --test phase3_stems_cache` — 11 passed

## Related issues

Closes #251