### PR TITLE
chore: ignore the model verification sidecars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ src-tauri/icons/black-icon.png
 
 # ONNX models (large binaries, downloaded via setup script)
 src-tauri/models/*.onnx
+# Sidecars the verified-manifest writer drops next to a downloaded model.
+src-tauri/models/*.verified.json
 src-tauri/generated/onnxruntime/
 src-tauri/generated/oauth/google-drive-client.json
 src-tauri/generated/oauth/dropbox-client.json


### PR DESCRIPTION
`separator::verified_manifest` writes `<model>.verified.json` next to each downloaded model (`src-tauri/src/separator/verified_manifest.rs:24`). `.gitignore` covered `src-tauri/models/*.onnx` but not the sidecar, so every dev checkout that has run `./scripts/setup.sh` carries a permanently untracked file in `git status`.

Docs-adjacent one-liner; no code paths touched.