### PR TITLE
feat(standards): adopt product quality baselines

### DIFF
--- a/.agents/skills/delivery/SKILL.md
+++ b/.agents/skills/delivery/SKILL.md
@@ -11,7 +11,9 @@ description: Format delivery reports and PR descriptions. Use when preparing a c
 2. Verification: Report exact commands run and their results.
 3. Gaps: If you ran only a subset, say exactly what you did **not** run.
 4. Contracts: If behavior changed, confirm `docs/references/contracts/*.md` was updated.
-5. Never skip local verification and leave first discovery of breakage to CI.
+5. Standards: For a product-surface change, name the profile from
+   `docs/references/product-standards.md` and its evidence or exception.
+6. Never skip local verification and leave first discovery of breakage to CI.
 
 ## Delivery report template
 

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -37,3 +37,9 @@ Report:
 ## Contract check
 
 If you changed public IPC commands, payloads, or events, verify the corresponding `docs/references/contracts/*.md` was updated in the same change.
+
+## Standards check
+
+For a product-surface change, read `docs/references/product-standards.md` and
+then the matched profile. Run its automated evidence and state any required
+manual evidence in the delivery report.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,7 @@ Report the commands you ran, and say which you skipped and why.
 - [ ] `cd src-tauri && cargo nextest run` _(Rust changes)_
 - [ ] `node --run check:i18n` _(new or changed UI copy)_
 - [ ] `docs/references/contracts/*.md` updated _(public IPC command, payload, or event changed)_
+- [ ] Applicable product-standard profile reviewed; its evidence or exception is stated in this PR
 
 ## Related issues
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
       categories: ${{ steps.classify.outputs.categories }}
       run_triage: ${{ steps.classify.outputs.run_triage }}
       run_conventional-commits: ${{ steps.classify.outputs.run_conventional-commits }}
+      run_standards-reference: ${{ steps.classify.outputs.run_standards-reference }}
       run_ci-gate: ${{ steps.classify.outputs.run_ci-gate }}
       run_js-quality: ${{ steps.classify.outputs.run_js-quality }}
       run_app-frontend: ${{ steps.classify.outputs.run_app-frontend }}
@@ -268,6 +269,32 @@ jobs:
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ── Standards reference ─────────────────────────────────────────────
+  # Validates the mandatory AGENTS.md → index → profile route without
+  # running a full application build for a documentation-only change.
+  standards-reference:
+    name: Standards reference
+    needs: triage
+    if: |
+      !cancelled() &&
+      needs.triage.outputs.run_standards-reference == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+
+      - name: Verify standards route
+        run: node --run check:standards
 
   # ── JS quality ───────────────────────────────────────────────────────
   # Format, lint, i18n, knip, schema drift, and dependency audit.
@@ -1162,6 +1189,7 @@ jobs:
     needs:
       - triage
       - conventional-commits
+      - standards-reference
       - js-quality
       - app-frontend
       - website
@@ -1183,6 +1211,7 @@ jobs:
           EXPECTED_JOBS: ${{ needs.triage.outputs.expected-jobs }}
           TRIAGE: ${{ needs.triage.result }}
           CONVENTIONAL_COMMITS: ${{ needs.conventional-commits.result }}
+          STANDARDS_REFERENCE: ${{ needs.standards-reference.result }}
           JS_QUALITY: ${{ needs.js-quality.result }}
           APP_FRONTEND: ${{ needs.app-frontend.result }}
           WEBSITE: ${{ needs.website.result }}
@@ -1204,6 +1233,7 @@ jobs:
           declare -A JOBS=(
             [triage]="$TRIAGE"
             [conventional-commits]="$CONVENTIONAL_COMMITS"
+            [standards-reference]="$STANDARDS_REFERENCE"
             [js-quality]="$JS_QUALITY"
             [app-frontend]="$APP_FRONTEND"
             [website]="$WEBSITE"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # OpenKara Agent Notes
 
-Coding agent instructions. Self-contained — do not assume cross-referencing.
+Coding agent instructions. This file contains the global rules. Load linked
+guidance only when the current change needs it.
 
 ## Project
 
@@ -32,6 +33,15 @@ Formatting is automated via PostToolUse hook (`pnpm format:write` + `cargo fmt`)
 behavior, types, and contracts. `docs/` exists for humans who need historical
 context or design rationale — do not read `docs/` to understand what the code
 does.
+
+## Product Standards (load on demand)
+
+Before you change a product surface, read
+[`docs/references/product-standards.md`](docs/references/product-standards.md).
+It routes the change to the applicable standard profile. Read only the matched
+profiles. These profiles are repository constraints. Put their required
+automated or manual evidence in the PR. Add an ADR before you introduce a new
+product surface or change a standards target.
 
 ## Documentation Rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,10 @@ cargo nextest run                                # Rust tests
 3. Run the checks above for the areas you touched.
 4. Update `docs/references/contracts/*.md` in the same change when you change a
    public IPC command, payload, or event.
-5. Open a pull request against `main`. The title must follow Conventional
+5. Read the applicable profile in
+   [`docs/references/product-standards.md`](docs/references/product-standards.md).
+   Put its automated or manual evidence, or a documented exception, in the PR.
+6. Open a pull request against `main`. The title must follow Conventional
    Commits, because CI checks it.
 
 ## Commit Messages

--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ pnpm tauri dev               # start dev server with hot reload
 cd src-tauri && cargo test -q   # backend tests (175+; see AGENTS.md for CI notes)
 pnpm lint                    # oxlint
 pnpm format                  # oxfmt check
+node --run check:standards   # standards route
 ```
 
 ### Building
@@ -342,6 +343,7 @@ pnpm tauri build             # production build with platform-specific bundle
 - [Changelog](./CHANGELOG.md) — Shipped changes and version notes
 - [IPC Contracts](./docs/references/contracts/) — Stable backend-facing interfaces
 - [Product Specs](./docs/references/product/) — User-facing behavior specs
+- [Product Standards](./docs/references/product-standards.md) — Change-specific quality constraints
 
 ## Contributing
 

--- a/docs/adr/0013-use-standards-as-product-quality-baselines.md
+++ b/docs/adr/0013-use-standards-as-product-quality-baselines.md
@@ -1,0 +1,45 @@
+# ADR 0013 — Use standards as product quality baselines
+
+Date: 2026-07-28
+Status: accepted
+
+## Context
+
+OpenKara is a cross-platform desktop app. It uses a WebView, native window
+features, local audio, remote libraries, OAuth, and signed updates. The
+project has quality checks for many of these areas. It needs a common source
+for the quality target of each area.
+
+## Decision
+
+OpenKara uses versioned standards as product quality baselines. The active
+standards, their scope, and their evidence are in
+[`docs/references/product-standards.md`](../references/product-standards.md).
+
+WCAG 2.2 level AA is the accessibility target for all rendered UI. WCAG2ICT
+extends that target to desktop software behavior. WAI-ARIA Authoring Practices
+define custom widget behavior. ISO 9241 defines the human-centred design and
+interaction review model. ISO/IEC 25010 defines the product quality model.
+
+The standards profile also defines product copy, locale tags, external
+protocols, security, release supply chain, and audio measurement. A change
+uses every profile that applies to its affected surface. A new standard
+version, a changed conformance target, or a removed profile needs a new ADR.
+
+Automated checks provide repeatable evidence. A complete conformance claim
+also needs review of the affected user process. An exception records the
+standard clause, user effect, reason, and compensating control in the change
+that introduces it.
+
+## Consequences
+
+- Every interactive feature has a keyboard path, accessible name, appropriate
+  role, state or value, focus order, and status feedback where needed.
+- Product changes use the ISO 9241 interaction principles and the ISO/IEC
+  25010 quality model during acceptance review.
+- User-visible text, locale data, network protocols, release artifacts, and
+  audio measurements use their selected standards instead of ad hoc formats.
+- New standard-specific test code names the exact standard version and clause
+  family that it checks.
+- A passing automation suite is evidence for the covered paths. Release
+  conformance claims include the remaining manual and platform checks.

--- a/docs/adr/0014-route-product-standards-by-changed-surface.md
+++ b/docs/adr/0014-route-product-standards-by-changed-surface.md
@@ -1,0 +1,33 @@
+# ADR 0014 — Route product standards by changed surface
+
+Date: 2026-07-28
+Status: accepted
+
+## Context
+
+ADR 0013 selects product quality standards. A single reference page gives
+agents too much unrelated material. An agent can also miss the standards route
+when `AGENTS.md` does not name it.
+
+## Decision
+
+`AGENTS.md` contains a short mandatory route to
+[`docs/references/product-standards.md`](../references/product-standards.md).
+The page maps changed product surfaces to small profile documents in
+`docs/references/standards/`.
+
+An implementation reads the index and only its matching profiles. A profile
+states its authorities, constraints, and required evidence. The pull request
+records that evidence or a standard-specific exception. A new product surface
+or a changed conformance target needs an ADR.
+
+`check:standards` verifies the routing structure in local hooks and CI. It
+protects the route. It does not replace feature-level tests or human review.
+
+## Consequences
+
+- Every future agent receives the standards route without loading the full
+  standards reference.
+- Standard guidance stays close to the surface that uses it.
+- The repository claims conformance only where it has matching evidence.
+- A broken standards route fails before merge.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -50,3 +50,4 @@ Write new ADRs in ASD-STE100 Simplified English. See `AGENTS.md` for the rules. 
 - [0010 — Library sort is mixed-script, locale-aware, case-insensitive](./0010-library-sort-mixed-script.md)
 - [0011 — Remote library mirror is database-first, files-lazy](./0011-remote-library-mirror-database-first.md)
 - [0012 — CDG seek resets both timelines, transport_generation preserves renderer](./0012-cdg-seek-resets-both-timelines.md)
+- [0013 — Use standards as product quality baselines](./0013-use-standards-as-product-quality-baselines.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -51,3 +51,4 @@ Write new ADRs in ASD-STE100 Simplified English. See `AGENTS.md` for the rules. 
 - [0011 — Remote library mirror is database-first, files-lazy](./0011-remote-library-mirror-database-first.md)
 - [0012 — CDG seek resets both timelines, transport_generation preserves renderer](./0012-cdg-seek-resets-both-timelines.md)
 - [0013 — Use standards as product quality baselines](./0013-use-standards-as-product-quality-baselines.md)
+- [0014 — Route product standards by changed surface](./0014-route-product-standards-by-changed-surface.md)

--- a/docs/references/product-standards.md
+++ b/docs/references/product-standards.md
@@ -1,0 +1,78 @@
+# Product Standards
+
+This page lists the selected standards for OpenKara. It gives each standard a
+scope and an evidence type. It does not make a whole-product certification
+claim.
+
+## Use of standards
+
+A change uses every profile that matches its affected product surface. An
+exception records the standard clause, user effect, reason, and compensating
+control in the same change.
+
+Automated checks give repeatable evidence. Review of a complete user process
+gives evidence for behavior that tools cannot measure.
+
+## Accessibility and interaction
+
+| Area                | Authority                                                        | Scope                                                                   | Evidence                                                                                                                    |
+| ------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Rendered UI         | [WCAG 2.2, level AA](https://www.w3.org/TR/WCAG22/)              | All React and WebView screens                                           | `jsx-a11y`, axe, keyboard Playwright tests, platform review                                                                 |
+| Desktop behavior    | [WCAG2ICT 2.2](https://www.w3.org/TR/wcag2ict-22/)               | Windows, dialogs, system integration, and non-web behavior              | Keyboard, focus, assistive-technology, and platform review                                                                  |
+| Custom widgets      | [WAI-ARIA Authoring Practices](https://www.w3.org/WAI/ARIA/apg/) | Dialogs, menus, lists, sliders, trees, drag operations, and live status | Native HTML first; APG role, state, and keyboard tests for custom widgets                                                   |
+| Interaction quality | [ISO 9241-110:2020](https://www.iso.org/standard/75258.html)     | Every material interaction change                                       | Review of task fit, clarity, user control, error recovery, and consistency                                                  |
+| Design process      | [ISO 9241-210:2019](https://www.iso.org/standard/77520.html)     | New or changed user flows                                               | User context, task scenario, prototype or implementation evidence, and outcome review                                       |
+| Product quality     | [ISO/IEC 25010:2023](https://www.iso.org/standard/78176.html)    | Feature and release acceptance                                          | Functional, performance, compatibility, usability, reliability, security, maintainability, portability, and safety evidence |
+
+Every action has a keyboard path. Every control has an accessible name. Native
+HTML elements carry semantics by default. A custom widget uses the matching
+APG pattern. Keyboard focus stays visible and unobscured. Interactive targets
+meet WCAG 2.2 target-size requirements. A dialog traps focus while open,
+closes by Escape where suitable, and returns focus to its invoking control.
+
+[Apple Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/),
+[Microsoft accessibility guidance](https://learn.microsoft.com/windows/apps/develop/accessibility),
+and [GNOME Human Interface Guidelines](https://developer.gnome.org/hig/)
+provide platform conventions. Platform conventions shape command names,
+shortcuts, menus, and window behavior on their platform.
+
+## Copy, language, and locale data
+
+| Area              | Authority                                                                    | Scope                                                             | Evidence                                                     |
+| ----------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------ |
+| Product copy      | [ISO 24495-1:2023](https://www.iso.org/standard/78907.html)                  | Labels, descriptions, errors, confirmations, and recovery text    | Copy review: users can find, understand, and use the message |
+| Technical English | ASD-STE100 Simplified English                                                | Repository technical prose                                        | Repository documentation review                              |
+| Language tags     | [BCP 47 / RFC 5646](https://www.rfc-editor.org/rfc/rfc5646)                  | Locale file names, HTML `lang`, settings, and API locale fields   | Canonical-tag tests and language-change tests                |
+| Locale data       | [Unicode LDML / TR35](https://unicode.org/reports/tr35/) and platform `Intl` | Display names, collation, dates, times, numbers, and plural rules | Locale tests and native-platform formatting                  |
+| Wire timestamps   | [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339)                           | Public data, remote sync records, and logs with timestamps        | Contract and serialization tests                             |
+
+Product text uses one term for one concept in each locale. Action labels start
+with a verb when they start an action. Error text states the problem, current
+state, and a safe recovery action. Translators preserve meaning and may change
+word order for their language.
+
+## Remote data, security, and releases
+
+| Area                 | Authority                                                                                                 | Scope                                                                  | Evidence                                                               |
+| -------------------- | --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| WebDAV and HTTP      | [RFC 4918](https://www.rfc-editor.org/rfc/rfc4918) and [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110) | Every WebDAV method and conditional write that OpenKara supports       | Provider contract and integration tests                                |
+| OAuth                | [RFC 9700](https://www.rfc-editor.org/rfc/rfc9700) and [RFC 7636](https://www.rfc-editor.org/rfc/rfc7636) | Browser-based OAuth for public desktop clients                         | Redirect, PKCE, token-storage, and reauthorization tests               |
+| Application security | [OWASP ASVS 5.0](https://owasp.org/www-project-application-security-verification-standard/)               | WebView, IPC input, local data, remote providers, and release services | Versioned security requirements, dependency checks, and security tests |
+| Secure development   | [NIST SSDF 1.1](https://csrc.nist.gov/pubs/sp/800/218/final)                                              | Source, dependencies, review, build, release, and response process     | CI gates, pinned actions, dependency policy, and release review        |
+| Privacy risk         | [NIST Privacy Framework 1.0](https://www.nist.gov/privacy-framework)                                      | Library data, remote sync, telemetry, diagnostics, and OAuth data      | Data map, minimization, user control, retention, and disclosure review |
+| Release provenance   | [SLSA 1.2](https://slsa.dev/spec/v1.2/) and [SPDX 3.0.1](https://spdx.github.io/spdx-spec/v3.0.1/)        | Published installers, update artifacts, and dependency inventory       | Signed artifacts, provenance, and a published SBOM                     |
+
+OpenKara applies ASVS requirements where the requirement matches the
+application architecture. The project names the ASVS version and requirement
+identifier when it records a security requirement. Release provenance and the
+SBOM describe the exact release artifact and its build inputs.
+
+## Audio
+
+| Area                   | Authority                                                              | Scope                                                                       | Evidence                                               |
+| ---------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------ |
+| Loudness and true peak | [ITU-R BS.1770-5](https://www.itu.int/rec/R-REC-BS.1770-5-202311-I/en) | Loudness display, normalization, limiter behavior, and exported measurement | Deterministic fixture measurements and tolerance tests |
+
+BS.1770-5 applies when OpenKara measures or changes loudness. It gives no
+source-separation quality score and no playback-clock synchronization model.
+Those areas use product contracts, deterministic fixtures, and dedicated ADRs.

--- a/docs/references/product-standards.md
+++ b/docs/references/product-standards.md
@@ -1,78 +1,26 @@
 # Product Standards
 
-This page lists the selected standards for OpenKara. It gives each standard a
-scope and an evidence type. It does not make a whole-product certification
-claim.
+This page routes a change to the standards that apply to it. It does not make
+a whole-product certification claim.
 
-## Use of standards
+## Required route
 
-A change uses every profile that matches its affected product surface. An
-exception records the standard clause, user effect, reason, and compensating
-control in the same change.
+Before a product-surface change, identify the affected surfaces. Read only the
+matching profile. Put the required automated or manual evidence in the pull
+request. Record an exception with its standard clause, user effect, reason, and
+compensating control in the same change.
 
-Automated checks give repeatable evidence. Review of a complete user process
-gives evidence for behavior that tools cannot measure.
+| Changed surface                                                                                            | Read this profile                                                             | Required evidence                                                       |
+| ---------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Feature outcome, acceptance, architecture, quality, or tests                                               | [Lifecycle, quality, and testing](standards/lifecycle-quality-and-testing.md) | Traceable acceptance evidence, tests, and ADR when required             |
+| Rendered UI, keyboard input, dialogs, menus, drag operations, or task flow                                 | [Interaction and accessibility](standards/interaction-and-accessibility.md)   | Static, browser, and platform evidence that matches the widget or flow  |
+| Product copy, locale, terminology, timestamps, units, or serialized data                                   | [Language, terminology, and data](standards/language-terminology-and-data.md) | Copy, locale, serialization, and contract evidence                      |
+| IPC, WebDAV, OAuth, a public HTTP API, events, or compatibility                                            | [Interfaces and compatibility](standards/interfaces-and-compatibility.md)     | Contract, integration, migration, and error-model evidence              |
+| Credentials, local data, remote providers, privacy, dependency, CI, or release artifacts                   | [Security, privacy, and release](standards/security-privacy-and-release.md)   | Threat, privacy, dependency, and release evidence                       |
+| Model catalog, source separation, loudness, telemetry, a hosted service, container, or Kubernetes resource | [Models, media, and operations](standards/models-media-and-operations.md)     | Deterministic media or model evidence and service evidence when present |
 
-## Accessibility and interaction
+The profiles are constraints when their scope matches. A profile never creates
+a feature roadmap. A new product surface or a changed conformance target needs
+an ADR.
 
-| Area                | Authority                                                        | Scope                                                                   | Evidence                                                                                                                    |
-| ------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| Rendered UI         | [WCAG 2.2, level AA](https://www.w3.org/TR/WCAG22/)              | All React and WebView screens                                           | `jsx-a11y`, axe, keyboard Playwright tests, platform review                                                                 |
-| Desktop behavior    | [WCAG2ICT 2.2](https://www.w3.org/TR/wcag2ict-22/)               | Windows, dialogs, system integration, and non-web behavior              | Keyboard, focus, assistive-technology, and platform review                                                                  |
-| Custom widgets      | [WAI-ARIA Authoring Practices](https://www.w3.org/WAI/ARIA/apg/) | Dialogs, menus, lists, sliders, trees, drag operations, and live status | Native HTML first; APG role, state, and keyboard tests for custom widgets                                                   |
-| Interaction quality | [ISO 9241-110:2020](https://www.iso.org/standard/75258.html)     | Every material interaction change                                       | Review of task fit, clarity, user control, error recovery, and consistency                                                  |
-| Design process      | [ISO 9241-210:2019](https://www.iso.org/standard/77520.html)     | New or changed user flows                                               | User context, task scenario, prototype or implementation evidence, and outcome review                                       |
-| Product quality     | [ISO/IEC 25010:2023](https://www.iso.org/standard/78176.html)    | Feature and release acceptance                                          | Functional, performance, compatibility, usability, reliability, security, maintainability, portability, and safety evidence |
-
-Every action has a keyboard path. Every control has an accessible name. Native
-HTML elements carry semantics by default. A custom widget uses the matching
-APG pattern. Keyboard focus stays visible and unobscured. Interactive targets
-meet WCAG 2.2 target-size requirements. A dialog traps focus while open,
-closes by Escape where suitable, and returns focus to its invoking control.
-
-[Apple Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/),
-[Microsoft accessibility guidance](https://learn.microsoft.com/windows/apps/develop/accessibility),
-and [GNOME Human Interface Guidelines](https://developer.gnome.org/hig/)
-provide platform conventions. Platform conventions shape command names,
-shortcuts, menus, and window behavior on their platform.
-
-## Copy, language, and locale data
-
-| Area              | Authority                                                                    | Scope                                                             | Evidence                                                     |
-| ----------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------ |
-| Product copy      | [ISO 24495-1:2023](https://www.iso.org/standard/78907.html)                  | Labels, descriptions, errors, confirmations, and recovery text    | Copy review: users can find, understand, and use the message |
-| Technical English | ASD-STE100 Simplified English                                                | Repository technical prose                                        | Repository documentation review                              |
-| Language tags     | [BCP 47 / RFC 5646](https://www.rfc-editor.org/rfc/rfc5646)                  | Locale file names, HTML `lang`, settings, and API locale fields   | Canonical-tag tests and language-change tests                |
-| Locale data       | [Unicode LDML / TR35](https://unicode.org/reports/tr35/) and platform `Intl` | Display names, collation, dates, times, numbers, and plural rules | Locale tests and native-platform formatting                  |
-| Wire timestamps   | [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339)                           | Public data, remote sync records, and logs with timestamps        | Contract and serialization tests                             |
-
-Product text uses one term for one concept in each locale. Action labels start
-with a verb when they start an action. Error text states the problem, current
-state, and a safe recovery action. Translators preserve meaning and may change
-word order for their language.
-
-## Remote data, security, and releases
-
-| Area                 | Authority                                                                                                 | Scope                                                                  | Evidence                                                               |
-| -------------------- | --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| WebDAV and HTTP      | [RFC 4918](https://www.rfc-editor.org/rfc/rfc4918) and [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110) | Every WebDAV method and conditional write that OpenKara supports       | Provider contract and integration tests                                |
-| OAuth                | [RFC 9700](https://www.rfc-editor.org/rfc/rfc9700) and [RFC 7636](https://www.rfc-editor.org/rfc/rfc7636) | Browser-based OAuth for public desktop clients                         | Redirect, PKCE, token-storage, and reauthorization tests               |
-| Application security | [OWASP ASVS 5.0](https://owasp.org/www-project-application-security-verification-standard/)               | WebView, IPC input, local data, remote providers, and release services | Versioned security requirements, dependency checks, and security tests |
-| Secure development   | [NIST SSDF 1.1](https://csrc.nist.gov/pubs/sp/800/218/final)                                              | Source, dependencies, review, build, release, and response process     | CI gates, pinned actions, dependency policy, and release review        |
-| Privacy risk         | [NIST Privacy Framework 1.0](https://www.nist.gov/privacy-framework)                                      | Library data, remote sync, telemetry, diagnostics, and OAuth data      | Data map, minimization, user control, retention, and disclosure review |
-| Release provenance   | [SLSA 1.2](https://slsa.dev/spec/v1.2/) and [SPDX 3.0.1](https://spdx.github.io/spdx-spec/v3.0.1/)        | Published installers, update artifacts, and dependency inventory       | Signed artifacts, provenance, and a published SBOM                     |
-
-OpenKara applies ASVS requirements where the requirement matches the
-application architecture. The project names the ASVS version and requirement
-identifier when it records a security requirement. Release provenance and the
-SBOM describe the exact release artifact and its build inputs.
-
-## Audio
-
-| Area                   | Authority                                                              | Scope                                                                       | Evidence                                               |
-| ---------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------ |
-| Loudness and true peak | [ITU-R BS.1770-5](https://www.itu.int/rec/R-REC-BS.1770-5-202311-I/en) | Loudness display, normalization, limiter behavior, and exported measurement | Deterministic fixture measurements and tolerance tests |
-
-BS.1770-5 applies when OpenKara measures or changes loudness. It gives no
-source-separation quality score and no playback-clock synchronization model.
-Those areas use product contracts, deterministic fixtures, and dedicated ADRs.
+See [the standards directory](standards/README.md) for the profile index.

--- a/docs/references/standards/README.md
+++ b/docs/references/standards/README.md
@@ -1,0 +1,17 @@
+# Standards Profiles
+
+Open the profile that matches the product surface that you change. The profile
+states its authorities, constraints, and required evidence. It is current-state
+guidance. It does not describe a backlog.
+
+| Profile                                                             | Use when you change                                                              |
+| ------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| [Lifecycle, quality, and testing](lifecycle-quality-and-testing.md) | Requirements, acceptance, architecture, quality, or test evidence                |
+| [Interaction and accessibility](interaction-and-accessibility.md)   | UI, input, user flow, assistive technology, or platform behavior                 |
+| [Language, terminology, and data](language-terminology-and-data.md) | Copy, locale data, terms, dates, times, units, or structured values              |
+| [Interfaces and compatibility](interfaces-and-compatibility.md)     | IPC, sync, OAuth, WebDAV, public HTTP APIs, events, or versions                  |
+| [Security, privacy, and release](security-privacy-and-release.md)   | Secrets, local or remote data, dependencies, CI, release, or disclosure          |
+| [Models, media, and operations](models-media-and-operations.md)     | Models, source separation, audio measurement, telemetry, services, or containers |
+
+The route starts in
+[`docs/references/product-standards.md`](../product-standards.md).

--- a/docs/references/standards/interaction-and-accessibility.md
+++ b/docs/references/standards/interaction-and-accessibility.md
@@ -1,0 +1,34 @@
+# Interaction and Accessibility
+
+Use this profile for every rendered UI, input path, user flow, or platform
+interaction.
+
+## Authorities
+
+| Authority                                                                                                                              | Use in OpenKara                                                                                 |
+| -------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| [WCAG 2.2 AA](https://www.w3.org/TR/WCAG22/) and [ISO/IEC 40500:2025](https://www.iso.org/standard/91029.html)                         | Rendered WebView UI conformance target                                                          |
+| [WCAG2ICT 2.2](https://www.w3.org/TR/wcag2ict-22/)                                                                                     | Desktop and non-web interpretation of WCAG 2.2                                                  |
+| [WAI-ARIA Authoring Practices](https://www.w3.org/WAI/ARIA/apg/)                                                                       | Keyboard and state behavior for custom widgets                                                  |
+| [ISO 9241-110:2020](https://www.iso.org/standard/75258.html)                                                                           | Interaction principles for task fit, clarity, user control, error tolerance, and consistency    |
+| [ISO 9241-210:2019](https://www.iso.org/standard/77520.html)                                                                           | Human-centred design for changed user flows                                                     |
+| Apple, [Microsoft](https://learn.microsoft.com/windows/apps/develop/accessibility), and [GNOME](https://developer.gnome.org/hig/) HIGs | Platform command names, shortcuts, menus, window behavior, and assistive technology conventions |
+
+## Constraints
+
+- Every action has a keyboard path. Every control has an accessible name.
+- Prefer native HTML semantics. A custom widget follows its matching APG
+  pattern for role, state, value, focus, and keyboard operation.
+- Focus stays visible and unobscured. A suitable dialog traps focus, responds
+  to Escape, and returns focus to its invoking control.
+- Interactive targets meet WCAG 2.2 target-size requirements.
+- Status, progress, errors, and results have the required semantic feedback.
+- A material task-flow change reviews task fit, clarity, user control, error
+  recovery, and consistency before acceptance.
+
+## Required evidence
+
+- `jsx-a11y` and the WCAG 2.2 A/AA axe suite for changed rendered UI.
+- Keyboard browser tests for changed custom widgets or critical user flows.
+- A platform and assistive-technology review when native window behavior,
+  menus, drag operations, or OS integration changes.

--- a/docs/references/standards/interfaces-and-compatibility.md
+++ b/docs/references/standards/interfaces-and-compatibility.md
@@ -1,0 +1,36 @@
+# Interfaces and Compatibility
+
+Use this profile for IPC, remote sync, authentication, public HTTP APIs, event
+interfaces, schemas, and compatibility decisions.
+
+## Authorities
+
+| Authority                                                                                                                                                                                         | Use in OpenKara                                                           |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| [HTTP Semantics, RFC 9110](https://www.rfc-editor.org/rfc/rfc9110) and [WebDAV, RFC 4918](https://www.rfc-editor.org/rfc/rfc4918)                                                                 | Remote library methods, conditional writes, status handling, and recovery |
+| [OAuth 2.0 Security BCP, RFC 9700](https://www.rfc-editor.org/rfc/rfc9700) and [PKCE, RFC 7636](https://www.rfc-editor.org/rfc/rfc7636)                                                           | Public desktop OAuth redirect, PKCE, token use, and reauthorization       |
+| [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html)                                                                                                                                  | Versioned public contracts, plugins, SDKs, and compatibility commitments  |
+| [OpenAPI 3.1.1](https://spec.openapis.org/oas/v3.1.1.html), [JSON Schema 2020-12](https://json-schema.org/draft/2020-12/json-schema-core), and [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) | A public HTTP API, its schemas, and its problem responses                 |
+| [AsyncAPI 3.0.0](https://www.asyncapi.com/docs/reference/specification/v3.0.0) and [CloudEvents 1.0](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md)                           | A public event or message interface                                       |
+
+## Constraints
+
+OpenKara currently exposes Tauri IPC contracts and remote WebDAV providers.
+The matching contract document changes with any public IPC command, payload,
+event, or source enum.
+
+Use OpenAPI, JSON Schema, and RFC 9457 only when a change exposes a public HTTP
+API. Use AsyncAPI and CloudEvents only when a change exposes a public event
+interface. A change that introduces either surface adds an ADR before it
+commits the contract.
+
+Use Semantic Versioning when the project makes a versioned public compatibility
+commitment. Define a migration and a compatibility window before a breaking
+change.
+
+## Required evidence
+
+- Contract and provider integration tests for changed IPC, WebDAV, or OAuth
+  behavior.
+- Schema and problem-response tests for a public HTTP API.
+- Compatibility, migration, and consumer evidence for a breaking change.

--- a/docs/references/standards/language-terminology-and-data.md
+++ b/docs/references/standards/language-terminology-and-data.md
@@ -1,0 +1,37 @@
+# Language, Terminology, and Data
+
+Use this profile for user-visible text, locale behavior, terms, timestamps,
+units, serialized values, and logs.
+
+## Authorities
+
+| Authority                                                                                                                    | Use in OpenKara                                                                                      |
+| ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| [ISO 24495-1:2023](https://www.iso.org/standard/78907.html)                                                                  | Plain language for labels, help, errors, confirmations, and recovery text                            |
+| ASD-STE100 Simplified English                                                                                                | Repository technical prose, as defined in `AGENTS.md`                                                |
+| [ISO 704:2022](https://www.iso.org/standard/79077.html) and [ISO 1087:2019](https://www.iso.org/standard/62330.html)         | One concept, one preferred term, stable definitions, controlled synonyms, and terminology vocabulary |
+| [BCP 47 / RFC 5646](https://www.rfc-editor.org/rfc/rfc5646)                                                                  | Locale tags in files, HTML, settings, and public data                                                |
+| [Unicode LDML / TR35](https://unicode.org/reports/tr35/) and platform `Intl`                                                 | Display names, collation, dates, times, numbers, and plural rules                                    |
+| [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339) and [ISO 8601-1:2019](https://www.iso.org/standard/70907.html)            | Interchange timestamps, dates, and machine-readable time values                                      |
+| [ISO 80000](https://www.iso.org/standard/76921.html) and the [SI Brochure](https://www.bipm.org/en/publications/si-brochure) | Quantity names, symbols, and explicit base-unit fields                                               |
+
+## Constraints
+
+- Use one preferred term for one concept in each locale. Define a cross-surface
+  term before using a new synonym for it.
+- Use concise action labels. Error text states the problem, current state, and
+  safe recovery action.
+- Use canonical BCP 47 tags. Keep the document `lang` value synchronized with
+  the selected locale.
+- Use `Intl` or locale data for human display. Use RFC 3339 for public wire
+  timestamps. Do not use localized display strings as interchange data.
+- Name numeric fields with their unit, such as `duration_ms`, `size_bytes`, or
+  `gain_db`. Store a defined base unit and convert only at the display edge.
+
+## Required evidence
+
+- Locale-key parity and canonical-tag tests for changed UI copy or locale data.
+- Serialization or contract tests for changed timestamps, numeric values, and
+  unit-bearing fields.
+- Copy review for new user-facing messages and terminology review for a new
+  cross-surface term.

--- a/docs/references/standards/lifecycle-quality-and-testing.md
+++ b/docs/references/standards/lifecycle-quality-and-testing.md
@@ -1,0 +1,37 @@
+# Lifecycle, Quality, and Testing
+
+Use this profile for a material behavior change, a feature acceptance decision,
+an architecture decision, or test design.
+
+## Authorities
+
+| Authority                                                            | Use in OpenKara                                                                                                                           |
+| -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| [ISO/IEC/IEEE 12207:2026](https://www.iso.org/standard/90219.html)   | Lifecycle vocabulary and responsibility from change through operation and maintenance                                                     |
+| [ISO/IEC/IEEE 29148:2018](https://www.iso.org/standard/72089.html)   | Outcome, acceptance criteria, priority, and traceability for material requirements                                                        |
+| [ISO/IEC/IEEE 42010:2022](https://www.iso.org/standard/74393.html)   | Stakeholders, concerns, views, and ADRs for architecture decisions                                                                        |
+| [ISO/IEC 25010:2023](https://www.iso.org/standard/78176.html)        | Functional suitability, performance, compatibility, usability, reliability, security, maintainability, portability, and safety acceptance |
+| [ISO/IEC/IEEE 29119-1:2022](https://www.iso.org/standard/81291.html) | Test concepts and traceable test evidence                                                                                                 |
+| [ISO 9241-11:2018](https://www.iso.org/standard/63500.html)          | Effectiveness, efficiency, and satisfaction in a named context of use                                                                     |
+
+## Constraints
+
+- A material change names its user outcome and acceptance criteria in its issue
+  or pull request.
+- Each acceptance criterion has automated evidence or a named manual review.
+- A load-bearing architecture choice records its stakeholders, concern,
+  decision, and consequences in an ADR.
+- Acceptance selects the ISO/IEC 25010 characteristics that the change can
+  affect. It does not use a generic quality claim.
+- A usability review names the user, task, environment, completion result,
+  time or effort, and errors that matter for the change.
+- Tests state the behavior that they prove. A test that only mirrors an
+  implementation detail does not substitute for acceptance evidence.
+
+## Required evidence
+
+- Linked acceptance criteria and a test, inspection, or manual task result for
+  each criterion.
+- An ADR for a durable architecture or standards decision.
+- Regression coverage for a defect or an explicit reason why the behavior has
+  no stable automated seam.

--- a/docs/references/standards/models-media-and-operations.md
+++ b/docs/references/standards/models-media-and-operations.md
@@ -1,0 +1,38 @@
+# Models, Media, and Operations
+
+Use this profile for model catalog changes, source separation, audio
+measurement, telemetry, a hosted service, container images, or Kubernetes
+resources.
+
+## Authorities
+
+| Authority                                                                                                                                                                                                             | Use in OpenKara                                                                |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| [ITU-R BS.1770-5](https://www.itu.int/rec/R-REC-BS.1770-5-202311-I/en)                                                                                                                                                | Loudness, true peak, normalization, limiter behavior, and exported measurement |
+| [ISO/IEC 42001:2023](https://www.iso.org/standard/81230.html), [ISO/IEC 23894:2023](https://www.iso.org/standard/77304.html), and [NIST AI RMF 1.0](https://www.nist.gov/itl/ai-risk-management-framework)            | Governance and risk review for model or dataset changes                        |
+| Model Cards and Datasheets for Datasets                                                                                                                                                                               | Model capability, limits, evaluation data, provenance, and known risks         |
+| [OpenTelemetry](https://opentelemetry.io/docs/specs/) and SRE SLI/SLO practice                                                                                                                                        | A hosted service, telemetry pipeline, or user-critical remote operation        |
+| [OCI Image and Distribution Specifications](https://opencontainers.org/) and [Kubernetes API conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md) | Container images, registries, or Kubernetes-native APIs                        |
+
+## Constraints
+
+- BS.1770-5 applies only when the product measures or changes loudness. It
+  does not define source-separation quality or playback-clock synchronization.
+- A model or catalog change records source, license, checksum, supported
+  platform, deterministic evaluation fixture, capability limit, and known user
+  effect. Keep model input local unless the user has a clear remote-data choice.
+- Do not claim ISO/IEC 42001 certification or AI RMF conformance. These
+  authorities guide model and dataset risk review.
+- A hosted service or telemetry pipeline defines its SLI, SLO, error budget,
+  data purpose, retention, and user control before it collects production data.
+- A container or Kubernetes interface uses its matching OCI or API convention
+  and records the new product surface in an ADR.
+
+## Required evidence
+
+- Deterministic fixture measurements and tolerances for changed loudness or
+  media processing.
+- Catalog, provenance, license, checksum, and model-evaluation evidence for a
+  changed model.
+- Trace, metric, log, SLO, and privacy evidence for a hosted service or
+  telemetry change.

--- a/docs/references/standards/security-privacy-and-release.md
+++ b/docs/references/standards/security-privacy-and-release.md
@@ -1,0 +1,39 @@
+# Security, Privacy, and Release
+
+Use this profile for credentials, local or remote data, dependencies, build
+automation, releases, vulnerability handling, and privacy behavior.
+
+## Authorities
+
+| Authority                                                                                                                       | Use in OpenKara                                                                                     |
+| ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| [OWASP ASVS 5.0](https://owasp.org/www-project-application-security-verification-standard/)                                     | Versioned application-security requirements for WebView, IPC, data, providers, and release services |
+| [NIST SSDF 1.1](https://csrc.nist.gov/pubs/sp/800/218/final)                                                                    | Secure development, code review, dependency, build, release, and response controls                  |
+| [NIST Privacy Framework 1.0](https://www.nist.gov/privacy-framework)                                                            | Data map, minimization, user control, retention, and disclosure review                              |
+| [ISO/IEC 27001:2022](https://www.iso.org/standard/27001) and [ISO/IEC 27701:2025](https://www.iso.org/standard/27701)           | Governance reference for information-security and privacy management systems                        |
+| [ISO/IEC 29147:2018](https://www.iso.org/standard/72311.html) and [ISO/IEC 30111:2019](https://www.iso.org/standard/69725.html) | Vulnerability disclosure and handling process                                                       |
+| [SLSA 1.2](https://slsa.dev/spec/v1.2/) and [SPDX 3.0.1](https://spdx.github.io/spdx-spec/v3.0.1/)                              | Artifact provenance and software bill of materials                                                  |
+
+## Constraints
+
+- Apply the ASVS requirement that matches the changed architecture. Record its
+  version and identifier when a security requirement drives the design.
+- Treat credentials, library data, OAuth data, diagnostics, and telemetry as
+  data subjects to privacy review. Keep only the data needed for the stated
+  user outcome.
+- Do not claim ISO 27001 or ISO 27701 certification. These standards guide
+  governance controls when the project has evidence for them.
+- A public vulnerability-disclosure SLA requires `SECURITY.md`, a private
+  reporting channel, severity handling, and coordinated disclosure evidence.
+- A release may claim SLSA provenance or an SPDX SBOM only when the release
+  workflow creates and publishes that exact artifact evidence.
+
+## Required evidence
+
+- Security tests, threat review, or ASVS requirement evidence for a changed
+  trust boundary.
+- Privacy review for changed data collection, storage, sync, diagnostics, or
+  user control.
+- Dependency policy and build evidence for changed dependencies or workflows.
+- Signed artifacts, provenance, and SBOM evidence when a release claim uses
+  those terms.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -43,6 +43,9 @@ pre-push:
     lint:
       use_stdin: true
       run: sh scripts/git-hooks/skip-delete-only-push.sh 'node --run lint'
+    standards-route:
+      use_stdin: true
+      run: sh scripts/git-hooks/skip-delete-only-push.sh 'node --run check:standards'
     patch-coverage:
       use_stdin: true
       run: sh scripts/git-hooks/skip-delete-only-push.sh 'pnpm test:coverage && pnpm check:patch-coverage'

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "render:winget": "node scripts/render-winget-manifests.mjs",
     "generate:db-schema": "node scripts/generate-db-schema.mjs",
     "check:i18n": "node scripts/check-i18n.mjs",
+    "check:standards": "node scripts/check-standards.mjs",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "check:patch-coverage": "node scripts/check-patch-coverage.mjs",

--- a/scripts/check-standards.mjs
+++ b/scripts/check-standards.mjs
@@ -1,0 +1,88 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const profiles = [
+  "lifecycle-quality-and-testing.md",
+  "interaction-and-accessibility.md",
+  "language-terminology-and-data.md",
+  "interfaces-and-compatibility.md",
+  "security-privacy-and-release.md",
+  "models-media-and-operations.md",
+];
+
+const requiredFiles = [
+  "AGENTS.md",
+  "CONTRIBUTING.md",
+  ".github/PULL_REQUEST_TEMPLATE.md",
+  "docs/references/product-standards.md",
+  "docs/references/standards/README.md",
+  "docs/adr/0014-route-product-standards-by-changed-surface.md",
+  ...profiles.map((profile) => `docs/references/standards/${profile}`),
+];
+
+const failures = [];
+
+function read(path) {
+  const absolutePath = resolve(root, path);
+  if (!existsSync(absolutePath)) {
+    failures.push(`Missing required standards file: ${path}`);
+    return "";
+  }
+  return readFileSync(absolutePath, "utf8");
+}
+
+for (const path of requiredFiles) {
+  read(path);
+}
+
+const agents = read("AGENTS.md");
+if (!agents.includes("docs/references/product-standards.md")) {
+  failures.push("AGENTS.md does not route agents to product standards.");
+}
+
+const contributing = read("CONTRIBUTING.md");
+if (!contributing.includes("docs/references/product-standards.md")) {
+  failures.push(
+    "CONTRIBUTING.md does not route contributors to product standards.",
+  );
+}
+
+const template = read(".github/PULL_REQUEST_TEMPLATE.md");
+if (!template.includes("product-standard profile")) {
+  failures.push(
+    "The pull request template has no product-standards evidence check.",
+  );
+}
+
+const index = read("docs/references/product-standards.md");
+for (const profile of profiles) {
+  if (!index.includes(`standards/${profile}`)) {
+    failures.push(`Product standards index does not link to ${profile}.`);
+  }
+}
+
+for (const profile of profiles) {
+  const path = `docs/references/standards/${profile}`;
+  const contents = read(path);
+  if (!contents.includes("## Authorities")) {
+    failures.push(`${path} has no authorities section.`);
+  }
+  if (!contents.includes("## Constraints")) {
+    failures.push(`${path} has no constraints section.`);
+  }
+  if (!contents.includes("## Required evidence")) {
+    failures.push(`${path} has no required-evidence section.`);
+  }
+}
+
+if (failures.length > 0) {
+  for (const failure of failures) {
+    console.error(`Standards check failed: ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log("Standards route is valid.");

--- a/scripts/ci/classify-changes.mjs
+++ b/scripts/ci/classify-changes.mjs
@@ -120,6 +120,7 @@ const CATEGORY_PATTERNS = {
     ".github/workflows/ci.yml",
     ".github/labeler.yml",
     "scripts/ci/**",
+    "scripts/check-standards.mjs",
     "tests/ci/**",
     "tests/workflow-security.test.ts",
     "scripts/check-patch-coverage.mjs",
@@ -208,6 +209,8 @@ function classifyFile(file) {
 const JOB_RULES = {
   triage: () => true,
   "conventional-commits": (_cats, event) => event === "pull_request",
+  "standards-reference": (cats) =>
+    cats.has("docs") || cats.has("ci_workflow") || cats.has("unknown"),
   "ci-gate": () => true,
 
   "js-quality": (cats) =>

--- a/src/lib/i18n.test.ts
+++ b/src/lib/i18n.test.ts
@@ -1,5 +1,7 @@
+// @vitest-environment jsdom
+
 import { afterEach, describe, expect, it } from "vitest";
-import { SUPPORTED_LANGUAGES, detectSystemLanguage } from "./i18n";
+import i18next, { SUPPORTED_LANGUAGES, detectSystemLanguage } from "./i18n";
 
 const supported = new Set(SUPPORTED_LANGUAGES.map((l) => l.code));
 
@@ -11,7 +13,10 @@ function setNavigatorLanguage(value: string): void {
 }
 
 describe("detectSystemLanguage", () => {
-  afterEach(() => setNavigatorLanguage("en-US"));
+  afterEach(async () => {
+    setNavigatorLanguage("en-US");
+    await i18next.changeLanguage("en");
+  });
 
   it("returns an exact BCP-47 tag match when the locale ships", () => {
     setNavigatorLanguage("zh-CN");
@@ -56,5 +61,16 @@ describe("detectSystemLanguage", () => {
   it("falls back to en for an unknown language", () => {
     setNavigatorLanguage("xx-YY");
     expect(detectSystemLanguage()).toBe("en");
+  });
+
+  it("uses canonical BCP-47 tags for every shipped locale", () => {
+    for (const { code } of SUPPORTED_LANGUAGES) {
+      expect(Intl.getCanonicalLocales(code)).toEqual([code]);
+    }
+  });
+
+  it("updates the document language when the app language changes", async () => {
+    await i18next.changeLanguage("zh-CN");
+    expect(document.documentElement.lang).toBe("zh-CN");
   });
 });

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -122,7 +122,14 @@ export function detectSystemLanguage(): string {
   return shared?.code ?? "en";
 }
 
-i18next.use(initReactI18next).init({
+function setDocumentLanguage(language: string): void {
+  if (typeof document === "undefined") return;
+  document.documentElement.lang = language;
+}
+
+i18next.on("languageChanged", setDocumentLanguage);
+
+void i18next.use(initReactI18next).init({
   resources: Object.fromEntries(
     Object.entries(translations).map(([code, translation]) => [
       code,

--- a/tests/ci/classify-changes.test.ts
+++ b/tests/ci/classify-changes.test.ts
@@ -396,6 +396,7 @@ describe("synthetic fixtures", () => {
     expect(result.expectedJobs).toEqual([
       "triage",
       "conventional-commits",
+      "standards-reference",
       "ci-gate",
     ]);
   });
@@ -407,6 +408,7 @@ describe("synthetic fixtures", () => {
     expect(result.expectedJobs).toEqual([
       "triage",
       "conventional-commits",
+      "standards-reference",
       "ci-gate",
     ]);
   });
@@ -504,6 +506,7 @@ describe("structural invariants", () => {
     const requiredJobs = [
       "triage",
       "conventional-commits",
+      "standards-reference",
       "ci-gate",
       "js-quality",
       "app-frontend",

--- a/tests/e2e/accessibility.spec.ts
+++ b/tests/e2e/accessibility.spec.ts
@@ -2,7 +2,14 @@ import AxeBuilder from "@axe-core/playwright";
 import type { Page } from "@playwright/test";
 import { expect, test } from "./fixtures/base-test";
 
-const WCAG_AA_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"];
+const WCAG_AA_TAGS = [
+  "wcag2a",
+  "wcag2aa",
+  "wcag21a",
+  "wcag21aa",
+  "wcag22a",
+  "wcag22aa",
+];
 
 async function expectNoAutomatableViolations(page: Page) {
   const results = await new AxeBuilder({ page })


### PR DESCRIPTION
## What changed

- Adopt a versioned product-quality standards baseline through ADR 0013 and the standards reference.
- Add progressive, changed-surface standard profiles and an AGENTS.md route through ADR 0014.
- Add an executable standards-route check in local hooks and CI.
- Extend accessibility coverage to WCAG 2.2 A and AA, and keep the document `lang` attribute synchronized with the active BCP 47 locale.
- Add canonical locale-tag coverage and documentation/PR guidance for standards evidence.

## Why

OpenKara now has a concise repository entry point to standards, with detailed rules loaded only for the surface being changed. The CI check keeps that routing intact. Accessibility and locale metadata requirements have direct automated coverage.

## User and developer impact

- Contributors can find the applicable standard profile without loading unrelated guidance.
- CI validates the standards reference structure and runs only the required jobs for the changed surface.
- Assistive technologies receive the active document language, and automated accessibility testing covers WCAG 2.2 A and AA.

## Contracts

No public IPC contract changed.

## Verification

- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm test` — 187 files, 2,118 tests
- [x] `node --run check:standards`
- [x] CI change-classification contract tests
- [ ] Local Chromium/WebKit execution — Playwright browser binaries are unavailable in this environment; CI runs the browser accessibility gate.

## Residual risk

CI provides the remaining browser-runtime verification.