### PR TITLE
ci: drop two pieces of duplicated work from every run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -591,11 +591,16 @@ jobs:
       - name: ort C API level vs catalog runtimes
         run: node scripts/ci/check-ort-api-level.mjs
 
+      # Prebuilt binary rather than `cargo install`, which rebuilt cargo-shear
+      # from source on every run of a job whose actual work takes seconds.
+      - name: Install cargo-shear
+        uses: taiki-e/install-action@7a562dfa955aa2e4d5b0fd6ebd57ff9715c07b0b # v2.73.0
+        with:
+          tool: cargo-shear@1.12.4
+
       - name: cargo-shear (unused Cargo dependencies)
         working-directory: src-tauri
-        run: |
-          cargo install cargo-shear --version 1.12.4 --locked
-          cargo shear --deny-warnings --locked
+        run: cargo shear --deny-warnings --locked
 
   rust-test:
     name: Rust tests (${{ matrix.name }})
@@ -968,9 +973,8 @@ jobs:
       - name: Install JavaScript dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Audit dependencies
-        run: pnpm audit --audit-level=high
-
+      # No `pnpm audit` here: js-quality already gates the same lockfile, and a
+      # second run only adds a registry round trip to the slowest job in CI.
       - name: Restore ONNX Runtime cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:


### PR DESCRIPTION
Two changes, both removals.

**`pnpm audit` ran four times per run.** Once in `js-quality`, then again in each of the three `tauri-build` legs — against the same lockfile, so the three extra runs could only ever agree with the first. They also put a registry round trip inside the slowest job in CI, where a transient npm outage would fail a 60-minute build for a reason `js-quality` already covered.

**`dependency-checks` rebuilt `cargo-shear` from source on every run.** `cargo install cargo-shear --locked` is minutes of compilation for a check whose actual work takes seconds. `taiki-e/install-action` fetches the prebuilt binary — the same action, pinned to the same SHA, that the `rust-test` matrix already uses for nextest.

Neither change weakens a gate: the same audit runs, the same `cargo shear --deny-warnings --locked` runs.

## Test plan

- [x] `pnpm vitest run tests/ci tests/workflow-security.test.ts` — 71 passed (the drift-protection suites that parse `ci.yml`)
- [x] `node --run format` — clean
- CI itself is the rest of the verification: `ci-gate` compares the job set that ran against the classifier's expectation, so a workflow edit that changed which jobs run would fail it.