### PR TITLE
feat(diagnostics): show where the model file belongs

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,16 @@ OpenKara uses custom ONNX builds of [Demucs](https://github.com/adefossez/demucs
 
 On first launch, OpenKara automatically downloads the standard `openkara-models` asset pinned by the app's embedded catalog snapshot (currently generation 9) into the app data directory. Settings offers an update check that installs newer catalog generations without waiting for an app release. The current standard model is ~199.8 MiB on disk, and the optional high quality model is ~800.1 MiB. Both assets are ONNX Runtime-optimized and carry metadata used for cache invalidation. See the [openkara-models README](https://github.com/thedavidweng/openkara-models#readme) for details on the conversion pipeline. For local development and deterministic tests, run `./scripts/setup.sh` to populate `src-tauri/models/`.
 
+### Installing a model by hand
+
+The download resumes after a network failure, but a slow or restricted connection can still make it impractical. You can place the file yourself: OpenKara checks the managed model path at startup and adopts whatever is there once its SHA-256 matches the catalog pin.
+
+1. **Settings → About → Model file** shows the exact path your build expects, including the file name for the active variant.
+2. Download that file from [openkara-models releases](https://github.com/thedavidweng/openkara-models/releases).
+3. Put it at that path and restart OpenKara.
+
+A file whose digest does not match the pin is ignored and the normal download runs instead, so a partial or wrong file cannot corrupt the install.
+
 ## Tech Stack
 
 | Layer             | Technology                                                                                              | Purpose                         |

--- a/README_CN.md
+++ b/README_CN.md
@@ -139,6 +139,16 @@ OpenKara 使用自定义 ONNX 格式的 [Demucs](https://github.com/adefossez/de
 
 首次启动时，OpenKara 会将标准 `openkara-models` 资源（当前锁定为 generation 9）下载到应用数据目录。当前标准模型磁盘大小约为 199.8 MiB，可选的高质量模型约为 800.1 MiB。两者都已完成 ONNX Runtime 离线优化，并携带用于缓存失效的 metadata。详见 [openkara-models README](https://github.com/thedavidweng/openkara-models#readme) 了解转换流水线。开发环境和需要稳定输入的测试可运行 `./scripts/setup.sh` 填充 `src-tauri/models/`。
 
+### 手动放置模型文件
+
+下载中断后会断点续传，但网络太慢或受限时仍可能不现实。你可以自己放文件：OpenKara 启动时会检查托管模型路径，只要 SHA-256 与 catalog pin 一致就直接采用。
+
+1. **设置 → 关于 → 模型文件** 显示你这个构建期望的完整路径，含当前变体的文件名。
+2. 从 [openkara-models releases](https://github.com/thedavidweng/openkara-models/releases) 下载该文件。
+3. 放到那个路径，重启 OpenKara。
+
+摘要对不上的文件会被忽略并照常触发下载，所以放错或放了半个文件都不会污染安装。
+
 ## 技术栈
 
 | 层级     | 技术                                                                                                    | 用途                         |

--- a/src-tauri/src/commands/diagnostics.rs
+++ b/src-tauri/src/commands/diagnostics.rs
@@ -46,6 +46,10 @@ pub struct DebugInfo {
     pub model_installed_version: Option<String>,
     /// Upstream tag pinned by the embedded catalog for the active variant.
     pub model_pinned_version: String,
+    /// Where the active variant's model file is expected on disk. Surfaced so a
+    /// user on a slow connection can place a verified download there by hand
+    /// instead of guessing the app data layout (#270).
+    pub model_path: String,
     /// Bootstrap state of the ONNX Runtime (`ready` / `missing` / …).
     pub runtime_state: String,
     /// Active runtime upstream version (or the pinned version when absent).
@@ -100,6 +104,7 @@ pub fn assemble_debug_info(
     model_installed: bool,
     model_installed_version: Option<String>,
     model_pinned_version: String,
+    model_path: String,
     runtime_state: &str,
     runtime_version: String,
     runtime_artifact_id: Option<String>,
@@ -119,6 +124,7 @@ pub fn assemble_debug_info(
         model_installed,
         model_installed_version,
         model_pinned_version,
+        model_path,
         runtime_state: runtime_state.to_owned(),
         runtime_version,
         runtime_artifact_id,
@@ -189,6 +195,7 @@ pub fn get_debug_info(
         model_installed,
         model_installed_version,
         descriptor.upstream_tag.clone(),
+        managed_model_path.display().to_string(),
         runtime_state_label(&runtime_snapshot.state),
         runtime_snapshot.version.clone(),
         runtime_snapshot.active_artifact_id.clone(),
@@ -215,6 +222,8 @@ mod tests {
             true,
             Some("model-v2.1.0".to_owned()),
             "model-v2.1.0".to_owned(),
+            "/Users/me/Library/Application Support/com.openkara.desktop/models/htdemucs.onnx"
+                .to_owned(),
             "ready",
             "v1.27.1".to_owned(),
             Some("onnxruntime-1.27.1-openkara-aarch64-apple-darwin".to_owned()),
@@ -235,6 +244,10 @@ mod tests {
         assert_eq!(info.catalog_release_id, "2026-07-25-006");
         assert_eq!(info.model_variant, "htdemucs");
         assert_eq!(info.model_state, "ready");
+        assert_eq!(
+            info.model_path,
+            "/Users/me/Library/Application Support/com.openkara.desktop/models/htdemucs.onnx"
+        );
         assert!(info.model_installed);
         assert_eq!(
             info.model_installed_version.as_deref(),
@@ -314,6 +327,7 @@ mod tests {
             false,
             None,
             "model-v2.1.0".to_owned(),
+            "/home/me/.local/share/com.openkara.desktop/models/htdemucs_ft.onnx".to_owned(),
             "missing",
             "v1.27.1".to_owned(),
             None,

--- a/src/components/Settings/SettingsAboutSection.test.tsx
+++ b/src/components/Settings/SettingsAboutSection.test.tsx
@@ -42,6 +42,7 @@ const sample: DebugInfo = {
   model_installed: true,
   model_installed_version: "model-v2.1.0",
   model_pinned_version: "model-v2.1.0",
+  model_path: "/tmp/models/htdemucs.onnx",
   runtime_state: "ready",
   runtime_version: "v1.27.1",
   runtime_artifact_id: "onnxruntime-1.27.1-openkara-aarch64-apple-darwin",

--- a/src/components/Settings/SettingsAboutSection.tsx
+++ b/src/components/Settings/SettingsAboutSection.tsx
@@ -71,6 +71,7 @@ export function SettingsAboutSection() {
     ? `${info.runtime_state} · ${info.runtime_version}`
     : placeholder;
   const executionProvider = info ? info.execution_provider : placeholder;
+  const modelPath = info ? info.model_path : placeholder;
   const logFile = info ? info.log_file : placeholder;
 
   return (
@@ -83,6 +84,7 @@ export function SettingsAboutSection() {
         <AboutRow label={t("settings.about.system")} value={system} />
         <AboutRow label={t("settings.about.catalog")} value={catalog} />
         <AboutRow label={t("settings.about.model")} value={model} />
+        <AboutRow label={t("settings.about.modelPath")} value={modelPath} />
         <AboutRow label={t("settings.about.runtime")} value={runtime} />
         <AboutRow
           label={t("settings.about.executionProvider")}

--- a/src/lib/debug-info.test.ts
+++ b/src/lib/debug-info.test.ts
@@ -18,6 +18,7 @@ const sample: DebugInfo = {
   model_installed: true,
   model_installed_version: "model-v2.1.0",
   model_pinned_version: "model-v2.1.0",
+  model_path: "/tmp/models/htdemucs.onnx",
   runtime_state: "ready",
   runtime_version: "v1.27.1",
   runtime_artifact_id: "onnxruntime-1.27.1-openkara-aarch64-apple-darwin",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -589,6 +589,7 @@
       "system": "System",
       "catalog": "Katalog",
       "model": "Modell",
+      "modelPath": "Modelldatei",
       "runtime": "Runtime",
       "executionProvider": "Ausführungsanbieter",
       "logFile": "Protokolldatei",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -589,6 +589,7 @@
       "system": "System",
       "catalog": "Catalog",
       "model": "Model",
+      "modelPath": "Model file",
       "runtime": "Runtime",
       "executionProvider": "Execution provider",
       "logFile": "Log file",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -590,6 +590,7 @@
       "system": "Sistema",
       "catalog": "Catálogo",
       "model": "Modelo",
+      "modelPath": "Archivo del modelo",
       "runtime": "Runtime",
       "executionProvider": "Proveedor de ejecución",
       "logFile": "Archivo de registro",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -590,6 +590,7 @@
       "system": "Système",
       "catalog": "Catalogue",
       "model": "Modèle",
+      "modelPath": "Fichier du modèle",
       "runtime": "Runtime",
       "executionProvider": "Fournisseur d'exécution",
       "logFile": "Fichier journal",

--- a/src/locales/id.json
+++ b/src/locales/id.json
@@ -588,6 +588,7 @@
       "system": "Sistem",
       "catalog": "Katalog",
       "model": "Model",
+      "modelPath": "Berkas model",
       "runtime": "Runtime",
       "executionProvider": "Penyedia eksekusi",
       "logFile": "Berkas log",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -590,6 +590,7 @@
       "system": "Sistema",
       "catalog": "Catalogo",
       "model": "Modello",
+      "modelPath": "File del modello",
       "runtime": "Runtime",
       "executionProvider": "Provider di esecuzione",
       "logFile": "File di log",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -588,6 +588,7 @@
       "system": "システム",
       "catalog": "カタログ",
       "model": "モデル",
+      "modelPath": "モデルファイル",
       "runtime": "ランタイム",
       "executionProvider": "実行プロバイダー",
       "logFile": "ログファイル",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -588,6 +588,7 @@
       "system": "시스템",
       "catalog": "카탈로그",
       "model": "모델",
+      "modelPath": "모델 파일",
       "runtime": "런타임",
       "executionProvider": "실행 공급자",
       "logFile": "로그 파일",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -589,6 +589,7 @@
       "system": "Systeem",
       "catalog": "Catalogus",
       "model": "Model",
+      "modelPath": "Modelbestand",
       "runtime": "Runtime",
       "executionProvider": "Uitvoeringsprovider",
       "logFile": "Logbestand",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -591,6 +591,7 @@
       "system": "System",
       "catalog": "Katalog",
       "model": "Model",
+      "modelPath": "Plik modelu",
       "runtime": "Środowisko",
       "executionProvider": "Dostawca wykonania",
       "logFile": "Plik dziennika",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -590,6 +590,7 @@
       "system": "Sistema",
       "catalog": "Catálogo",
       "model": "Modelo",
+      "modelPath": "Arquivo do modelo",
       "runtime": "Runtime",
       "executionProvider": "Provedor de execução",
       "logFile": "Arquivo de log",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -591,6 +591,7 @@
       "system": "Система",
       "catalog": "Каталог",
       "model": "Модель",
+      "modelPath": "Файл модели",
       "runtime": "Среда выполнения",
       "executionProvider": "Провайдер выполнения",
       "logFile": "Файл журнала",

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -588,6 +588,7 @@
       "system": "ระบบ",
       "catalog": "แคตตาล็อก",
       "model": "โมเดล",
+      "modelPath": "ไฟล์โมเดล",
       "runtime": "รันไทม์",
       "executionProvider": "ตัวประมวลผล",
       "logFile": "ไฟล์บันทึก",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -589,6 +589,7 @@
       "system": "Sistem",
       "catalog": "Katalog",
       "model": "Model",
+      "modelPath": "Model dosyası",
       "runtime": "Çalışma zamanı",
       "executionProvider": "Yürütme sağlayıcısı",
       "logFile": "Günlük dosyası",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -588,6 +588,7 @@
       "system": "Hệ thống",
       "catalog": "Danh mục",
       "model": "Mô hình",
+      "modelPath": "Tệp mô hình",
       "runtime": "Runtime",
       "executionProvider": "Trình thực thi",
       "logFile": "Tệp nhật ký",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -589,6 +589,7 @@
       "system": "系统",
       "catalog": "目录",
       "model": "模型",
+      "modelPath": "模型文件",
       "runtime": "运行时",
       "executionProvider": "执行提供程序",
       "logFile": "日志文件",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -588,6 +588,7 @@
       "system": "系統",
       "catalog": "目錄",
       "model": "模型",
+      "modelPath": "模型檔案",
       "runtime": "執行環境",
       "executionProvider": "執行提供者",
       "logFile": "記錄檔",

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -282,6 +282,8 @@ export interface DebugInfo {
   model_installed: boolean;
   model_installed_version: string | null;
   model_pinned_version: string;
+  /** Absolute path where the active variant's model file is expected. */
+  model_path: string;
   runtime_state: string;
   runtime_version: string;
   runtime_artifact_id: string | null;


### PR DESCRIPTION
## Why

#270 asked: *"Can I download the model file by myself and then import it? Or config it's path."*

It already works — `resolve_model_installation` checks the managed model path at startup and adopts whatever is there once its SHA-256 matches the catalog pin. But **nothing in the app told the user where that path is.** About reported the variant and its state, not the location, so the honest answer was "go read the app data directory layout for your OS", which is not an answer.

I only found this because I went to write the issue reply and could not point at anything.

## Changes

- `DebugInfo` gains `model_path` — `get_debug_info` already computed `managed_model_path` for the version check, so this is exposing a value that was being thrown away.
- About shows it as **Model file**, a copyable path, in all 18 locales.
- Both READMEs get a three-step *Installing a model by hand* section under AI Models.

The docs say out loud that a digest which does not match the pin is ignored and the normal download runs instead. That is what makes the manual route safe to recommend — without it, "put a file here" sounds like a way to corrupt your install.

No contract-doc change: there is no `get_debug_info` entry under `docs/references/contracts/`.

## Test plan

- [x] `cargo test --lib diagnostics` — 5 passed, including a new assertion on the assembled path and both `assemble_debug_info` fixtures updated
- [x] `pnpm vitest run` — 2090 passed
- [x] `node --run check:i18n` — all 18 locales match
- [x] `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `node --run lint`, `node --run format` — clean

## Related issues

Refs #270