### PR TITLE
docs: correct the developer-facing docs that had drifted

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,11 +8,14 @@ Brief description of the changes.
 
 ## Test plan
 
-- [ ] `go test ./... -race` passes
-- [ ] `go vet ./...` clean
-- [ ] `gofmt -l` empty
-- [ ] New/changed commands tested with `--json` output
-- [ ] Safety model respected (dry-run, confirm, read-only) _(if applicable)_
+Report the commands you ran, and say which you skipped and why.
+
+- [ ] `node --run lint` and `node --run build`
+- [ ] `pnpm vitest run` _(frontend changes)_
+- [ ] `cd src-tauri && cargo clippy --all-targets -- -D warnings` _(Rust changes)_
+- [ ] `cd src-tauri && cargo nextest run` _(Rust changes)_
+- [ ] `node --run check:i18n` _(new or changed UI copy)_
+- [ ] `docs/references/contracts/*.md` updated _(public IPC command, payload, or event changed)_
 
 ## Related issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,35 +7,44 @@ Thanks for your interest in contributing.
 ```bash
 git clone https://github.com/thedavidweng/OpenKara.git
 cd OpenKara
-mise install  # install tools pinned in mise.toml
+mise install        # install tools pinned in mise.toml
 pnpm install
+./scripts/setup.sh  # download the separation model and ONNX Runtime for local dev
 ```
 
 ## Development
 
 ```bash
-# Start dev server (hot-reload)
-pnpm tauri dev
+pnpm tauri dev      # dev server with hot reload
+pnpm tauri build    # release bundle
+```
 
-# Build release binary
-pnpm tauri build
+## Checks
 
-# Run Rust linter
-cargo clippy
+Git hooks run most of these for you. `pre-commit` formats the staged files.
+`pre-push` runs the format check, the lint, and patch coverage. Run the rest
+before you open a pull request.
 
-# Format code
-cargo fmt
+```bash
+node --run lint                                  # frontend lint
+node --run build                                 # typecheck and build the frontend
+pnpm vitest run                                  # frontend tests
+node --run check:i18n                            # locale key parity
 
-# Run tests
-cargo test
+cd src-tauri
+cargo clippy --all-targets -- -D warnings        # Rust lint
+cargo nextest run                                # Rust tests
 ```
 
 ## Pull Requests
 
 1. Fork the repository and create a feature branch.
-2. Make your changes with tests if applicable.
-3. Run `cargo clippy` and `cargo fmt` before you commit.
-4. Open a pull request against `main`.
+2. Make your changes. Add tests when the change has behavior to pin.
+3. Run the checks above for the areas you touched.
+4. Update `docs/references/contracts/*.md` in the same change when you change a
+   public IPC command, payload, or event.
+5. Open a pull request against `main`. The title must follow Conventional
+   Commits, because CI checks it.
 
 ## Commit Messages
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ On first launch, OpenKara will prompt you to create a Karaoke Library and start 
 **Prerequisites:**
 
 - [Node.js](https://nodejs.org/) 24（与 CI 一致；仓库根目录含 `.nvmrc`）
-- [pnpm](https://pnpm.io/) 10+
+- [pnpm](https://pnpm.io/) 11
 - [Rust](https://rustup.rs/) stable toolchain
 - Platform dependencies for [Tauri 2](https://v2.tauri.app/start/prerequisites/)
 
@@ -292,7 +292,7 @@ filter such as `OPENKARA_LOG=openkara_lib=trace,warn`).
 ### Prerequisites
 
 - Node.js 24（`nvm use` 或 `fnm use` 读取 `.nvmrc` / `.node-version`）
-- pnpm 10+
+- pnpm 11
 - Rust stable via [rustup](https://rustup.rs/)
 - [Tauri 2 prerequisites](https://v2.tauri.app/start/prerequisites/) for your platform
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -50,8 +50,13 @@
 
 - **本地音频导入** — 直接使用你已有的音乐，无需订阅，无需重复购买。
 - **AI 人声分离** — 在本地完成歌曲的人声与伴奏分离。
+- **流式播放** — 环形缓冲流式解码 + 分块缓存，弱网下自动切换带宽感知代理模式，失败按指数退避重试。
+- **远程资料库** — 连接 Google Drive、Dropbox 或 WebDAV 资料库。刷新、发布、重新授权都不会丢失本地状态。
+- **播放列表与轮唱** — 创建播放列表，为队列分配演唱者并轮换，也可按演唱者筛选队列。
 - **同步歌词** — 可从在线来源、内嵌标签或 `.lrc` 伴随文件加载时间同步歌词。
+- **歌词罗马音** — 13 种语言自动罗马音转写，含普通话、粤语、日语、韩语等，可按歌曲覆盖语言。
 - **CD+G 伴随图形** — 如果歌曲旁边有同名 `.cdg` 文件，OpenKara 会在全屏播放时渲染对应图形。
+- **AirPlay 投放** — 把 Karaoke 播放投放到 AirPlay 设备，支持观众端串流。
 - **可移植曲库** — 自包含的曲库目录，可放置在 NAS、USB 硬盘上，跨设备共享。
 - **跨平台** — 支持 macOS、Windows 和 Linux。
 - **四轨混音器** — 人声、鼓、贝斯、其他乐器独立音量控制。可折叠的伴奏滑块，展开查看各轨详情。
@@ -99,7 +104,7 @@ xattr -rd com.apple.quarantine /Applications/OpenKara.app
 **前置条件：**
 
 - [Node.js](https://nodejs.org/) 24（与 CI 一致；仓库根目录含 `.nvmrc`）
-- [pnpm](https://pnpm.io/) 10+
+- [pnpm](https://pnpm.io/) 11
 - [Rust](https://rustup.rs/) stable 工具链
 - [Tauri 2](https://v2.tauri.app/start/prerequisites/) 平台依赖
 
@@ -242,7 +247,7 @@ OpenKara 会写入滚动日志文件（默认 info 级别，错误必录），�
 ### 前置条件
 
 - Node.js 24（`nvm use` 或 `fnm use` 读取 `.nvmrc` / `.node-version`）
-- pnpm 10+
+- pnpm 11
 - 通过 [rustup](https://rustup.rs/) 安装的 Rust stable
 - 对应平台的 [Tauri 2 依赖](https://v2.tauri.app/start/prerequisites/)
 


### PR DESCRIPTION
First pass of the 1.0 readiness review, scoped to documentation that was factually wrong rather than merely thin.

| What | Was | Now |
| --- | --- | --- |
| `.github/PULL_REQUEST_TEMPLATE.md` | a **Go project's** template — `go test ./... -race`, `go vet`, `gofmt -l`, and a `--json` CLI contract that does not exist here | the checks this repo actually runs, including the contract-doc rule from `AGENTS.md` |
| README / README_CN prerequisites | "pnpm 10+" | `pnpm 11` — `package.json` pins `pnpm@11.13.0` and declares `"pnpm": ">=11 <12"`, so following the README could not install |
| README_CN features | 12 entries | 17 — it was missing streaming playback, remote repositories, playlists and singer rotation, lyrics romanization, and AirPlay casting |
| CONTRIBUTING | `cargo clippy` / `cargo fmt` / `cargo test` only | the frontend commands, `cargo nextest`, `check:i18n`, the contract-doc rule, `./scripts/setup.sh`, and the fact that the git hooks already run most of it |

Every claim was checked against the file it describes — `package.json` for the pnpm floor, the README feature list for the CN parity, `ci.yml` and `lefthook.yml` for the command list.

## Test plan

- [x] `node --run format` — clean
- [x] EN/CN feature counts compared programmatically: 17 and 17
- Docs-only; no code paths touched