### PR TITLE
chore(rust): drop the dead-code allowances that were silencing nothing

### DIFF
--- a/src-tauri/src/remote/control_db.rs
+++ b/src-tauri/src/remote/control_db.rs
@@ -194,7 +194,6 @@ impl OperationState {
 ///
 /// Mirrors the `direction` CHECK constraint.
 // used by PR#5: resumable uploads/downloads
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TransferDirection {
@@ -204,7 +203,6 @@ pub enum TransferDirection {
 
 impl TransferDirection {
     // used by PR#5: resumable uploads/downloads
-    #[allow(dead_code)]
     pub fn as_str(self) -> &'static str {
         match self {
             TransferDirection::Upload => "upload",
@@ -834,7 +832,6 @@ pub fn list_operations(connection: &Connection) -> CommandResult<Vec<OperationRo
 
 /// Load all operation rows for a given library.
 // used by PR#4: operation executor
-#[allow(dead_code)]
 pub fn list_operations_for_library(
     connection: &Connection,
     library_id: &str,
@@ -1046,7 +1043,6 @@ fn map_transfer_part_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TransferPa
 /// completes (or is cancelled) so stale offsets do not cause a future restart
 /// to resume against a non-existent remote partial.
 // used by PR#5: resumable uploads/downloads
-#[allow(dead_code)]
 pub fn delete_transfer_parts(connection: &Connection, operation_id: &str) -> CommandResult<()> {
     connection
         .execute(

--- a/src-tauri/src/remote/errors.rs
+++ b/src-tauri/src/remote/errors.rs
@@ -28,7 +28,6 @@ pub(crate) struct RemoteProviderCapabilities {
     /// The provider supports resumable uploads with offset query/resume.
     /// PR#5 fills this `true` where supported; PR#4 leaves it `false`.
     // used by PR#5: resumable uploads
-    #[allow(dead_code)]
     pub resumable_upload: bool,
     /// The provider supports HTTP Range downloads.
     pub range_download: bool,
@@ -77,10 +76,8 @@ pub(crate) enum RemoteErrorKind {
     /// The authenticated user lacks permission for the operation.
     PermissionDenied,
     /// The local disk is full.
-    #[allow(dead_code)]
     DiskFull,
     /// The operation was cancelled by the user or a coalescing decision.
-    #[allow(dead_code)]
     OperationCancelled,
     /// The playback request that initiated this operation is no longer
     /// current — the user skipped to a different song (or a newer request
@@ -151,7 +148,6 @@ pub(crate) struct RemoteError {
     /// shared retry driver when present and bounded; `None` means the driver
     /// falls back to full-jitter backoff.
     // used by PR#5: shared network retry policy
-    #[allow(dead_code)]
     pub retry_after: Option<std::time::Duration>,
 }
 
@@ -263,7 +259,6 @@ pub(crate) fn kind_from_http_status(status: reqwest::StatusCode) -> RemoteErrorK
 /// file write (e.g. uploading bytes read from disk). Disk-full is detected by
 /// error kind; everything else is treated as a local IO failure (not a remote
 /// kind, but reported as NetworkUnavailable so the operation retries).
-#[allow(dead_code)]
 pub(crate) fn kind_from_io_error(error: &std::io::Error) -> RemoteErrorKind {
     if error.kind() == std::io::ErrorKind::Other {
         // `ErrorKind::Other` may wrap ENOSPC on some platforms via

--- a/src-tauri/src/remote/google_drive.rs
+++ b/src-tauri/src/remote/google_drive.rs
@@ -567,7 +567,6 @@ const GOOGLE_DRIVE_RESUMABLE_CHUNK_SIZE: usize = 8 * 1024 * 1024;
 /// Initiate a resumable upload session for a new file. Returns the session URL
 /// (from the `Location` header) to persist in
 /// `remote_transfer_parts.provider_session_id`.
-#[allow(dead_code)]
 pub(crate) fn google_drive_begin_resumable_upload(
     app_data_dir: &Path,
     secret: &mut GoogleDriveSecret,
@@ -607,7 +606,6 @@ pub(crate) fn google_drive_begin_resumable_upload(
 /// Initiate a resumable upload session for updating an existing file (by
 /// `file_id`). Used when the file already exists and we want to overwrite it
 /// resumably.
-#[allow(dead_code)]
 pub(crate) fn google_drive_begin_resumable_upload_existing(
     app_data_dir: &Path,
     secret: &mut GoogleDriveSecret,
@@ -645,7 +643,6 @@ pub(crate) fn google_drive_begin_resumable_upload_existing(
 /// `Content-Range: bytes */*` and an empty body. Google Drive responds with
 /// 308 (Permanent Redirect) and a `Range: bytes=0-<committed>` header, or 200
 /// if the upload is complete.
-#[allow(dead_code)]
 pub(crate) fn google_drive_query_resumable_offset(
     session_url: &str,
     access_token: &str,
@@ -698,7 +695,6 @@ pub(crate) fn google_drive_query_resumable_offset(
 
 /// Upload a single chunk to a resumable upload session. `start` is the byte
 /// offset within the file; `chunk` is the chunk bytes.
-#[allow(dead_code)]
 pub(crate) fn google_drive_upload_chunk(
     session_url: &str,
     access_token: &str,
@@ -737,7 +733,6 @@ pub(crate) fn google_drive_upload_chunk(
 ///
 /// For a new file, pass `parent_id` + `file_name`. For an existing file,
 /// pass `file_id` (the session is initiated against the existing file).
-#[allow(dead_code)]
 pub(crate) fn google_drive_resumable_upload(
     app_data_dir: &Path,
     secret: &mut GoogleDriveSecret,

--- a/src-tauri/src/remote/provider.rs
+++ b/src-tauri/src/remote/provider.rs
@@ -112,7 +112,6 @@ pub(crate) trait RemoteProvider {
     /// The caller checks `resumable_upload` first and falls back to
     /// `upload_file` when unsupported.
     // used by PR#5: resumable uploads
-    #[allow(dead_code)]
     fn resumable_upload_bytes(
         &self,
         _relative_path: &str,

--- a/src-tauri/src/services/playback_source.rs
+++ b/src-tauri/src/services/playback_source.rs
@@ -180,7 +180,6 @@ pub(crate) struct StreamingPlaybackSource {
     /// release / track skip / stop), the pin count decrements so the entry
     /// becomes eligible for eviction. `None` for local sources. The field is
     /// never read directly — it exists only for its `Drop` side effect.
-    #[allow(dead_code)]
     pub(crate) cache_pin_guard: Option<CachePinGuard>,
 }
 

--- a/src-tauri/src/services/reconnect.rs
+++ b/src-tauri/src/services/reconnect.rs
@@ -55,7 +55,6 @@ use std::time::Duration;
 /// pinned the cache entry for the process lifetime.
 pub(crate) struct RemoteStreamingRuntime {
     /// RAII pin guard. Unpins the cache entry on drop.
-    #[allow(dead_code)]
     pub(crate) cache_pin_guard: Option<CachePinGuard>,
     /// Fetch event receiver. The caller should drain this in a dedicated
     /// listener thread to handle ConsecutiveFailures, UrlExpired, etc.
@@ -415,7 +414,6 @@ impl EventSink for RecordingEventSink {
 /// Production reconnect entry point used by `services::playback`. Wraps
 /// [`run_reconnect`] with the production jitter RNG and sleep function.
 /// Exposed so the playback loop does not need to thread the RNG/sleep itself.
-#[allow(dead_code)]
 pub(crate) fn reconnect_production<S, R, K, C, G, E>(
     song_id: &str,
     request_id: u64,

--- a/src-tauri/src/window_shell.rs
+++ b/src-tauri/src/window_shell.rs
@@ -23,6 +23,7 @@ pub enum WindowChromeVariant {
     // The `Mac` variant is only constructed on macOS, but must exist on all
     // platforms for serde serialization compatibility — the frontend expects
     // `mac` in the JSON payload regardless of the backend platform.
+    #[allow(dead_code)]
     Mac,
 }
 
@@ -30,6 +31,7 @@ pub enum WindowChromeVariant {
 #[serde(rename_all = "snake_case")]
 pub enum WindowShellTier {
     Desktop,
+    #[allow(dead_code)]
     Mac,
 }
 
@@ -57,6 +59,7 @@ impl WindowShellState {
 
     /// macOS-only constructor. Gated because on Linux the `Mac` variants and
     /// `MAC_*` constants are never used; the `Mac` enum variants still exist
+    /// (with `#[allow(dead_code)]`) for serde serialization compatibility.
     #[cfg(target_os = "macos")]
     pub fn mac() -> Self {
         Self {

--- a/src-tauri/src/window_shell.rs
+++ b/src-tauri/src/window_shell.rs
@@ -23,7 +23,6 @@ pub enum WindowChromeVariant {
     // The `Mac` variant is only constructed on macOS, but must exist on all
     // platforms for serde serialization compatibility — the frontend expects
     // `mac` in the JSON payload regardless of the backend platform.
-    #[allow(dead_code)]
     Mac,
 }
 
@@ -31,7 +30,6 @@ pub enum WindowChromeVariant {
 #[serde(rename_all = "snake_case")]
 pub enum WindowShellTier {
     Desktop,
-    #[allow(dead_code)]
     Mac,
 }
 
@@ -59,7 +57,6 @@ impl WindowShellState {
 
     /// macOS-only constructor. Gated because on Linux the `Mac` variants and
     /// `MAC_*` constants are never used; the `Mac` enum variants still exist
-    /// (with `#[allow(dead_code)]`) for serde serialization compatibility.
     #[cfg(target_os = "macos")]
     pub fn mac() -> Self {
         Self {


### PR DESCRIPTION
## What I measured

The tree carried **79** `#[allow(dead_code)]` attributes. Removing all of them and recompiling shows the compiler only objects to **58**.

The other 21 suppressed a warning that no longer exists. That is worse than clutter: an `#[allow]` on an item that has since been wired up will also silence the *next* thing in that item that goes dead.

## What this changes

Only the provably stale attributes are dropped. The rule: an attribute goes only when neither the item it guards **nor any member of that item** appears in the compiler's flagged list — the member scan is why this is 21 rather than 34, and it is the conservative direction.

`cargo clippy --all-targets -- -D warnings` is clean afterwards. That is the proof, not the process.

**Nothing was deleted beyond the attributes themselves.** No code was removed.

## The finding this leaves behind

The 58 remaining allowances are load-bearing, and **~44 of them sit in `src/remote/`**:

| File | Unreferenced items |
| --- | --- |
| `remote/executor.rs` | 10 |
| `remote/atomic_download.rs` | 6 |
| `remote/recovery.rs`, `remote/mutation.rs` | 4 each |
| `remote/fault_injection.rs`, `remote/errors.rs`, `remote/control_db.rs` | 3 each |
| others across `remote/` | the rest |

Several carry comments saying the retention is deliberate ("retained for non-TX call sites / future callers", "used by `mutation::sync_backend` in non-test builds"). So this is not obviously debris — deciding what of the remote control plane ships in 1.0 is a product call, and mass-deleting it as a lint cleanup would be the wrong shape of change. Flagging it with numbers so the decision can be made deliberately.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo nextest run` — 1237 passed
- [x] `cargo fmt --check` — clean