### PR TITLE
fix(standards): apply product quality baselines across the codebase

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -14,6 +14,16 @@ A clear description of the feature you'd like.
 
 Why do you need this? What problem does it solve?
 
+## User outcome
+
+What user outcome does this change enable?
+
+## Acceptance criteria
+
+How will we know this change is successful? List each criterion.
+
+-
+
 ## Proposed solution
 
 If you have a specific implementation in mind, describe it here. Include command syntax if applicable.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,10 @@ Brief description of the changes.
 
 -
 
+## Acceptance criteria
+
+Link to the issue's acceptance criteria, or list them here if this PR has no linked issue.
+
 ## Test plan
 
 Report the commands you ran, and say which you skipped and why.

--- a/.github/dependency-review.yml
+++ b/.github/dependency-review.yml
@@ -1,0 +1,11 @@
+# Dependency review configuration for OpenKara
+# Supports NIST SSDF 1.1 dependency policy controls
+fail_on_severity: high
+allow_licenses:
+  - Apache-2.0
+  - MIT
+  - BSD-2-Clause
+  - BSD-3-Clause
+  - ISC
+  - MPL-2.0
+  - Unicode-DFS-2016

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,57 @@
+# Security Policy
+
+OpenKara takes security reports seriously. This file tells you how to report a vulnerability and what to expect after you report it.
+
+## Reporting a Vulnerability
+
+Report security issues through GitHub's private vulnerability reporting channel. Open the repository on GitHub. Go to the **Security** tab. Select **Report a vulnerability**. Submit your report there.
+
+Do not open a public GitHub issue for a security problem. Do not publish a vulnerability in any public channel before the fix ships.
+
+Include these details in your report:
+
+- A description of the vulnerability.
+- The steps to reproduce the issue.
+- The affected version or commit.
+- The impact on a user or system.
+- A CVSS v3.1 score if you have one.
+
+## Supported Versions
+
+Only the latest release line receives security fixes. Older releases do not get backports. Upgrade to the latest release before you report an issue.
+
+## Severity Classification
+
+OpenKara rates vulnerabilities with CVSS v3.1. The table maps the score to a severity.
+
+| Severity | CVSS v3.1 Score |
+| -------- | --------------- |
+| Critical | 9.0 - 10.0      |
+| High     | 7.0 - 8.9       |
+| Medium   | 4.0 - 6.9       |
+| Low      | 0.1 - 3.9       |
+
+## Response SLA
+
+The maintainer acknowledges and fixes each report on this schedule.
+
+| Severity | Acknowledge within | Fix within   |
+| -------- | ------------------ | ------------ |
+| Critical | 48 hours           | 7 days       |
+| High     | 72 hours           | 30 days      |
+| Medium   | 7 days             | Next release |
+| Low      | 7 days             | Next release |
+
+The maintainer tells the reporter when the fix is ready. The maintainer also tells the reporter if the report is declined and why.
+
+## Coordinated Disclosure
+
+OpenKara uses a 90-day disclosure window. The maintainer publishes the fix and the advisory after 90 days from the report date, or sooner if the reporter and the maintainer agree.
+
+The maintainer credits the reporter by name unless the reporter asks to stay anonymous.
+
+The maintainer discloses early only when all of these conditions are true:
+
+- The vulnerability is under active exploitation.
+- A fix is available.
+- The reporter agrees to the early disclosure.

--- a/docs/adr/0015-lyrics-acquisition-multi-source-fallback-chain.md
+++ b/docs/adr/0015-lyrics-acquisition-multi-source-fallback-chain.md
@@ -1,0 +1,41 @@
+# ADR 0015 — Lyrics acquisition uses a multi-source fallback chain
+
+Date: 2026-07-28
+Status: accepted
+
+## Context
+
+A song can supply timed lyrics from more than one place. Embedded tags,
+sidecar files, and online databases each hold a subset of the catalog. No
+single source is complete. Online sources add latency and can fail when the
+network is slow or absent. The player must show lyrics without blocking
+playback on a network timeout. The source that supplied the lyrics also
+matters to the user, because online lyrics can be wrong and the user must
+know where to override them.
+
+## Decision
+
+Lyrics acquisition follows a fixed fallback chain. The chain reads the
+SQLite lyrics cache first. On a cache miss it tries local sources before
+online sources. The local order is embedded tags, then sidecar files. The
+sidecar order is TTML, then LYS, then LRC. The online order is LRCLIB, then
+LrcApi. The first source that returns valid timed lyrics wins. A miss on
+every source writes a negative-cache entry with a time-to-live so a later
+addition to LRCLIB or LrcApi can be found on the next fetch. The winning
+source is recorded in the cache and returned to the frontend through the
+`LyricsPayload` source field.
+
+## Consequences
+
+- New lyrics sources must slot into the fixed chain. They cannot bypass the
+  cache or the local-before-online order.
+- Local sources must stay free of network calls so playback never waits on a
+  network timeout for lyrics that exist on disk.
+- A new sidecar format must declare its priority relative to TTML, LYS, and
+  LRC. The `read_sidecar_lyrics` priority function is the single place that
+  sets this order.
+- The negative-cache time-to-live is the only mechanism that lets a later
+  online addition become visible. A source that removes this TTL creates
+  stale empty-lyrics results.
+- The `LyricsSource` enum is the contract for the winning source. A new
+  source adds a variant here and in the IPC contract, not in ad hoc strings.

--- a/docs/adr/0016-source-separation-runs-locally-with-onnx-runtime.md
+++ b/docs/adr/0016-source-separation-runs-locally-with-onnx-runtime.md
@@ -1,0 +1,41 @@
+# ADR 0016 — Source separation runs locally with ONNX Runtime
+
+Date: 2026-07-28
+Status: accepted
+
+## Context
+
+Stem separation turns a mixed track into vocals, drums, bass, and other
+stems. Cloud separation services exist and need no local compute. They send
+user audio to a remote server, charge recurring fees, and stop working
+offline. OpenKara is a desktop karaoke app. Its users value privacy, offline
+play, and no per-use cost. The separation model is large and the runtime is
+platform-specific, so a local path must solve model delivery and runtime
+delivery on every supported platform.
+
+## Decision
+
+Source separation runs locally on the user's machine. The backend embeds the
+Demucs model as an ONNX file and runs it through ONNX Runtime. The model is
+downloaded to the app data directory on first launch and verified with a
+pinned SHA-256 checksum. The ONNX Runtime shared library is resolved from
+bundled app resources, with a local development fallback under
+`src-tauri/generated/onnxruntime/`. Runtime installation is catalog-driven
+with staged activation: a candidate runtime is verified before it replaces
+the active runtime, and a failed activation rolls back to the previous
+verified runtime. No user audio leaves the machine for separation.
+
+## Consequences
+
+- Separation works offline. Code that assumes network access for separation
+  is a regression.
+- User audio for separation never leaves the machine. A future cloud path
+  must be opt-in and must not change the default local behavior.
+- The runtime bootstrap is load-bearing. A runtime loaded by the current
+  process is never overwritten in place. The candidate, active, and previous
+  slots are the only supported activation path.
+- Model and runtime delivery add first-launch and platform-specific work.
+  The model path boundary in `AGENTS.md` holds: `src-tauri/models/` is a
+  development cache only, and shipped builds use the app data directory.
+- The stem order is fixed by ADR 0009. This ADR records the local-execution
+  decision, not the stem order.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -52,3 +52,5 @@ Write new ADRs in ASD-STE100 Simplified English. See `AGENTS.md` for the rules. 
 - [0012 — CDG seek resets both timelines, transport_generation preserves renderer](./0012-cdg-seek-resets-both-timelines.md)
 - [0013 — Use standards as product quality baselines](./0013-use-standards-as-product-quality-baselines.md)
 - [0014 — Route product standards by changed surface](./0014-route-product-standards-by-changed-surface.md)
+- [0015 — Lyrics acquisition uses a multi-source fallback chain](./0015-lyrics-acquisition-multi-source-fallback-chain.md)
+- [0016 — Source separation runs locally with ONNX Runtime](./0016-source-separation-runs-locally-with-onnx-runtime.md)

--- a/docs/references/contracts/library.md
+++ b/docs/references/contracts/library.md
@@ -30,6 +30,20 @@
 21. `playlists` 表和 `playlist_songs` 表通过 `ON DELETE CASCADE` 与 `songs` 表联动；删除歌曲时自动清理关联
 22. `set_library_sort_mode(mode: LibrarySortMode) -> AppSettings` — 持久化资料库排序模式并返回更新后的全局设置
 23. `get_cover_art(hash: String, size?: CoverArtSize) -> Option<Vec<u8>>` — 读取封面图原始字节或派生缩略图/预览图
+24. `get_import_candidate_details(paths: Vec<String>) -> Vec<ImportCandidateDetails>` — 预览导入候选文件的格式、比特率、文件大小和时长
+25. `delete_songs(song_ids: Vec<String>) -> DeleteSongsResult` — 批量删除歌曲及其关联数据
+26. `update_song_metadata(hash: String, title: Option<String>, artist: Option<String>) -> Song` — 更新单首歌曲的标题和歌手元数据
+27. `set_songs_language(song_ids: Vec<String>, language: Option<String>) -> Vec<Song>` — 批量设置歌曲语言标签
+28. `get_song_properties(song_id: String) -> SongProperties` — 读取单首歌曲的技术属性（格式、采样率、声道、比特率、文件大小、时长）
+29. `create_library(path: String) -> LibraryRegistrySnapshot` — 在指定路径创建新本地资料库并设为活动
+30. `open_library(path: String) -> LibraryRegistrySnapshot` — 打开指定路径的已有本地资料库并设为活动
+31. `switch_library(library_id: String) -> LibraryRegistrySnapshot` — 切换活动资料库
+32. `get_library_path() -> Option<String>` — 返回活动资料库的 canonicalized 根路径
+33. `get_library_registry() -> LibraryRegistrySnapshot` — 返回所有已注册资料库及当前活动资料库 ID
+34. `get_active_library() -> Option<RegisteredLibrary>` — 返回当前活动资料库的注册条目
+35. `remove_library(library_id: String) -> LibraryRegistrySnapshot` — 移除资料库注册（本地不删文件，远程只移除凭据）
+36. `rename_library(library_id: String, display_name: String) -> LibraryRegistrySnapshot` — 重命名资料库显示名
+37. `delete_library(library_id: String) -> LibraryRegistrySnapshot` — 永久删除资料库（本地删除文件，远程删除 provider 内容）
 
 ## Inputs / outputs / required dependencies
 
@@ -281,6 +295,233 @@
    - 验证成功后才写入新凭据、保存新的 remote root locator，并刷新本地 working copy。
    - 若位置变化且 `allow_relocation=false`，返回错误，等待 UI 进行用户确认。
 
+### Command: `begin_remote_auth`
+
+**Input**
+
+```json
+{
+  "provider": "google_drive",
+  "payload": null
+}
+```
+
+`provider` is one of `google_drive`, `dropbox`, `webdav`. `payload` is an optional provider-specific JSON object (e.g. WebDAV server URL and credentials).
+
+**Output:** `RemoteAuthStart`
+
+```json
+{
+  "session_id": "session-uuid",
+  "provider": "google_drive",
+  "authorization_url": "https://...",
+  "expires_at_ms": 1760000000000
+}
+```
+
+**Semantics**
+
+1. Starts an OAuth or WebDAV authentication session for the given provider
+2. For OAuth providers, returns an `authorization_url` the frontend opens in the system browser
+3. For WebDAV, the `payload` carries the server URL and credentials; no browser redirect is needed
+4. The session ID is used by `poll_remote_auth` and `cancel_remote_auth`
+
+### Command: `poll_remote_auth`
+
+**Input**
+
+```json
+{
+  "session_id": "session-uuid"
+}
+```
+
+**Output:** `RemoteAuthStatus`
+
+```json
+{
+  "session_id": "session-uuid",
+  "provider": "google_drive",
+  "state": "ready",
+  "remote_root_locator": "google_drive://account-id/path",
+  "display_name": "My Drive",
+  "error": null
+}
+```
+
+**Semantics**
+
+1. `state` is one of `pending`, `ready`, `failed`
+2. The frontend polls this command until `state` is `ready` or `failed`
+3. When `state = ready`, `remote_root_locator` and `display_name` are set
+4. When `state = failed`, `error` contains a `CommandError`
+
+### Command: `cancel_remote_auth`
+
+**Input**
+
+```json
+{
+  "session_id": "session-uuid"
+}
+```
+
+**Output:** `()`
+
+**Semantics**
+
+1. Cancels an in-progress authentication session
+2. After cancellation, `poll_remote_auth` for the same session ID returns `failed`
+
+### Command: `open_external_url`
+
+**Input**
+
+```json
+{
+  "url": "https://..."
+}
+```
+
+**Output:** `()`
+
+**Semantics**
+
+1. Opens the given URL in the system default browser
+2. Used for OAuth authorization URLs and help links
+
+### Command: `list_remote_library_roots`
+
+**Input**
+
+```json
+{
+  "session_id": "session-uuid"
+}
+```
+
+**Output:** `Vec<RemoteLibraryCandidate>`
+
+**Semantics**
+
+1. Lists existing OpenKara library directories found in the authenticated provider account
+2. Each candidate includes the provider, remote root locator, display name, and account ID
+3. The frontend shows these as options when the user chooses which remote library to register
+
+### Command: `create_remote_library`
+
+**Input**
+
+```json
+{
+  "session_id": "session-uuid",
+  "display_name": "My New Library"
+}
+```
+
+**Output:** `RemoteLibraryCandidate`
+
+**Semantics**
+
+1. Creates a new OpenKara library directory in the authenticated provider account
+2. Does not register the library in app config; the frontend calls `register_remote_library` after the user confirms
+3. Returns the candidate with the new remote root locator
+
+### Command: `register_remote_library`
+
+**Input**
+
+```json
+{
+  "session_id": "session-uuid",
+  "remote_root_locator": "google_drive://account-id/path",
+  "display_name": "My Remote Library"
+}
+```
+
+**Output:** `LibraryRegistrySnapshot`
+
+**Semantics**
+
+1. Registers the remote library in app config using the authenticated session
+2. Downloads the remote `openkara.db` and media files to the local working copy
+3. Sets the new library as the active library
+4. If the remote location does not contain a valid OpenKara library, the command returns `CommandError`
+
+### Command: `get_all_upload_statuses`
+
+**Input**: none
+
+**Output:** `Vec<UploadStatusSnapshot>`
+
+```json
+[
+  {
+    "song_id": "sha256 song hash",
+    "state": "running",
+    "percent": 42,
+    "remote_library_id": "library-uuid",
+    "detail": null,
+    "error": null
+  }
+]
+```
+
+**Semantics**
+
+1. Returns the current upload status for all songs that have an active or recent upload
+2. `state` is one of `idle`, `running`, `completed`, `failed`
+3. The frontend uses this to show upload progress indicators in the library
+
+### Shared type: `RemoteAuthStart`
+
+| Field               | Type                    | Notes                                           |
+| ------------------- | ----------------------- | ----------------------------------------------- |
+| `session_id`        | `String`                | Session ID for polling and cancellation         |
+| `provider`          | `RemoteLibraryProvider` | The provider being authenticated                |
+| `authorization_url` | `Option<String>`        | OAuth URL to open in browser; `null` for WebDAV |
+| `expires_at_ms`     | `Option<i64>`           | Session expiry wall-clock ms                    |
+
+### Shared type: `RemoteAuthStatus`
+
+| Field                 | Type                    | Notes                           |
+| --------------------- | ----------------------- | ------------------------------- |
+| `session_id`          | `String`                | Session ID                      |
+| `provider`            | `RemoteLibraryProvider` | The provider                    |
+| `state`               | `RemoteAuthState`       | `pending`, `ready`, or `failed` |
+| `remote_root_locator` | `Option<String>`        | Set when `state = ready`        |
+| `display_name`        | `Option<String>`        | Set when `state = ready`        |
+| `error`               | `Option<CommandError>`  | Set when `state = failed`       |
+
+### Shared type: `RemoteLibraryCandidate`
+
+| Field                 | Type                    | Notes                               |
+| --------------------- | ----------------------- | ----------------------------------- |
+| `provider`            | `RemoteLibraryProvider` | The provider                        |
+| `remote_root_locator` | `String`                | Provider-specific root locator      |
+| `remote_path_display` | `String`                | Human-readable path in the provider |
+| `display_name`        | `String`                | Library display name                |
+| `account_id`          | `String`                | Provider account ID                 |
+
+### Shared type: `UploadStatusSnapshot`
+
+| Field               | Type                   | Notes                                       |
+| ------------------- | ---------------------- | ------------------------------------------- |
+| `song_id`           | `String`               | The song hash                               |
+| `state`             | `UploadState`          | `idle`, `running`, `completed`, or `failed` |
+| `percent`           | `u8`                   | Upload progress (0–100)                     |
+| `remote_library_id` | `Option<String>`       | Target remote library ID                    |
+| `detail`            | `Option<String>`       | Diagnostic detail string                    |
+| `error`             | `Option<CommandError>` | Set when `state = failed`                   |
+
+### Shared enum: `RemoteLibraryProvider`
+
+| Serialized value | Meaning      |
+| ---------------- | ------------ |
+| `google_drive`   | Google Drive |
+| `dropbox`        | Dropbox      |
+| `web_dav`        | WebDAV       |
+
 ### Command: `set_songs_instrumental`
 
 **Input**
@@ -301,6 +542,298 @@
 3. `instrumental = true` 表示该歌曲被视为官方伴奏，不参与 AI 分离
 4. `Media+G` 歌曲当前不会由前端发起该命令，但后端字段本身不额外限制素材类型
 5. 若任一 `song_id` 不存在，命令返回顶层 `CommandError`
+
+### Command: `get_import_candidate_details`
+
+**Input**
+
+```json
+{
+  "paths": ["/absolute/or/relative/audio/path.mp3"]
+}
+```
+
+**Output:** `Vec<ImportCandidateDetails>`
+
+```json
+[
+  {
+    "path": "/music/track.mp3",
+    "format": "mp3",
+    "bit_rate": 320000,
+    "file_size": 5242880,
+    "duration_ms": 180000
+  }
+]
+```
+
+**Semantics**
+
+1. Reads each path and probes its audio format, bit rate, file size, and duration
+2. Does not write to the database or copy media
+3. The frontend uses this to show file details in the import confirmation dialog
+4. If a file cannot be read or probed, the command returns `CommandError` with `code = media_read_failed`
+
+### Command: `delete_songs`
+
+**Input**
+
+```json
+{
+  "song_ids": ["sha256 song hash"]
+}
+```
+
+**Output:** `DeleteSongsResult`
+
+```json
+{
+  "deleted_song_ids": ["sha256 song hash"],
+  "failed": [
+    {
+      "song_id": "sha256 song hash",
+      "error": {
+        "code": "media_read_failed",
+        "message": "failed to delete song files",
+        "retryable": false,
+        "fallback": "keep_current_state"
+      }
+    }
+  ]
+}
+```
+
+**Semantics**
+
+1. Deletes each song's database rows (lyrics, history, stems, playlist FKs) and managed media files
+2. A single song failure does not abort the batch; failures fall into `failed`
+3. If the currently playing song is among the deleted songs, the backend clears the playback track and CDG state
+4. Returns the list of successfully deleted song IDs and per-song failures
+
+### Command: `update_song_metadata`
+
+**Input**
+
+```json
+{
+  "hash": "sha256 song hash",
+  "title": "optional new title",
+  "artist": "optional new artist"
+}
+```
+
+**Output:** `Song` — the updated song with absolute thumbnail path.
+
+**Semantics**
+
+1. Updates `songs.title` and `songs.artist` for the given hash
+2. `null` for `title` or `artist` clears the field; the field name is retained for IPC stability
+3. The command publishes the updated song to the active remote library if one is connected
+4. If the song does not exist, the command returns `CommandError`
+
+### Command: `set_songs_language`
+
+**Input**
+
+```json
+{
+  "song_ids": ["sha256 song hash"],
+  "language": "en"
+}
+```
+
+Pass `null` for `language` to clear the language tag.
+
+**Output:** `Vec<Song>`
+
+**Semantics**
+
+1. Batch-updates `songs.language` for each requested song
+2. Returns the updated songs with absolute thumbnail paths
+3. The command mirrors the change to the active remote library if one is connected
+4. If any `song_id` does not exist, the command returns `CommandError`
+
+### Command: `get_song_properties`
+
+**Input**
+
+```json
+{
+  "song_id": "sha256 song hash"
+}
+```
+
+**Output:** `SongProperties`
+
+```json
+{
+  "format": "mp3",
+  "sample_rate": 44100,
+  "channels": 2,
+  "bit_rate": 320000,
+  "file_size": 5242880,
+  "duration_ms": 180000,
+  "hash": "sha256 song hash"
+}
+```
+
+**Semantics**
+
+1. Probes the song file on disk for technical properties (format, sample rate, channels, bit rate, file size, duration)
+2. For remote songs, the command ensures the file is cached before probing
+3. If the song does not exist, the command returns `CommandError`
+
+### Command: `create_library`
+
+**Input**
+
+```json
+{
+  "path": "/path/to/new/library"
+}
+```
+
+**Output:** `LibraryRegistrySnapshot`
+
+**Semantics**
+
+1. Creates a new library directory structure at the given path
+2. Initializes the library SQLite database
+3. Registers the library in app config and sets it as the active library
+4. If the path already contains a library, the command returns `CommandError`
+
+### Command: `open_library`
+
+**Input**
+
+```json
+{
+  "path": "/path/to/existing/library"
+}
+```
+
+**Output:** `LibraryRegistrySnapshot`
+
+**Semantics**
+
+1. Opens an existing library directory at the given path
+2. Initializes the library SQLite database if needed
+3. Registers the library in app config and sets it as the active library
+4. If the path does not contain a valid library, the command returns `CommandError`
+
+### Command: `switch_library`
+
+**Input**
+
+```json
+{
+  "library_id": "library-uuid"
+}
+```
+
+**Output:** `LibraryRegistrySnapshot`
+
+**Semantics**
+
+1. Switches the active library to the one identified by `library_id`
+2. Clears all library-scoped runtime state (playback, CDG, remote upload statuses) before activating the new library
+3. If the library ID is not found, the command returns `CommandError`
+
+### Command: `get_library_path`
+
+**Input**: none
+
+**Output:** `Option<String>` — the canonicalized absolute path of the active library root, or `null` when no library is active.
+
+### Command: `get_library_registry`
+
+**Input**: none
+
+**Output:** `LibraryRegistrySnapshot`
+
+```json
+{
+  "active_library_id": "library-uuid",
+  "libraries": [
+    {
+      "kind": "local",
+      "id": "library-uuid",
+      "display_name": "My Library",
+      "root_path": "/path/to/library"
+    }
+  ]
+}
+```
+
+**Semantics**
+
+1. Reads the app config and returns all registered libraries plus the active library ID
+2. Does not open any database or touch disk
+
+### Command: `get_active_library`
+
+**Input**: none
+
+**Output:** `Option<RegisteredLibrary>` — the active library entry, or `null` when no library is active.
+
+### Command: `remove_library`
+
+**Input**
+
+```json
+{
+  "library_id": "library-uuid"
+}
+```
+
+**Output:** `LibraryRegistrySnapshot`
+
+**Semantics**
+
+1. Removes the library from app config and removes its stored credentials
+2. For local libraries, does not delete files on disk
+3. For remote libraries, removes only local credentials and registration; provider-hosted content is not deleted
+4. If the removed library was active, the backend activates the first remaining library or clears all library-scoped state when no library remains
+5. If the library ID is not found, the command returns `CommandError`
+
+### Command: `rename_library`
+
+**Input**
+
+```json
+{
+  "library_id": "library-uuid",
+  "display_name": "New Name"
+}
+```
+
+**Output:** `LibraryRegistrySnapshot`
+
+**Semantics**
+
+1. Updates the display name of the registered library in app config
+2. Does not rename the library directory on disk
+3. If the library ID is not found, the command returns `CommandError`
+
+### Command: `delete_library`
+
+**Input**
+
+```json
+{
+  "library_id": "library-uuid"
+}
+```
+
+**Output:** `LibraryRegistrySnapshot`
+
+**Semantics**
+
+1. Permanently deletes the library data, then calls `remove_library`
+2. For local libraries, deletes the entire library directory from disk
+3. For remote libraries, deletes the provider-hosted content and the local working copy
+4. The UI must present this as a permanent destructive action
+5. If the library ID is not found, the command returns `CommandError`
 
 ### Shared type: `Song`
 
@@ -350,6 +883,58 @@
 | --------- | -------------- | -------------------- |
 | `song_id` | `String`       | 请求中的歌曲 hash    |
 | `error`   | `CommandError` | 单首失败的结构化错误 |
+
+### Shared type: `ImportCandidateDetails`
+
+| Field         | Type          | Notes                             |
+| ------------- | ------------- | --------------------------------- |
+| `path`        | `String`      | The probed file path              |
+| `format`      | `String`      | Audio format (e.g. `mp3`, `flac`) |
+| `bit_rate`    | `Option<u32>` | Bit rate in bits per second       |
+| `file_size`   | `u64`         | File size in bytes                |
+| `duration_ms` | `Option<i64>` | Duration in milliseconds          |
+
+### Shared type: `DeleteSongsResult`
+
+| Field              | Type                      | Notes                                       |
+| ------------------ | ------------------------- | ------------------------------------------- |
+| `deleted_song_ids` | `Vec<String>`             | Successfully deleted song hashes            |
+| `failed`           | `Vec<DeleteSongsFailure>` | Per-song failures, allowing partial success |
+
+### Shared type: `DeleteSongsFailure`
+
+| Field     | Type           | Notes              |
+| --------- | -------------- | ------------------ |
+| `song_id` | `String`       | The song hash      |
+| `error`   | `CommandError` | The failure reason |
+
+### Shared type: `SongProperties`
+
+| Field         | Type          | Notes                             |
+| ------------- | ------------- | --------------------------------- |
+| `format`      | `String`      | Audio format (e.g. `mp3`, `flac`) |
+| `sample_rate` | `Option<u32>` | Sample rate in Hz                 |
+| `channels`    | `Option<u16>` | Number of audio channels          |
+| `bit_rate`    | `Option<u32>` | Bit rate in bits per second       |
+| `file_size`   | `u64`         | File size in bytes                |
+| `duration_ms` | `i64`         | Duration in milliseconds          |
+| `hash`        | `String`      | The song hash                     |
+
+### Shared type: `LibraryRegistrySnapshot`
+
+| Field               | Type                     | Notes                        |
+| ------------------- | ------------------------ | ---------------------------- |
+| `active_library_id` | `Option<String>`         | Active library ID, or `null` |
+| `libraries`         | `Vec<RegisteredLibrary>` | All registered libraries     |
+
+### Shared type: `RegisteredLibrary`
+
+Tagged union with `kind` discriminator.
+
+| Variant  | Fields                                                                                                                                                    | Notes                            |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| `local`  | `id`, `display_name`, `root_path`                                                                                                                         | A local on-disk library          |
+| `remote` | `id`, `display_name`, `provider`, `account_id`, `remote_root_locator`, `remote_path_display`, `connection_config?`, `cached_db_path?`, `remote_revision?` | A provider-hosted remote library |
 
 ### Command: `set_library_sort_mode`
 

--- a/docs/references/contracts/lyrics.md
+++ b/docs/references/contracts/lyrics.md
@@ -7,12 +7,13 @@
 1. `fetch_lyrics(song_id: String) -> LyricsPayload`
 2. `set_lyrics_offset(song_id: String, ms: i64) -> ()`
 3. `set_lyrics_font_step(step: i8) -> AppSettings`
-4. 抓取优先顺序固定为 `LRCLIB -> LrcApi -> embedded -> sidecar`
-5. sidecar 优先级固定为 `.ttml -> .lys -> .lrc`；每个候选格式必须先能解析出至少一行歌词，格式错误时继续尝试下一种
-6. SQLite `lyrics` 表按 `song_hash` 缓存原始歌词文本和 `offset_ms`
-7. 对同一首歌重复调用 `fetch_lyrics` 时，优先命中 SQLite cache，不重复发起 HTTP 请求
-8. 歌词字号是全局显示偏好，不写入 `lyrics` 表；它走 `AppSettings.lyrics_font_step`
-9. 歌词命令失败值统一为 `CommandError`，详见 [errors.md](./errors.md)
+4. `save_manual_lyrics(song_id: String, text: String) -> LyricsPayload`
+5. 抓取优先顺序固定为 `LRCLIB -> LrcApi -> embedded -> sidecar`
+6. sidecar 优先级固定为 `.ttml -> .lys -> .lrc`；每个候选格式必须先能解析出至少一行歌词，格式错误时继续尝试下一种
+7. SQLite `lyrics` 表按 `song_hash` 缓存原始歌词文本和 `offset_ms`
+8. 对同一首歌重复调用 `fetch_lyrics` 时，优先命中 SQLite cache，不重复发起 HTTP 请求
+9. 歌词字号是全局显示偏好，不写入 `lyrics` 表；它走 `AppSettings.lyrics_font_step`
+10. 歌词命令失败值统一为 `CommandError`，详见 [errors.md](./errors.md)
 
 ## Inputs / outputs / required dependencies
 
@@ -149,6 +150,28 @@
 2. 只有在该歌曲已经存在缓存歌词时，命令才会成功
 3. 如果歌曲存在但还没有缓存歌词，命令返回 `CommandError`
 4. 该命令只更新 SQLite 中的 `offset_ms`，不会重抓歌词
+
+### Command: `save_manual_lyrics`
+
+**Input**
+
+```json
+{
+  "song_id": "sha256 hash string",
+  "text": "[00:35.66]Look at the stars"
+}
+```
+
+**Output:** `LyricsPayload` — the parsed lyrics with the detected source.
+
+**Semantics**
+
+1. The command parses the `text` as LRC, TTML, or plain text
+2. The backend detects the source type from the content: `manual_ttml` for XML-starting text, `manual_lys` for LRC-starting text, `manual` for plain text
+3. The command writes the raw text, detected source, and parsed offset to the SQLite `lyrics` cache
+4. The command publishes the updated lyrics to the active remote library if one is connected
+5. If the text cannot be parsed as timed lyrics, the backend falls back to plain-text lines
+6. If the song does not exist, the command returns `CommandError`
 
 ### Command: `set_lyrics_font_step`
 

--- a/docs/references/contracts/model-bootstrap.md
+++ b/docs/references/contracts/model-bootstrap.md
@@ -221,6 +221,132 @@ Per-variant `state` is one of `not_installed`, `up_to_date`,
 装模型的 generation 时，本命令同样报错（拒绝把旧工件当作"更新"呈现）；
 `download_model` 侧也会拒绝隐式降级——降级需要用户显式删除模型后重新下载。
 
+## Runtime Bootstrap commands (Settings)
+
+These commands let the Settings UI inspect and manage the ONNX Runtime
+installation. They are separate from the model bootstrap flow.
+
+### Command: `get_runtime_bootstrap_status`
+
+**Input**: none
+
+**Output:** `RuntimeBootstrapStatusSnapshot`
+
+```json
+{
+  "state": "ready",
+  "runtime_path": "/path/to/onnxruntime/lib",
+  "downloaded_bytes": null,
+  "total_bytes": null,
+  "version": "v1.27.1",
+  "active_artifact_id": "onnxruntime-1.27.1-openkara-aarch64-apple-darwin",
+  "target_triple": "aarch64-apple-darwin",
+  "candidate_version": null,
+  "restart_required": false,
+  "error": null
+}
+```
+
+### Shared type: `RuntimeBootstrapStatusSnapshot`
+
+| Field                | Type                                                                                                                                                                                             | Notes                                                                                                             |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| `state`              | `"missing" \| "downloading" \| "ready" \| "update_available" \| "downloading_candidate" \| "candidate_ready_restart_required" \| "activation_failed_previous_restored" \| "corrupt" \| "failed"` | Runtime lifecycle state                                                                                           |
+| `runtime_path`       | `String`                                                                                                                                                                                         | Active runtime library path, or target install path                                                               |
+| `downloaded_bytes`   | `Option<u64>`                                                                                                                                                                                    | Present during `downloading` / `downloading_candidate`                                                            |
+| `total_bytes`        | `Option<u64>`                                                                                                                                                                                    | Present when the download endpoint returns `Content-Length`                                                       |
+| `version`            | `String`                                                                                                                                                                                         | Active runtime upstream version; `legacy` for pre-slot installs; pinned catalog version when nothing is installed |
+| `active_artifact_id` | `Option<String>`                                                                                                                                                                                 | Active runtime artifact ID, when a slot install is active                                                         |
+| `target_triple`      | `String`                                                                                                                                                                                         | Runtime target triple for this build                                                                              |
+| `candidate_version`  | `Option<String>`                                                                                                                                                                                 | Upstream version of the staged candidate, when one exists                                                         |
+| `restart_required`   | `bool`                                                                                                                                                                                           | `true` when a candidate is staged and activation requires restart                                                 |
+| `error`              | `Option<CommandError>`                                                                                                                                                                           | Present when `state = failed`                                                                                     |
+
+### Command: `download_runtime`
+
+**Input**: none
+
+**Output:** `RuntimeBootstrapStatusSnapshot`
+
+Downloads the ONNX Runtime for the current target triple. First install
+downloads and loads immediately. When a runtime is already active (or a
+legacy install is loaded), the download is staged as a next-launch
+candidate instead — a loaded runtime is never replaced in place.
+
+The download is single-flight: a concurrent call while a download is in
+progress returns the current downloading status instead of spawning a
+duplicate task.
+
+### Command: `check_runtime_updates`
+
+**Input**: none
+
+**Output:** `RuntimeUpdateReport`
+
+```json
+{
+  "generation": 3,
+  "release_id": "2026-07-23-003",
+  "target_triple": "aarch64-apple-darwin",
+  "state": "up_to_date",
+  "installed_version": "v1.27.1",
+  "available_version": "v1.27.1",
+  "available_bytes": 10485760,
+  "restart_required": false
+}
+```
+
+Fetches and verifies the current stable catalog from the network, compares
+the installed runtime against the catalog artifact, and caches the
+verified catalog so a subsequent `download_runtime` installs the newer
+artifact. `state` is one of `not_installed`, `up_to_date`,
+`update_available`, `installed_without_identity`. A failed check returns
+`CommandError` and never affects the readiness of the installed runtime.
+
+### Shared type: `RuntimeUpdateReport`
+
+| Field               | Type               | Notes                                                                              |
+| ------------------- | ------------------ | ---------------------------------------------------------------------------------- |
+| `generation`        | `u64`              | Catalog generation                                                                 |
+| `release_id`        | `String`           | Catalog release ID                                                                 |
+| `target_triple`     | `String`           | Runtime target triple                                                              |
+| `state`             | `ModelUpdateState` | `not_installed`, `up_to_date`, `update_available`, or `installed_without_identity` |
+| `installed_version` | `Option<String>`   | Installed runtime upstream version                                                 |
+| `available_version` | `String`           | Available runtime upstream version                                                 |
+| `available_bytes`   | `u64`              | Download size in bytes                                                             |
+| `restart_required`  | `bool`             | `true` when a runtime is already installed                                         |
+
+### Command: `delete_runtime`
+
+**Input**: none
+
+**Output:** `()`
+
+Removes the active runtime installation, its slot record, and the
+candidate. The user invokes this from Settings to clear a corrupt or
+incorrect install before re-downloading. A loaded runtime stays mapped
+into the process until restart; `delete_runtime` only removes disk state
+and slot metadata.
+
+### Events
+
+#### `runtime-bootstrap-progress`
+
+Payload is a full `RuntimeBootstrapStatusSnapshot` with `state =
+"downloading"` or `"downloading_candidate"`. `downloaded_bytes` increases
+monotonically during the download.
+
+#### `runtime-bootstrap-ready`
+
+Payload is a full `RuntimeBootstrapStatusSnapshot` with `state = "ready"`
+or `"candidate_ready_restart_required"`. `downloaded_bytes` and `error`
+are `null`.
+
+#### `runtime-bootstrap-error`
+
+Payload is a full `RuntimeBootstrapStatusSnapshot` with `state = "failed"`
+and `error.code = "model_unavailable"`.
+
 ## Runtime path resolution semantics
 
 1. 优先使用活动模型 variant 对应的 `<app_data_dir>/models/<descriptor.filename>`

--- a/docs/references/contracts/playback.md
+++ b/docs/references/contracts/playback.md
@@ -18,7 +18,8 @@
 10. `set_preload_candidate(song_id: Option<String>) -> ()` — #88 无缝播放预加载命令（见下）
 11. `playback-position` 事件 payload 为 `{ ms: u64, transport_generation: u64, snapshot: PlaybackStateSnapshot }`
 12. `track-transitioned` 事件 payload 为 `{ transitionSerial: u64, preloadGeneration: u64, fromSongId: String, toSongId: String, state: PlaybackStateSnapshot }` — #88/#89 无缝换轨通知（见下）
-13. `get_waveform(hash: String, buckets: Option<usize>) -> Vec<f32>` — #90 波形 seekbar 命令（见下）
+13. `playback-ended` 事件 payload 为 `{ songId: String }` — 播放结束通知（见下）
+14. `get_waveform(hash: String, buckets: Option<usize>) -> Vec<f32>` — #90 波形 seekbar 命令（见下）
 
 ### Peak envelope 可视化（#87）
 
@@ -326,6 +327,23 @@ playing ↔ playing（pause/resume，通过 isPlaying 区分）
 5. `transition_serial` 单调递增，可用于去重或调试
 6. 如果前端 clock 持有的 `song_id` 既不是 `from_song_id` 也不是 `to_song_id`（用户手动切换了歌曲），则忽略该事件
 7. 无缝换轨时 `transport_generation` 递增，使前端 generation 过滤器丢弃旧歌的延迟 `playback-position` 事件（#103）
+
+### Event: `playback-ended`
+
+**Payload**
+
+```json
+{
+  "songId": "sha256 hash string"
+}
+```
+
+**Semantics**
+
+1. Emitted when the current track reaches EOF and no prepared track is available for gapless transition
+2. The frontend uses this event to advance the queue and load the next song
+3. The `songId` field lets the frontend guard against stale events from a previous transport
+4. This event is not emitted when a gapless transition occurs; `track-transitioned` covers that path
 
 ### Event: `remote-playback-reconnect` (#151)
 

--- a/docs/references/contracts/separation.md
+++ b/docs/references/contracts/separation.md
@@ -8,13 +8,22 @@
 2. `upgrade_to_four_stem(song_id: String) -> SeparationStatusSnapshot`
 3. `re_separate(song_id: String, stem_mode: StemMode) -> SeparationStatusSnapshot`
 4. `get_separation_status(song_id: String) -> SeparationStatusSnapshot`
-5. `separation-progress` 事件 payload 为 `{ song_id: String, percent: u8 }`
-6. `separation-complete` 事件 payload 为 `{ song_id: String, status: SeparationStatusSnapshot }`
-7. `separation-error` 事件 payload 为 `{ song_id: String, error: CommandError }`
-8. stem cache 目录固定为 `<app_cache_dir>/stems/{song_hash}/`
-9. `separate(song_id)` 只有在模型 bootstrap 为 `ready` 时才会真正启动后台 worker
-10. 分离前会把输入音频归一化为 Demucs 需要的 `44.1 kHz / stereo`
-11. 超过单个 Demucs window 的长音频会按固定窗口分段推理并拼回完整 stems
+5. `get_all_separation_statuses() -> Vec<SeparationStatusSnapshot>`
+6. `cancel_separation(song_id: String) -> ()`
+7. `downgrade_single_to_two_stem(song_id: String) -> SeparationStatusSnapshot`
+8. `batch_separate(song_ids: Vec<String>) -> ()`
+9. `cancel_batch_separation() -> ()`
+10. `separation-progress` 事件 payload 为 `{ song_id: String, percent: u8 }`
+11. `separation-complete` 事件 payload 为 `{ song_id: String, status: SeparationStatusSnapshot }`
+12. `separation-error` 事件 payload 为 `{ song_id: String, error: CommandError }`
+13. `separation-cancelled` 事件 payload 为 `{ song_id: String }`
+14. `batch-separation-progress` 事件 payload 为 `BatchSeparationProgress`
+15. `batch-separation-complete` 事件 payload 为 `BatchSeparationProgress`
+16. `batch-separation-cancelled` 事件 payload 为 `BatchSeparationProgress`
+17. stem cache 目录固定为 `<app_cache_dir>/stems/{song_hash}/`
+18. `separate(song_id)` 只有在模型 bootstrap 为 `ready` 时才会真正启动后台 worker
+19. 分离前会把输入音频归一化为 Demucs 需要的 `44.1 kHz / stereo`
+20. 超过单个 Demucs window 的长音频会按固定窗口分段推理并拼回完整 stems
 
 ## Inputs / outputs / required dependencies
 
@@ -143,6 +152,164 @@
   }
 }
 ```
+
+### Command: `get_all_separation_statuses`
+
+**Input**: none
+
+**Output:** `Vec<SeparationStatusSnapshot>`
+
+**Semantics**
+
+1. The frontend calls this command once at startup to hydrate the separation status store
+2. The command reads all cached stem entries from the SQLite `stems` table
+3. Only entries whose stem files still exist on disk are returned as `completed`
+4. The command also populates the in-memory separation status map so subsequent `get_separation_status` calls return the correct state
+5. Songs without any cached stems are not included in the returned vector
+
+### Command: `cancel_separation`
+
+**Input**
+
+```json
+{
+  "songId": "sha256 hash string"
+}
+```
+
+**Output:** `()`
+
+**Semantics**
+
+1. Sets the cancellation flag for the given song if a separation job is currently running
+2. A cancelled run never surfaces a `separation-error` event or an error toast
+3. If the song is not currently separating, the command is a benign no-op success
+4. The backend emits `separation-cancelled` after the worker observes the flag and stops
+
+### Command: `downgrade_single_to_two_stem`
+
+**Input**
+
+```json
+{
+  "songId": "sha256 hash string"
+}
+```
+
+**Output:** `SeparationStatusSnapshot`
+
+**Semantics**
+
+1. Removes the individual drum/bass/other stem files for the given song and updates the database entry to two-stem
+2. The command emits a `separation-complete` event with the updated `completed` status
+3. `cacheHit` is `false` because a downgrade is an explicit user action, not a cache-served separation
+4. The command publishes the updated song to the active remote library if one is connected
+5. If the song does not have individual stems, the command returns the current `completed` status
+
+### Command: `batch_separate`
+
+**Input**
+
+```json
+{
+  "songIds": ["sha256 hash string"]
+}
+```
+
+Pass an empty `songIds` vector to separate all separable songs in the library.
+
+**Output:** `()`
+
+**Semantics**
+
+1. If a batch separation is already running, the command returns `CommandError`
+2. The command plans the batch: songs with valid cached stems for the active stem mode are skipped and counted in `skipped`
+3. Songs marked `instrumental = true` or Media+G are excluded from the plan
+4. Jobs run sequentially because ONNX Runtime is memory-heavy
+5. The command returns immediately; the batch loop runs in the background
+6. The backend emits `batch-separation-progress` events during the batch and a terminal `batch-separation-complete` event
+7. Each song in the batch also emits the standard `separation-progress`, `separation-complete`, and `separation-error` events
+8. Runtime and model bootstrap happen once before the batch loop starts; if bootstrap fails, the batch emits a terminal `batch-separation-complete` event with all candidates as `failed`
+
+### Command: `cancel_batch_separation`
+
+**Input**: none
+
+**Output:** `()`
+
+**Semantics**
+
+1. If no batch separation is running, the command returns `CommandError`
+2. The command sets the batch cancel flag and flags the in-flight song so the batch stops mid-song
+3. The backend emits `batch-separation-cancelled` after the current song stops
+4. Songs that were not yet processed remain unseparated
+
+### Event: `separation-cancelled`
+
+```json
+{
+  "songId": "sha256 hash string"
+}
+```
+
+**Semantics**
+
+1. Emitted when a cancellation flag was set and the worker observed it before completing
+2. A cancelled run never emits `separation-error`; the frontend resets the song status to `idle`
+3. A run that completed successfully before the cancellation flag was observed does not emit this event
+
+### Event: `batch-separation-progress`
+
+```json
+{
+  "total": 15,
+  "completed": 3,
+  "skipped": 5,
+  "failed": 0,
+  "currentSongId": "sha256 hash string",
+  "currentPercent": 42
+}
+```
+
+**Semantics**
+
+1. `total` is the number of candidate songs to separate (excludes skipped songs)
+2. `skipped` is the number of songs that already had valid cached stems for the active stem mode
+3. `currentSongId` is `null` between songs or when the batch has not started processing
+4. `currentPercent` is the per-song progress of the current song (0–100)
+5. The backend emits this event at the start of the batch, before each song, and on each per-song progress update
+
+### Event: `batch-separation-complete`
+
+Payload is the same `BatchSeparationProgress` shape as `batch-separation-progress`.
+
+**Semantics**
+
+1. Emitted when the batch loop finishes all candidate songs
+2. `completed` + `failed` + `skipped` = `total` + `skipped`
+3. `currentSongId` is `null` and `currentPercent` is `0`
+4. If the prerequisite bootstrap failed, the backend emits this event with all candidates as `failed`
+
+### Event: `batch-separation-cancelled`
+
+Payload is the same `BatchSeparationProgress` shape as `batch-separation-progress`.
+
+**Semantics**
+
+1. Emitted when the user called `cancel_batch_separation` and the batch loop observed the cancel flag
+2. `completed` and `failed` reflect the state at the time of cancellation
+3. Songs that were not yet processed remain unseparated
+
+### Shared type: `BatchSeparationProgress`
+
+| Field             | Type             | Notes                                             |
+| ----------------- | ---------------- | ------------------------------------------------- |
+| `total`           | `usize`          | Candidate songs to separate (excludes skipped)    |
+| `completed`       | `usize`          | Songs that finished successfully                  |
+| `skipped`         | `usize`          | Songs that already had valid cached stems         |
+| `failed`          | `usize`          | Songs that failed separation                      |
+| `current_song_id` | `Option<String>` | The song being processed, or `null` between songs |
+| `current_percent` | `u8`             | Per-song progress of the current song (0–100)     |
 
 ### Shared error type: `CommandError`
 

--- a/docs/references/contracts/settings.md
+++ b/docs/references/contracts/settings.md
@@ -80,7 +80,64 @@ stays explicitly dark regardless of the primary preference.
 - `set_eq_gains(gains_db: [f32; 5]) -> AppSettings`
 - `set_crossfade_enabled(enabled: bool) -> AppSettings`
 - `set_crossfade_duration_ms(duration_ms: u32) -> AppSettings`
+- `set_update_policy(policy: UpdatePolicy) -> AppSettings`
 - `restart_app() -> ()`
+
+## Update policy
+
+`UpdatePolicy` enum values (serialized as lowercase snake_case strings):
+
+| Value             | Meaning                                                               |
+| ----------------- | --------------------------------------------------------------------- |
+| `"manual"`        | Only check for updates when the user triggers it manually             |
+| `"notify"`        | Check on startup and surface available updates (default)              |
+| `"auto_download"` | Download updates in the background; activation still requires restart |
+
+### Command
+
+- `set_update_policy(policy: UpdatePolicy) -> AppSettings` — Persist the
+  update policy. Return the updated settings snapshot. Activation of a
+  staged runtime always requires a restart regardless of policy; the policy
+  only governs checking and downloading.
+
+## Debug info
+
+`get_debug_info() -> DebugInfo`
+
+Returns a diagnostic snapshot for bug reports. Both the Settings → About
+panel and the macOS Help menu call this command. The frontend owns the
+plain-text formatting.
+
+| Field                     | Type             | Notes                                                   |
+| ------------------------- | ---------------- | ------------------------------------------------------- |
+| `app_version`             | `string`         | Application version from the bundle                     |
+| `build_sha`               | `string`         | Git short SHA, or `"unknown"`                           |
+| `os`                      | `string`         | Operating system family (`macos` / `windows` / `linux`) |
+| `arch`                    | `string`         | CPU architecture (`aarch64` / `x86_64`)                 |
+| `catalog_generation`      | `u64`            | Embedded catalog generation                             |
+| `catalog_release_id`      | `string`         | Embedded catalog release ID                             |
+| `model_variant`           | `string`         | Active separation model variant                         |
+| `model_state`             | `string`         | Bootstrap state of the active model                     |
+| `model_installed`         | `bool`           | Whether the active model is installed and verified      |
+| `model_installed_version` | `Option<string>` | Installed model upstream tag, when known                |
+| `model_pinned_version`    | `string`         | Upstream tag pinned by the embedded catalog             |
+| `model_path`              | `string`         | Expected model file path on disk                        |
+| `runtime_state`           | `string`         | Bootstrap state of the ONNX Runtime                     |
+| `runtime_version`         | `string`         | Active runtime upstream version                         |
+| `runtime_artifact_id`     | `Option<string>` | Active runtime artifact ID                              |
+| `runtime_target_triple`   | `string`         | Runtime target triple for this build                    |
+| `execution_provider`      | `string`         | Current execution-provider preference                   |
+| `log_file`                | `string`         | Path pattern of the rolling log file                    |
+
+## Self-update probe
+
+`self_update_supported() -> bool`
+
+Returns whether the running install can self-update through
+`tauri-plugin-updater`. Only bundles that emit signed updater artifacts are
+updatable: the AppImage on Linux, the `.app`/DMG on macOS, and the NSIS
+installer on Windows. A Linux `.deb`, Flatpak, or an unbundled dev binary
+returns `false`. The frontend gates its launch update check on this probe.
 
 ## Remote streaming cache
 

--- a/src-tauri/catalog/release-manifest.json
+++ b/src-tauri/catalog/release-manifest.json
@@ -13,7 +13,13 @@
           "replacement_artifact_id": "htdemucs.spectral.fp32.onnx",
           "sunset_generation": 11
         },
+        "capability_limit": {
+          "channels": 2,
+          "max_segment_seconds": 7.8,
+          "sample_rate_hz": 44100
+        },
         "download_url": "https://github.com/thedavidweng/openkara-models/releases/download/model-v2.1.0/htdemucs.onnx",
+        "evaluation_fixture": null,
         "extracted_file_digests": {
           "htdemucs.onnx": {
             "sha256": "3d85dad9b53c8a6a16d8d8d0518122c2ca750542f39104dc6ace77372c6dc8a9",
@@ -22,6 +28,7 @@
         },
         "filename": "htdemucs.onnx",
         "kind": "model",
+        "known_user_effect": "Requires stereo input; mono and surround audio are rejected. Audio not at 44.1 kHz is resampled before separation. Waveform-interface delivery; no longer loadable by current builds, install the spectral-core replacement.",
         "model": {
           "cache_key": "htdemucs-balanced-fp32-model-v2.1.0",
           "compatible_runtime_ids": [
@@ -92,7 +99,13 @@
           "replacement_artifact_id": "htdemucs_ft.spectral.fp32.onnx",
           "sunset_generation": 11
         },
+        "capability_limit": {
+          "channels": 2,
+          "max_segment_seconds": 7.8,
+          "sample_rate_hz": 44100
+        },
         "download_url": "https://github.com/thedavidweng/openkara-models/releases/download/model-ft-v2.1.0/htdemucs_ft.onnx",
+        "evaluation_fixture": null,
         "extracted_file_digests": {
           "htdemucs_ft.onnx": {
             "sha256": "bf7189043607085299c55379b208067efac12b2c44dddef5f5cc5e789e6cd03b",
@@ -101,6 +114,7 @@
         },
         "filename": "htdemucs_ft.onnx",
         "kind": "model",
+        "known_user_effect": "Requires stereo input; mono and surround audio are rejected. Audio not at 44.1 kHz is resampled before separation. Waveform-interface delivery; no longer loadable by current builds, install the spectral-core replacement.",
         "model": {
           "cache_key": "htdemucs-ft-quality-fp32-model-ft-v2.1.0",
           "compatible_runtime_ids": [
@@ -171,7 +185,13 @@
           "replacement_artifact_id": "htdemucs_ft.spectral.fp32.onnx",
           "sunset_generation": 11
         },
+        "capability_limit": {
+          "channels": 2,
+          "max_segment_seconds": 7.8,
+          "sample_rate_hz": 44100
+        },
         "download_url": "https://github.com/thedavidweng/openkara-models/releases/download/model-derived-v1.0.0/htdemucs_ft.dedup.fp32.onnx",
+        "evaluation_fixture": null,
         "extracted_file_digests": {
           "htdemucs_ft.dedup.fp32.onnx": {
             "sha256": "05b5e94d941667577277e1b4d97029d38d45037439e3daaac76de63d64de6ffd",
@@ -180,6 +200,7 @@
         },
         "filename": "htdemucs_ft.dedup.fp32.onnx",
         "kind": "model",
+        "known_user_effect": "Requires stereo input; mono and surround audio are rejected. Audio not at 44.1 kHz is resampled before separation. Waveform-interface delivery; no longer loadable by current builds, install the spectral-core replacement.",
         "model": {
           "cache_key": "htdemucs-ft-quality-fp32-model-derived-v1.0.0",
           "compatible_runtime_ids": [
@@ -250,7 +271,13 @@
           "replacement_artifact_id": "htdemucs.spectral.fp32.onnx",
           "sunset_generation": 11
         },
+        "capability_limit": {
+          "channels": 2,
+          "max_segment_seconds": 7.8,
+          "sample_rate_hz": 44100
+        },
         "download_url": "https://github.com/thedavidweng/openkara-models/releases/download/model-derived-v1.2.0/htdemucs.dual.fp32.onnx.tar.gz",
+        "evaluation_fixture": null,
         "extracted_file_digests": {
           "htdemucs.dual.fp32.onnx": {
             "sha256": "d4dce4aaf9171b0dc2e717ce1ccf3a75eb44aa7c15fb48646d233cac8149b968",
@@ -259,6 +286,7 @@
         },
         "filename": "htdemucs.dual.fp32.onnx.tar.gz",
         "kind": "model",
+        "known_user_effect": "Requires stereo input; mono and surround audio are rejected. Audio not at 44.1 kHz is resampled before separation. Waveform-interface delivery; no longer loadable by current builds, install the spectral-core replacement.",
         "model": {
           "cache_key": "htdemucs-balanced-fp32-dual-model-derived-v1.1.0",
           "compatible_runtime_ids": [
@@ -329,7 +357,13 @@
           "replacement_artifact_id": "htdemucs_ft.spectral.fp32.onnx",
           "sunset_generation": 11
         },
+        "capability_limit": {
+          "channels": 2,
+          "max_segment_seconds": 7.8,
+          "sample_rate_hz": 44100
+        },
         "download_url": "https://github.com/thedavidweng/openkara-models/releases/download/model-derived-v1.2.0/htdemucs_ft.dual.fp32.onnx.tar.gz",
+        "evaluation_fixture": null,
         "extracted_file_digests": {
           "htdemucs_ft.dual.fp32.onnx": {
             "sha256": "6274ea282a3e64cc5ac5375dc3f8171b88b6d85ce4ce5f679850168b220ab52d",
@@ -338,6 +372,7 @@
         },
         "filename": "htdemucs_ft.dual.fp32.onnx.tar.gz",
         "kind": "model",
+        "known_user_effect": "Requires stereo input; mono and surround audio are rejected. Audio not at 44.1 kHz is resampled before separation. Waveform-interface delivery; no longer loadable by current builds, install the spectral-core replacement.",
         "model": {
           "cache_key": "htdemucs-ft-quality-fp32-dual-model-derived-v1.1.0",
           "compatible_runtime_ids": [
@@ -407,7 +442,13 @@
           "replacement_artifact_id": null,
           "sunset_generation": null
         },
+        "capability_limit": {
+          "channels": 2,
+          "max_segment_seconds": 7.8,
+          "sample_rate_hz": 44100
+        },
         "download_url": "https://github.com/thedavidweng/openkara-models/releases/download/model-spectral-v1.0.0/htdemucs.spectral.onnx",
+        "evaluation_fixture": "openkara.spectral-contract/v1",
         "extracted_file_digests": {
           "htdemucs.spectral.onnx": {
             "sha256": "c3395410b1319976683bc874d97461655a9ea6089bbb0f3bd163d3829db13d02",
@@ -416,6 +457,7 @@
         },
         "filename": "htdemucs.spectral.onnx",
         "kind": "model",
+        "known_user_effect": "Requires stereo input; mono and surround audio are rejected. Audio not at 44.1 kHz is resampled before separation. The spectral transform discards the Nyquist bin (22050 Hz), so content at and above 22 kHz is not represented in the separated stems.",
         "model": {
           "cache_key": "htdemucs-spectral-fp32-model-spectral-v1.0.0",
           "compatible_runtime_ids": [
@@ -490,7 +532,13 @@
           "replacement_artifact_id": null,
           "sunset_generation": null
         },
+        "capability_limit": {
+          "channels": 2,
+          "max_segment_seconds": 7.8,
+          "sample_rate_hz": 44100
+        },
         "download_url": "https://github.com/thedavidweng/openkara-models/releases/download/model-ft-spectral-v1.0.0/htdemucs_ft.spectral.onnx",
+        "evaluation_fixture": "openkara.spectral-contract/v1",
         "extracted_file_digests": {
           "htdemucs_ft.spectral.onnx": {
             "sha256": "af604e3cceb04f1537547bb2edde16fed7cb065d2c8659a0b348bdd9ac16c3a4",
@@ -499,6 +547,7 @@
         },
         "filename": "htdemucs_ft.spectral.onnx",
         "kind": "model",
+        "known_user_effect": "Requires stereo input; mono and surround audio are rejected. Audio not at 44.1 kHz is resampled before separation. The spectral transform discards the Nyquist bin (22050 Hz), so content at and above 22 kHz is not represented in the separated stems.",
         "model": {
           "cache_key": "htdemucs-ft-spectral-fp32-model-ft-spectral-v1.0.0",
           "compatible_runtime_ids": [

--- a/src-tauri/catalog/stable-pointer.json
+++ b/src-tauri/catalog/stable-pointer.json
@@ -3,8 +3,8 @@
   "generation": 10,
   "previous_release_id": "2026-07-25-006",
   "release_id": "2026-07-26-001",
-  "release_manifest_sha256": "818f0c10d590ff805f2df22bd651f9e86fa29ac004f2c233513b0176612f2505",
-  "release_manifest_size": 104331,
+  "release_manifest_sha256": "b8bb3b0203a176f41ef8f22bfcb569a74cca71da06870b93b1b704bf8aae1f2b",
+  "release_manifest_size": 107430,
   "release_manifest_url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-07-26-001/release-manifest.json",
   "schema_version": "openkara.catalog/channel-v1",
   "updated_at": "2026-07-26T03:30:00Z"

--- a/src-tauri/src/separator/catalog.rs
+++ b/src-tauri/src/separator/catalog.rs
@@ -121,6 +121,19 @@ pub struct CatalogModel {
     pub deprecation: CatalogDeprecation,
     pub upstream: CatalogUpstream,
     pub model: CatalogModelMetadata,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub evaluation_fixture: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capability_limit: Option<CapabilityLimit>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub known_user_effect: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CapabilityLimit {
+    pub max_segment_seconds: f64,
+    pub sample_rate_hz: u32,
+    pub channels: usize,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]

--- a/src/components/Layout/UpdateBanner.tsx
+++ b/src/components/Layout/UpdateBanner.tsx
@@ -100,7 +100,11 @@ export function UpdateBanner() {
   if (phase === "downloading") {
     return (
       <div className={containerClass}>
-        <div className="flex items-center gap-2 text-[12px] text-[var(--color-text)]">
+        <div
+          role="status"
+          aria-live="polite"
+          className="flex items-center gap-2 text-[12px] text-[var(--color-text)]"
+        >
           <Loader2 size={12} className="animate-spin" />
           {t("updater.downloading", { percent })}
         </div>

--- a/src/components/Library/ContextMenu.keyboard.test.tsx
+++ b/src/components/Library/ContextMenu.keyboard.test.tsx
@@ -1,0 +1,613 @@
+// @vitest-environment jsdom
+
+import { createRoot } from "react-dom/client";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { ContextMenu } from "./ContextMenu";
+import type { ContextMenuItem } from "./ContextMenu";
+
+function renderMenu(
+  items: ContextMenuItem[],
+  opts: {
+    onClose?: () => void;
+    triggerRef?: React.RefObject<HTMLElement | null>;
+  } = {},
+) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const onClose = opts.onClose ?? vi.fn();
+  act(() => {
+    root.render(
+      <ContextMenu
+        x={10}
+        y={10}
+        items={items}
+        onClose={onClose}
+        triggerRef={opts.triggerRef}
+      />,
+    );
+  });
+  return { container, root, onClose };
+}
+
+describe("ContextMenu keyboard navigation and ARIA", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    if (root) act(() => root.unmount());
+    if (container) container.remove();
+  });
+
+  test("renders role=menu and role=menuitem for each item", () => {
+    const items: ContextMenuItem[] = [
+      { label: "Play", onClick: () => {} },
+      { label: "Delete", onClick: () => {} },
+    ];
+    ({ container, root } = renderMenu(items));
+
+    const menu = document.querySelector('[role="menu"]');
+    expect(menu).not.toBeNull();
+    expect(menu?.getAttribute("aria-orientation")).toBe("vertical");
+
+    const menuItems = document.querySelectorAll('[role="menuitem"]');
+    expect(menuItems).toHaveLength(2);
+  });
+
+  test("renders role=menuitemcheckbox with aria-checked for indicator items", () => {
+    const items: ContextMenuItem[] = [
+      { label: "Toggle", onClick: () => {}, indicator: "checked" },
+      { label: "Partial", onClick: () => {}, indicator: "mixed" },
+      { label: "Off", onClick: () => {}, indicator: null },
+    ];
+    ({ container, root } = renderMenu(items));
+
+    const checkboxes = document.querySelectorAll('[role="menuitemcheckbox"]');
+    expect(checkboxes).toHaveLength(3);
+    expect(checkboxes[0].getAttribute("aria-checked")).toBe("true");
+    expect(checkboxes[1].getAttribute("aria-checked")).toBe("mixed");
+    expect(checkboxes[2].getAttribute("aria-checked")).toBe("false");
+  });
+
+  test("ArrowDown moves focus to the next item with wrap-around", () => {
+    const items: ContextMenuItem[] = [
+      { label: "Alpha", onClick: () => {} },
+      { label: "Beta", onClick: () => {} },
+      { label: "Gamma", onClick: () => {} },
+    ];
+    ({ container, root } = renderMenu(items));
+
+    const menu = document.querySelector('[role="menu"]') as HTMLElement;
+    const buttons = menu.querySelectorAll("button");
+
+    expect(document.activeElement).toBe(buttons[0]);
+
+    act(() => {
+      menu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+      );
+    });
+    expect(document.activeElement).toBe(buttons[1]);
+
+    act(() => {
+      menu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+      );
+    });
+    expect(document.activeElement).toBe(buttons[2]);
+
+    act(() => {
+      menu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+      );
+    });
+    expect(document.activeElement).toBe(buttons[0]);
+  });
+
+  test("ArrowUp moves focus to the previous item with wrap-around", () => {
+    const items: ContextMenuItem[] = [
+      { label: "Alpha", onClick: () => {} },
+      { label: "Beta", onClick: () => {} },
+    ];
+    ({ container, root } = renderMenu(items));
+
+    const menu = document.querySelector('[role="menu"]') as HTMLElement;
+    const buttons = menu.querySelectorAll("button");
+
+    expect(document.activeElement).toBe(buttons[0]);
+
+    act(() => {
+      menu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }),
+      );
+    });
+    expect(document.activeElement).toBe(buttons[1]);
+  });
+
+  test("Home and End move focus to first and last item", () => {
+    const items: ContextMenuItem[] = [
+      { label: "Alpha", onClick: () => {} },
+      { label: "Beta", onClick: () => {} },
+      { label: "Gamma", onClick: () => {} },
+    ];
+    ({ container, root } = renderMenu(items));
+
+    const menu = document.querySelector('[role="menu"]') as HTMLElement;
+    const buttons = menu.querySelectorAll("button");
+
+    act(() => {
+      menu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "End", bubbles: true }),
+      );
+    });
+    expect(document.activeElement).toBe(buttons[2]);
+
+    act(() => {
+      menu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Home", bubbles: true }),
+      );
+    });
+    expect(document.activeElement).toBe(buttons[0]);
+  });
+
+  test("Enter activates the focused item and closes the menu", () => {
+    const onClick = vi.fn();
+    const onClose = vi.fn();
+    const items: ContextMenuItem[] = [{ label: "Play", onClick }];
+    ({ container, root } = renderMenu(items, { onClose }));
+
+    const menu = document.querySelector('[role="menu"]') as HTMLElement;
+
+    act(() => {
+      menu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      );
+    });
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("Space activates the focused item and closes the menu", () => {
+    const onClick = vi.fn();
+    const onClose = vi.fn();
+    const items: ContextMenuItem[] = [{ label: "Play", onClick }];
+    ({ container, root } = renderMenu(items, { onClose }));
+
+    const menu = document.querySelector('[role="menu"]') as HTMLElement;
+
+    act(() => {
+      menu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: " ", bubbles: true }),
+      );
+    });
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("Escape closes the menu and returns focus to the trigger", () => {
+    const onClose = vi.fn();
+    const trigger = document.createElement("button");
+    document.body.appendChild(trigger);
+    const triggerRef = { current: trigger };
+    const items: ContextMenuItem[] = [{ label: "Play", onClick: () => {} }];
+    ({ container, root } = renderMenu(items, { onClose, triggerRef }));
+
+    const menu = document.querySelector('[role="menu"]') as HTMLElement;
+
+    act(() => {
+      menu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).toBe(trigger);
+
+    trigger.remove();
+  });
+
+  test("triggerRef sets aria-haspopup and aria-expanded on the trigger", () => {
+    const trigger = document.createElement("button");
+    document.body.appendChild(trigger);
+    const triggerRef = { current: trigger };
+    const items: ContextMenuItem[] = [{ label: "Play", onClick: () => {} }];
+    ({ container, root } = renderMenu(items, { triggerRef }));
+
+    expect(trigger.getAttribute("aria-haspopup")).toBe("true");
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+
+    act(() => root.unmount());
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+
+    trigger.remove();
+  });
+
+  test("ArrowRight opens a submenu for items with children", () => {
+    const items: ContextMenuItem[] = [
+      {
+        label: "Sort by",
+        children: [{ label: "Title", onClick: () => {} }],
+      },
+    ];
+    ({ container, root } = renderMenu(items));
+
+    const menu = document.querySelector('[role="menu"]') as HTMLElement;
+    const parentButton = menu.querySelector("button") as HTMLButtonElement;
+    expect(parentButton.getAttribute("aria-haspopup")).toBe("true");
+    expect(parentButton.getAttribute("aria-expanded")).toBe("false");
+
+    act(() => {
+      menu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+      );
+    });
+
+    expect(parentButton.getAttribute("aria-expanded")).toBe("true");
+    const submenu = document.querySelectorAll('[role="menu"]');
+    expect(submenu).toHaveLength(2);
+  });
+
+  test("type-ahead moves focus to the first item matching the typed letter", () => {
+    const items: ContextMenuItem[] = [
+      { label: "Alpha", onClick: () => {} },
+      { label: "Beta", onClick: () => {} },
+      { label: "Gamma", onClick: () => {} },
+    ];
+    ({ container, root } = renderMenu(items));
+
+    const menu = document.querySelector('[role="menu"]') as HTMLElement;
+    const buttons = menu.querySelectorAll("button");
+
+    expect(document.activeElement).toBe(buttons[0]);
+
+    act(() => {
+      menu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "g", bubbles: true }),
+      );
+    });
+    expect(document.activeElement).toBe(buttons[2]);
+
+    act(() => {
+      menu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "b", bubbles: true }),
+      );
+    });
+    expect(document.activeElement).toBe(buttons[1]);
+  });
+
+  test("click on a leaf item activates it and closes the menu", () => {
+    const onClick = vi.fn();
+    const onClose = vi.fn();
+    const items: ContextMenuItem[] = [{ label: "Play", onClick }];
+    ({ container, root } = renderMenu(items, { onClose }));
+
+    const button = document.querySelector(
+      '[role="menuitem"]',
+    ) as HTMLButtonElement;
+
+    act(() => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("mouse enter on a submenu parent opens the submenu", () => {
+    const items: ContextMenuItem[] = [
+      {
+        label: "Sort by",
+        children: [{ label: "Title", onClick: () => {} }],
+      },
+    ];
+    ({ container, root } = renderMenu(items));
+
+    const parentButton = document.querySelector(
+      '[role="menuitem"]',
+    ) as HTMLButtonElement;
+
+    act(() => {
+      parentButton.dispatchEvent(
+        new MouseEvent("mouseover", {
+          bubbles: true,
+          relatedTarget: document.body,
+        }),
+      );
+    });
+
+    expect(parentButton.getAttribute("aria-expanded")).toBe("true");
+    const submenus = document.querySelectorAll('[role="menu"]');
+    expect(submenus).toHaveLength(2);
+  });
+
+  test("mouse enter on a leaf item sets focus index", () => {
+    const items: ContextMenuItem[] = [
+      { label: "Alpha", onClick: () => {} },
+      { label: "Beta", onClick: () => {} },
+    ];
+    ({ container, root } = renderMenu(items));
+
+    const buttons = document.querySelectorAll('[role="menuitem"]');
+    const betaButton = buttons[1] as HTMLButtonElement;
+
+    act(() => {
+      betaButton.dispatchEvent(
+        new MouseEvent("mouseover", {
+          bubbles: true,
+          relatedTarget: document.body,
+        }),
+      );
+    });
+
+    expect(betaButton.tabIndex).toBe(0);
+  });
+});
+
+describe("ContextMenu SubMenu keyboard navigation", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    if (root) act(() => root.unmount());
+    if (container) container.remove();
+  });
+
+  function renderWithSubmenu(onClose?: () => void) {
+    const items: ContextMenuItem[] = [
+      {
+        label: "Sort by",
+        children: [
+          { label: "Title", onClick: vi.fn() },
+          { label: "Artist", onClick: vi.fn() },
+        ],
+      },
+    ];
+    const result = renderMenu(items, { onClose });
+    ({ container, root } = result);
+
+    const menu = document.querySelector('[role="menu"]') as HTMLElement;
+    act(() => {
+      menu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+      );
+    });
+    return result;
+  }
+
+  test("ArrowDown moves focus within the submenu", () => {
+    renderWithSubmenu();
+
+    const submenus = document.querySelectorAll('[role="menu"]');
+    const submenu = submenus[1] as HTMLElement;
+    const subButtons = submenu.querySelectorAll("button");
+
+    expect(document.activeElement).toBe(subButtons[0]);
+
+    act(() => {
+      submenu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+      );
+    });
+    expect(document.activeElement).toBe(subButtons[1]);
+  });
+
+  test("ArrowUp moves focus within the submenu with wrap-around", () => {
+    renderWithSubmenu();
+
+    const submenus = document.querySelectorAll('[role="menu"]');
+    const submenu = submenus[1] as HTMLElement;
+    const subButtons = submenu.querySelectorAll("button");
+
+    act(() => {
+      submenu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }),
+      );
+    });
+    expect(document.activeElement).toBe(subButtons[1]);
+  });
+
+  test("Enter activates the submenu item and closes the menu", () => {
+    const onClose = vi.fn();
+    const subOnClick = vi.fn();
+    const items: ContextMenuItem[] = [
+      {
+        label: "Sort by",
+        children: [{ label: "Title", onClick: subOnClick }],
+      },
+    ];
+    ({ container, root } = renderMenu(items, { onClose }));
+
+    const menu = document.querySelector('[role="menu"]') as HTMLElement;
+    act(() => {
+      menu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+      );
+    });
+
+    const submenus = document.querySelectorAll('[role="menu"]');
+    const submenu = submenus[1] as HTMLElement;
+
+    act(() => {
+      submenu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      );
+    });
+
+    expect(subOnClick).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test("Escape closes the submenu and the menu", () => {
+    const onClose = vi.fn();
+    renderWithSubmenu(onClose);
+
+    const submenus = document.querySelectorAll('[role="menu"]');
+    const submenu = submenus[1] as HTMLElement;
+
+    act(() => {
+      submenu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test("ArrowLeft closes the submenu", () => {
+    const onClose = vi.fn();
+    renderWithSubmenu(onClose);
+
+    const submenus = document.querySelectorAll('[role="menu"]');
+    const submenu = submenus[1] as HTMLElement;
+
+    act(() => {
+      submenu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }),
+      );
+    });
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test("Home and End move focus within the submenu", () => {
+    const items: ContextMenuItem[] = [
+      {
+        label: "Sort by",
+        children: [
+          { label: "Title", onClick: () => {} },
+          { label: "Artist", onClick: () => {} },
+          { label: "Album", onClick: () => {} },
+        ],
+      },
+    ];
+    ({ container, root } = renderMenu(items));
+
+    const menu = document.querySelector('[role="menu"]') as HTMLElement;
+    act(() => {
+      menu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+      );
+    });
+
+    const submenus = document.querySelectorAll('[role="menu"]');
+    const submenu = submenus[1] as HTMLElement;
+    const subButtons = submenu.querySelectorAll("button");
+
+    act(() => {
+      submenu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "End", bubbles: true }),
+      );
+    });
+    expect(document.activeElement).toBe(subButtons[2]);
+
+    act(() => {
+      submenu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Home", bubbles: true }),
+      );
+    });
+    expect(document.activeElement).toBe(subButtons[0]);
+  });
+
+  test("type-ahead moves focus within the submenu", () => {
+    const items: ContextMenuItem[] = [
+      {
+        label: "Sort by",
+        children: [
+          { label: "Title", onClick: () => {} },
+          { label: "Artist", onClick: () => {} },
+        ],
+      },
+    ];
+    ({ container, root } = renderMenu(items));
+
+    const menu = document.querySelector('[role="menu"]') as HTMLElement;
+    act(() => {
+      menu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+      );
+    });
+
+    const submenus = document.querySelectorAll('[role="menu"]');
+    const submenu = submenus[1] as HTMLElement;
+    const subButtons = submenu.querySelectorAll("button");
+
+    act(() => {
+      submenu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "a", bubbles: true }),
+      );
+    });
+    expect(document.activeElement).toBe(subButtons[1]);
+  });
+
+  test("Space activates the submenu item and closes the menu", () => {
+    const onClose = vi.fn();
+    const subOnClick = vi.fn();
+    const items: ContextMenuItem[] = [
+      {
+        label: "Sort by",
+        children: [{ label: "Title", onClick: subOnClick }],
+      },
+    ];
+    ({ container, root } = renderMenu(items, { onClose }));
+
+    const menu = document.querySelector('[role="menu"]') as HTMLElement;
+    act(() => {
+      menu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+      );
+    });
+
+    const submenus = document.querySelectorAll('[role="menu"]');
+    const submenu = submenus[1] as HTMLElement;
+
+    act(() => {
+      submenu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: " ", bubbles: true }),
+      );
+    });
+
+    expect(subOnClick).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test("click on a submenu item activates it and closes the menu", () => {
+    const onClose = vi.fn();
+    const subOnClick = vi.fn();
+    const items: ContextMenuItem[] = [
+      {
+        label: "Sort by",
+        children: [{ label: "Title", onClick: subOnClick }],
+      },
+    ];
+    ({ container, root } = renderMenu(items, { onClose }));
+
+    const menu = document.querySelector('[role="menu"]') as HTMLElement;
+    act(() => {
+      menu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+      );
+    });
+
+    const submenus = document.querySelectorAll('[role="menu"]');
+    const submenu = submenus[1] as HTMLElement;
+    const subButton = submenu.querySelector("button") as HTMLButtonElement;
+
+    act(() => {
+      subButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(subOnClick).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/Library/ContextMenu.keyboard.test.tsx
+++ b/src/components/Library/ContextMenu.keyboard.test.tsx
@@ -610,4 +610,114 @@ describe("ContextMenu SubMenu keyboard navigation", () => {
     expect(subOnClick).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalled();
   });
+
+  test("click on a submenu checkbox item activates it and closes the menu", () => {
+    const onClose = vi.fn();
+    const subOnClick = vi.fn();
+    const items: ContextMenuItem[] = [
+      {
+        label: "Sort by",
+        children: [
+          { label: "Title", onClick: subOnClick, indicator: "checked" },
+        ],
+      },
+    ];
+    ({ container, root } = renderMenu(items, { onClose }));
+
+    const menu = document.querySelector('[role="menu"]') as HTMLElement;
+    act(() => {
+      menu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+      );
+    });
+
+    const submenus = document.querySelectorAll('[role="menu"]');
+    const submenu = submenus[1] as HTMLElement;
+    const subCheckbox = submenu.querySelector(
+      '[role="menuitemcheckbox"]',
+    ) as HTMLButtonElement;
+
+    act(() => {
+      subCheckbox.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(subOnClick).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test("ArrowRight on a leaf item does nothing", () => {
+    const items: ContextMenuItem[] = [
+      { label: "Play", onClick: () => {} },
+      { label: "Delete", onClick: () => {} },
+    ];
+    ({ container, root } = renderMenu(items));
+
+    const menu = document.querySelector('[role="menu"]') as HTMLElement;
+    const buttons = menu.querySelectorAll("button");
+
+    act(() => {
+      menu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+      );
+    });
+
+    expect(document.querySelectorAll('[role="menu"]')).toHaveLength(1);
+    expect(document.activeElement).toBe(buttons[0]);
+  });
+
+  test("renders an empty menu with no items when items is empty", () => {
+    ({ container, root } = renderMenu([]));
+
+    const menu = document.querySelector('[role="menu"]');
+    expect(menu).not.toBeNull();
+    expect(menu?.querySelectorAll("button")).toHaveLength(0);
+  });
+
+  test("keyboard navigation does nothing when items is empty", () => {
+    ({ container, root } = renderMenu([]));
+
+    const menu = document.querySelector('[role="menu"]') as HTMLElement;
+    act(() => {
+      menu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+      );
+    });
+    expect(document.querySelectorAll('[role="menuitem"]')).toHaveLength(0);
+  });
+
+  test("mouse enter on a submenu item sets focus index", () => {
+    const items: ContextMenuItem[] = [
+      {
+        label: "Sort by",
+        children: [
+          { label: "Title", onClick: () => {} },
+          { label: "Artist", onClick: () => {} },
+        ],
+      },
+    ];
+    ({ container, root } = renderMenu(items));
+
+    const menu = document.querySelector('[role="menu"]') as HTMLElement;
+    act(() => {
+      menu.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+      );
+    });
+
+    const submenus = document.querySelectorAll('[role="menu"]');
+    const submenu = submenus[1] as HTMLElement;
+    const subButtons = submenu.querySelectorAll("button");
+    const secondSubButton = subButtons[1] as HTMLButtonElement;
+
+    act(() => {
+      secondSubButton.dispatchEvent(
+        new MouseEvent("mouseover", {
+          bubbles: true,
+          relatedTarget: document.body,
+        }),
+      );
+    });
+
+    expect(secondSubButton.tabIndex).toBe(0);
+  });
 });

--- a/src/components/Library/ContextMenu.tsx
+++ b/src/components/Library/ContextMenu.tsx
@@ -17,20 +17,30 @@ interface ContextMenuProps {
   y: number;
   items: ContextMenuItem[];
   onClose: () => void;
+  triggerRef?: React.RefObject<HTMLElement | null>;
 }
 
-export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
+export function ContextMenu({
+  x,
+  y,
+  items,
+  onClose,
+  triggerRef,
+}: ContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
   const [position, setPosition] = useState({ left: x, top: y });
+  const [focusedIndex, setFocusedIndex] = useState(0);
   const [submenuItem, setSubmenuItem] = useState<{
     children: ContextMenuItem[];
     parentRect: DOMRect;
   } | null>(null);
+  const [submenuOpenIndex, setSubmenuOpenIndex] = useState<number | null>(null);
   const isOverSubmenu = useRef(false);
   const hideTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mousePosRef = useRef<Point>({ x: 0, y: 0 });
   const parentItemRectRef = useRef<DOMRect | null>(null);
   const submenuRectRef = useRef<DOMRect | null>(null);
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   const itemCount = items.length;
 
@@ -52,9 +62,23 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
     hideTimeout.current = setTimeout(() => {
       if (!isOverSubmenu.current) {
         setSubmenuItem(null);
+        setSubmenuOpenIndex(null);
       }
     }, 300);
   };
+
+  useEffect(() => {
+    const trigger = triggerRef?.current ?? null;
+    if (trigger) {
+      trigger.setAttribute("aria-haspopup", "true");
+      trigger.setAttribute("aria-expanded", "true");
+    }
+    return () => {
+      if (trigger) {
+        trigger.setAttribute("aria-expanded", "false");
+      }
+    };
+  }, [triggerRef]);
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -66,7 +90,10 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
       }
     };
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") {
+        triggerRef?.current?.focus();
+        onClose();
+      }
     };
 
     document.addEventListener("mousedown", handleClickOutside);
@@ -75,11 +102,15 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
       document.removeEventListener("mousedown", handleClickOutside);
       document.removeEventListener("keydown", handleEscape);
     };
-  }, [onClose]);
+  }, [onClose, triggerRef]);
 
   useEffect(() => {
     return () => clearHide();
   }, []);
+
+  useEffect(() => {
+    itemRefs.current[focusedIndex]?.focus();
+  }, [focusedIndex]);
 
   useLayoutEffect(() => {
     const updatePosition = () => {
@@ -115,61 +146,153 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
     return null;
   }
 
+  const handleMenuKeyDown = (e: React.KeyboardEvent) => {
+    if (itemCount === 0) return;
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setFocusedIndex((prev) => (prev + 1) % itemCount);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setFocusedIndex((prev) => (prev - 1 + itemCount) % itemCount);
+        break;
+      case "Home":
+        e.preventDefault();
+        setFocusedIndex(0);
+        break;
+      case "End":
+        e.preventDefault();
+        setFocusedIndex(itemCount - 1);
+        break;
+      case "ArrowRight":
+      case "Enter":
+      case " ": {
+        const item = items[focusedIndex];
+        if (item.children) {
+          e.preventDefault();
+          const btn = itemRefs.current[focusedIndex];
+          if (btn) {
+            clearHide();
+            parentItemRectRef.current = btn.getBoundingClientRect();
+            setSubmenuOpenIndex(focusedIndex);
+            setSubmenuItem({
+              children: item.children,
+              parentRect: btn.getBoundingClientRect(),
+            });
+          }
+        } else if (e.key !== "ArrowRight") {
+          e.preventDefault();
+          item.onClick?.();
+          onClose();
+        }
+        break;
+      }
+      default:
+        if (e.key.length === 1 && /[a-zA-Z0-9]/.test(e.key)) {
+          const char = e.key.toLowerCase();
+          for (let i = 1; i <= itemCount; i++) {
+            const idx = (focusedIndex + i) % itemCount;
+            if (items[idx].label.toLowerCase().startsWith(char)) {
+              e.preventDefault();
+              setFocusedIndex(idx);
+              break;
+            }
+          }
+        }
+        break;
+    }
+  };
+
   return createPortal(
     <>
       <div
         ref={menuRef}
+        role="menu"
+        aria-orientation="vertical"
+        tabIndex={-1}
         className="fixed z-[70] min-w-[140px] rounded-md border border-[var(--color-border)] bg-[var(--color-sidebar)] py-1 shadow-xl"
         style={{ left: position.left, top: position.top }}
         onMouseMove={(e) => {
           mousePosRef.current = { x: e.clientX, y: e.clientY };
         }}
+        onKeyDown={handleMenuKeyDown}
       >
-        {items.map((item) => (
-          <button
-            key={item.label}
-            onClick={() => {
-              if (!item.children) {
-                item.onClick?.();
-                onClose();
+        {items.map((item, index) => {
+          const isCheckbox = item.indicator !== undefined;
+          const role = isCheckbox ? "menuitemcheckbox" : "menuitem";
+          const ariaChecked = isCheckbox
+            ? item.indicator === "checked"
+              ? "true"
+              : item.indicator === "mixed"
+                ? "mixed"
+                : "false"
+            : undefined;
+          return (
+            <button
+              key={item.label}
+              ref={(el) => {
+                itemRefs.current[index] = el;
+              }}
+              role={role}
+              aria-checked={ariaChecked}
+              aria-haspopup={item.children ? "true" : undefined}
+              aria-expanded={
+                item.children
+                  ? submenuOpenIndex === index
+                    ? "true"
+                    : "false"
+                  : undefined
               }
-            }}
-            onMouseEnter={
-              item.children
-                ? (e) => {
-                    clearHide();
-                    const btn = e.currentTarget;
-                    parentItemRectRef.current = btn.getBoundingClientRect();
-                    setSubmenuItem({
-                      children: item.children!,
-                      parentRect: btn.getBoundingClientRect(),
-                    });
-                  }
-                : undefined
-            }
-            onMouseLeave={
-              item.children
-                ? () => {
-                    scheduleHide();
-                  }
-                : undefined
-            }
-            className="flex w-full items-center px-3 py-1.5 text-left text-[13px] text-[var(--color-text-dim)] transition-colors hover:bg-[var(--color-hover)] hover:text-[var(--color-text)]"
-          >
-            <span
-              className="mr-2 flex h-4 w-4 shrink-0 items-center justify-center text-[10px] text-[var(--color-accent)]"
-              aria-hidden="true"
+              tabIndex={index === focusedIndex ? 0 : -1}
+              onClick={() => {
+                if (!item.children) {
+                  item.onClick?.();
+                  onClose();
+                }
+              }}
+              onMouseEnter={
+                item.children
+                  ? (e) => {
+                      clearHide();
+                      setFocusedIndex(index);
+                      const btn = e.currentTarget;
+                      parentItemRectRef.current = btn.getBoundingClientRect();
+                      setSubmenuOpenIndex(index);
+                      setSubmenuItem({
+                        children: item.children!,
+                        parentRect: btn.getBoundingClientRect(),
+                      });
+                    }
+                  : () => {
+                      setFocusedIndex(index);
+                    }
+              }
+              onMouseLeave={
+                item.children
+                  ? () => {
+                      scheduleHide();
+                    }
+                  : undefined
+              }
+              onFocus={() => setFocusedIndex(index)}
+              className="flex w-full items-center px-3 py-1.5 text-left text-[13px] text-[var(--color-text-dim)] transition-colors hover:bg-[var(--color-hover)] hover:text-[var(--color-text)]"
             >
-              {item.indicator === "checked"
-                ? "✓"
-                : item.indicator === "mixed"
-                  ? "−"
-                  : ""}
-            </span>
-            <span className="flex-1">{item.label}</span>
-            {item.children && <ChevronRight size={14} className="ml-3" />}
-          </button>
-        ))}
+              <span
+                className="mr-2 flex h-4 w-4 shrink-0 items-center justify-center text-[10px] text-[var(--color-accent)]"
+                aria-hidden="true"
+              >
+                {item.indicator === "checked"
+                  ? "✓"
+                  : item.indicator === "mixed"
+                    ? "−"
+                    : ""}
+              </span>
+              <span className="flex-1">{item.label}</span>
+              {item.children && <ChevronRight size={14} className="ml-3" />}
+            </button>
+          );
+        })}
       </div>
 
       {submenuItem && (
@@ -211,6 +334,8 @@ function SubMenu({
   onMouseLeave: () => void;
 }) {
   const menuRef = useRef<HTMLDivElement>(null);
+  const [focusedIndex, setFocusedIndex] = useState(0);
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const [pos, setPos] = useState({
     left: parentRect.right,
     top: parentRect.top,
@@ -238,37 +363,116 @@ function SubMenu({
     onSubmenuRect(menu.getBoundingClientRect());
   }, [parentRect, items, onSubmenuRect]);
 
+  useEffect(() => {
+    itemRefs.current[0]?.focus();
+  }, []);
+
+  useEffect(() => {
+    itemRefs.current[focusedIndex]?.focus();
+  }, [focusedIndex]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (items.length === 0) return;
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setFocusedIndex((prev) => (prev + 1) % items.length);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setFocusedIndex((prev) => (prev - 1 + items.length) % items.length);
+        break;
+      case "Home":
+        e.preventDefault();
+        setFocusedIndex(0);
+        break;
+      case "End":
+        e.preventDefault();
+        setFocusedIndex(items.length - 1);
+        break;
+      case "ArrowLeft":
+      case "Escape":
+        e.preventDefault();
+        onClose();
+        break;
+      case "Enter":
+      case " ": {
+        e.preventDefault();
+        const item = items[focusedIndex];
+        item.onClick?.();
+        onClose();
+        break;
+      }
+      default:
+        if (e.key.length === 1 && /[a-zA-Z0-9]/.test(e.key)) {
+          const char = e.key.toLowerCase();
+          for (let i = 1; i <= items.length; i++) {
+            const idx = (focusedIndex + i) % items.length;
+            if (items[idx].label.toLowerCase().startsWith(char)) {
+              e.preventDefault();
+              setFocusedIndex(idx);
+              break;
+            }
+          }
+        }
+        break;
+    }
+  };
+
   return (
     <div
       ref={menuRef}
+      role="menu"
+      aria-orientation="vertical"
+      tabIndex={-1}
       data-context-submenu
       className="fixed z-[71] min-w-[140px] rounded-md border border-[var(--color-border)] bg-[var(--color-sidebar)] py-1 shadow-xl"
       style={{ left: pos.left, top: pos.top }}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
+      onKeyDown={handleKeyDown}
     >
-      {items.map((item) => (
-        <button
-          key={item.label}
-          onClick={() => {
-            item.onClick?.();
-            onClose();
-          }}
-          className="flex w-full items-center px-3 py-1.5 text-left text-[13px] text-[var(--color-text-dim)] transition-colors hover:bg-[var(--color-hover)] hover:text-[var(--color-text)]"
-        >
-          <span
-            className="mr-2 flex h-4 w-4 shrink-0 items-center justify-center text-[10px] text-[var(--color-accent)]"
-            aria-hidden="true"
+      {items.map((item, index) => {
+        const isCheckbox = item.indicator !== undefined;
+        return (
+          <button
+            key={item.label}
+            ref={(el) => {
+              itemRefs.current[index] = el;
+            }}
+            role={isCheckbox ? "menuitemcheckbox" : "menuitem"}
+            aria-checked={
+              isCheckbox
+                ? item.indicator === "checked"
+                  ? "true"
+                  : item.indicator === "mixed"
+                    ? "mixed"
+                    : "false"
+                : undefined
+            }
+            tabIndex={index === focusedIndex ? 0 : -1}
+            onClick={() => {
+              item.onClick?.();
+              onClose();
+            }}
+            onMouseEnter={() => setFocusedIndex(index)}
+            onFocus={() => setFocusedIndex(index)}
+            className="flex w-full items-center px-3 py-1.5 text-left text-[13px] text-[var(--color-text-dim)] transition-colors hover:bg-[var(--color-hover)] hover:text-[var(--color-text)]"
           >
-            {item.indicator === "checked"
-              ? "✓"
-              : item.indicator === "mixed"
-                ? "−"
-                : ""}
-          </span>
-          <span>{item.label}</span>
-        </button>
-      ))}
+            <span
+              className="mr-2 flex h-4 w-4 shrink-0 items-center justify-center text-[10px] text-[var(--color-accent)]"
+              aria-hidden="true"
+            >
+              {item.indicator === "checked"
+                ? "✓"
+                : item.indicator === "mixed"
+                  ? "−"
+                  : ""}
+            </span>
+            <span>{item.label}</span>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/Library/SongListItem.tsx
+++ b/src/components/Library/SongListItem.tsx
@@ -274,7 +274,7 @@ export function SongListItem({ song, orderedHashes }: SongListItemProps) {
                 onClick={handleSeparate}
                 disabled={modelPreparing}
                 title={modelPreparing ? t("library.modelPreparing") : undefined}
-                className={`pointer-events-auto min-h-[24px] rounded border px-1.5 py-0.5 text-[10px] disabled:cursor-default disabled:opacity-50 ${
+                className={`pointer-events-auto min-h-[24px] min-w-[24px] rounded border px-1.5 py-0.5 text-[10px] disabled:cursor-default disabled:opacity-50 ${
                   isSelected
                     ? "border-[var(--sidebar-control-border)] bg-[var(--sidebar-control-bg)] text-[var(--color-text)] hover:bg-[var(--sidebar-row-overlay-bg)]"
                     : "border-[var(--sidebar-control-border)] bg-[var(--sidebar-control-bg)] text-[var(--color-text-dim)] hover:bg-[var(--sidebar-row-overlay-bg)]"
@@ -326,7 +326,7 @@ export function SongListItem({ song, orderedHashes }: SongListItemProps) {
               <button
                 type="button"
                 onClick={handleSeparate}
-                className="pointer-events-auto min-h-[24px] text-[10px] text-[var(--color-destructive)]"
+                className="pointer-events-auto min-h-[24px] min-w-[24px] text-[10px] text-[var(--color-destructive)]"
               >
                 {t("common.retry")}
               </button>

--- a/src/components/Library/SongPropertiesDialog.tsx
+++ b/src/components/Library/SongPropertiesDialog.tsx
@@ -239,18 +239,20 @@ export function SongPropertiesDialog({
                     {t("songProperties.instrumental")}
                   </span>
                   <label className="flex items-center gap-2 text-[12px] text-[var(--color-text)]">
-                    <input
-                      type="checkbox"
-                      checked={currentSong.instrumental}
-                      onChange={(event) =>
-                        void setSongsInstrumental(
-                          [currentSong.hash],
-                          event.target.checked,
-                        )
-                      }
-                      aria-label={t("songProperties.instrumental")}
-                      className="h-4 w-4 rounded border-[var(--color-border-light)] bg-[var(--color-surface)] accent-[var(--color-accent)]"
-                    />
+                    <span className="flex min-h-[24px] min-w-[24px] items-center justify-center">
+                      <input
+                        type="checkbox"
+                        checked={currentSong.instrumental}
+                        onChange={(event) =>
+                          void setSongsInstrumental(
+                            [currentSong.hash],
+                            event.target.checked,
+                          )
+                        }
+                        aria-label={t("songProperties.instrumental")}
+                        className="h-4 w-4 rounded border-[var(--color-border-light)] bg-[var(--color-surface)] accent-[var(--color-accent)]"
+                      />
+                    </span>
                   </label>
                 </div>
               )}

--- a/src/components/Player/MonitorPicker.test.tsx
+++ b/src/components/Player/MonitorPicker.test.tsx
@@ -451,4 +451,34 @@ describe("MonitorPicker", () => {
     anchor.remove();
     container.remove();
   });
+
+  test("document-level Escape closes the picker and returns focus to the anchor", async () => {
+    mockGetMonitors.mockResolvedValue([buildMonitor("Display A", 0)]);
+    const onClose = vi.fn();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const anchor = document.createElement("button");
+    document.body.appendChild(anchor);
+
+    await act(async () => {
+      root.render(
+        <MonitorPicker onClose={onClose} anchorRef={{ current: anchor }} />,
+      );
+    });
+    await flushEffects();
+
+    await act(async () => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+
+    expect(onClose).toHaveBeenCalled();
+    expect(document.activeElement).toBe(anchor);
+
+    await act(async () => root.unmount());
+    anchor.remove();
+    container.remove();
+  });
 });

--- a/src/components/Player/MonitorPicker.test.tsx
+++ b/src/components/Player/MonitorPicker.test.tsx
@@ -185,4 +185,270 @@ describe("MonitorPicker", () => {
     anchor.remove();
     container.remove();
   });
+
+  test("renders role=listbox and role=option with aria-selected", async () => {
+    mockGetMonitors.mockResolvedValue([
+      buildMonitor("Display A", 0),
+      buildMonitor("Display B", 1),
+    ]);
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const anchor = document.createElement("button");
+    document.body.appendChild(anchor);
+
+    await act(async () => {
+      root.render(
+        <MonitorPicker onClose={() => {}} anchorRef={{ current: anchor }} />,
+      );
+    });
+    await flushEffects();
+
+    const listbox = document.querySelector('[role="listbox"]');
+    expect(listbox).not.toBeNull();
+
+    const options = document.querySelectorAll('[role="option"]');
+    expect(options).toHaveLength(2);
+    expect(options[0].getAttribute("aria-selected")).toBe("true");
+    expect(options[1].getAttribute("aria-selected")).toBe("false");
+
+    await act(async () => root.unmount());
+    anchor.remove();
+    container.remove();
+  });
+
+  test("ArrowDown moves focus to the next monitor option", async () => {
+    mockGetMonitors.mockResolvedValue([
+      buildMonitor("Display A", 0),
+      buildMonitor("Display B", 1),
+      buildMonitor("Display C", 2),
+    ]);
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const anchor = document.createElement("button");
+    document.body.appendChild(anchor);
+
+    await act(async () => {
+      root.render(
+        <MonitorPicker onClose={() => {}} anchorRef={{ current: anchor }} />,
+      );
+    });
+    await flushEffects();
+
+    const listbox = document.querySelector('[role="listbox"]') as HTMLElement;
+    const options = document.querySelectorAll('[role="option"]');
+
+    expect(document.activeElement).toBe(options[0]);
+
+    await act(async () => {
+      listbox.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+      );
+    });
+    expect(document.activeElement).toBe(options[1]);
+
+    await act(async () => {
+      listbox.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+      );
+    });
+    expect(document.activeElement).toBe(options[2]);
+
+    await act(async () => {
+      listbox.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+      );
+    });
+    expect(document.activeElement).toBe(options[0]);
+
+    await act(async () => root.unmount());
+    anchor.remove();
+    container.remove();
+  });
+
+  test("ArrowUp moves focus to the previous monitor option", async () => {
+    mockGetMonitors.mockResolvedValue([
+      buildMonitor("Display A", 0),
+      buildMonitor("Display B", 1),
+    ]);
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const anchor = document.createElement("button");
+    document.body.appendChild(anchor);
+
+    await act(async () => {
+      root.render(
+        <MonitorPicker onClose={() => {}} anchorRef={{ current: anchor }} />,
+      );
+    });
+    await flushEffects();
+
+    const listbox = document.querySelector('[role="listbox"]') as HTMLElement;
+    const options = document.querySelectorAll('[role="option"]');
+
+    await act(async () => {
+      listbox.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }),
+      );
+    });
+    expect(document.activeElement).toBe(options[1]);
+
+    await act(async () => root.unmount());
+    anchor.remove();
+    container.remove();
+  });
+
+  test("Home and End move focus to first and last option", async () => {
+    mockGetMonitors.mockResolvedValue([
+      buildMonitor("Display A", 0),
+      buildMonitor("Display B", 1),
+      buildMonitor("Display C", 2),
+    ]);
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const anchor = document.createElement("button");
+    document.body.appendChild(anchor);
+
+    await act(async () => {
+      root.render(
+        <MonitorPicker onClose={() => {}} anchorRef={{ current: anchor }} />,
+      );
+    });
+    await flushEffects();
+
+    const listbox = document.querySelector('[role="listbox"]') as HTMLElement;
+    const options = document.querySelectorAll('[role="option"]');
+
+    await act(async () => {
+      listbox.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "End", bubbles: true }),
+      );
+    });
+    expect(document.activeElement).toBe(options[2]);
+
+    await act(async () => {
+      listbox.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Home", bubbles: true }),
+      );
+    });
+    expect(document.activeElement).toBe(options[0]);
+
+    await act(async () => root.unmount());
+    anchor.remove();
+    container.remove();
+  });
+
+  test("Escape closes the picker and returns focus to the anchor", async () => {
+    mockGetMonitors.mockResolvedValue([buildMonitor("Display A", 0)]);
+    const onClose = vi.fn();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const anchor = document.createElement("button");
+    document.body.appendChild(anchor);
+
+    await act(async () => {
+      root.render(
+        <MonitorPicker onClose={onClose} anchorRef={{ current: anchor }} />,
+      );
+    });
+    await flushEffects();
+
+    const listbox = document.querySelector('[role="listbox"]') as HTMLElement;
+
+    await act(async () => {
+      listbox.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+
+    expect(onClose).toHaveBeenCalled();
+    expect(document.activeElement).toBe(anchor);
+
+    await act(async () => root.unmount());
+    anchor.remove();
+    container.remove();
+  });
+
+  test("Enter selects the focused monitor and closes the picker", async () => {
+    mockGetMonitors.mockResolvedValue([
+      buildMonitor("Display A", 0),
+      buildMonitor("Display B", 1),
+    ]);
+    const onClose = vi.fn();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const anchor = document.createElement("button");
+    document.body.appendChild(anchor);
+
+    await act(async () => {
+      root.render(
+        <MonitorPicker onClose={onClose} anchorRef={{ current: anchor }} />,
+      );
+    });
+    await flushEffects();
+
+    const listbox = document.querySelector('[role="listbox"]') as HTMLElement;
+
+    await act(async () => {
+      listbox.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+      );
+    });
+    await act(async () => {
+      listbox.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      );
+    });
+    await flushEffects();
+
+    expect(mockOpenFullscreenPlayer).toHaveBeenCalledWith(1);
+    expect(onClose).toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+    anchor.remove();
+    container.remove();
+  });
+
+  test("mouse enter on an option sets focus index", async () => {
+    mockGetMonitors.mockResolvedValue([
+      buildMonitor("Display A", 0),
+      buildMonitor("Display B", 1),
+    ]);
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const anchor = document.createElement("button");
+    document.body.appendChild(anchor);
+
+    await act(async () => {
+      root.render(
+        <MonitorPicker onClose={() => {}} anchorRef={{ current: anchor }} />,
+      );
+    });
+    await flushEffects();
+
+    const options = document.querySelectorAll('[role="option"]');
+    const secondOption = options[1] as HTMLElement;
+
+    await act(async () => {
+      secondOption.dispatchEvent(
+        new MouseEvent("mouseover", {
+          bubbles: true,
+          relatedTarget: document.body,
+        }),
+      );
+    });
+
+    expect(secondOption.tabIndex).toBe(0);
+    expect(secondOption.getAttribute("aria-selected")).toBe("true");
+
+    await act(async () => root.unmount());
+    anchor.remove();
+    container.remove();
+  });
 });

--- a/src/components/Player/MonitorPicker.tsx
+++ b/src/components/Player/MonitorPicker.tsx
@@ -65,7 +65,10 @@ export function MonitorPicker({ onClose, anchorRef }: MonitorPickerProps) {
   const { t } = useTranslation();
   const [monitors, setMonitors] = useState<MonitorInfo[]>([]);
   const [position, setPosition] = useState<MonitorPickerPosition | null>(null);
+  const [focusedIndex, setFocusedIndex] = useState(0);
   const menuRef = useRef<HTMLDivElement>(null);
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const didInitialFocus = useRef(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -88,6 +91,19 @@ export function MonitorPicker({ onClose, anchorRef }: MonitorPickerProps) {
   }, []);
 
   useEffect(() => {
+    const anchor = anchorRef.current;
+    if (anchor) {
+      anchor.setAttribute("aria-haspopup", "listbox");
+      anchor.setAttribute("aria-expanded", "true");
+    }
+    return () => {
+      if (anchor) {
+        anchor.setAttribute("aria-expanded", "false");
+      }
+    };
+  }, [anchorRef]);
+
+  useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (
         menuRef.current &&
@@ -100,6 +116,7 @@ export function MonitorPicker({ onClose, anchorRef }: MonitorPickerProps) {
     };
     const handleEscape = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
+        anchorRef.current?.focus();
         onClose();
       }
     };
@@ -112,6 +129,18 @@ export function MonitorPicker({ onClose, anchorRef }: MonitorPickerProps) {
       document.removeEventListener("keydown", handleEscape);
     };
   }, [anchorRef, onClose]);
+
+  useEffect(() => {
+    if (monitors.length > 0 && !didInitialFocus.current) {
+      didInitialFocus.current = true;
+      setFocusedIndex(0);
+      optionRefs.current[0]?.focus();
+    }
+  }, [monitors]);
+
+  useEffect(() => {
+    optionRefs.current[focusedIndex]?.focus();
+  }, [focusedIndex]);
 
   useLayoutEffect(() => {
     const updatePosition = () => {
@@ -170,6 +199,41 @@ export function MonitorPicker({ onClose, anchorRef }: MonitorPickerProps) {
     onClose();
   };
 
+  const handleListboxKeyDown = (e: React.KeyboardEvent) => {
+    if (monitors.length === 0) return;
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setFocusedIndex((prev) => (prev + 1) % monitors.length);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setFocusedIndex(
+          (prev) => (prev - 1 + monitors.length) % monitors.length,
+        );
+        break;
+      case "Home":
+        e.preventDefault();
+        setFocusedIndex(0);
+        break;
+      case "End":
+        e.preventDefault();
+        setFocusedIndex(monitors.length - 1);
+        break;
+      case "Enter":
+      case " ":
+        e.preventDefault();
+        void handleMonitorSelect(focusedIndex);
+        break;
+      case "Escape":
+        e.preventDefault();
+        e.stopPropagation();
+        anchorRef.current?.focus();
+        onClose();
+        break;
+    }
+  };
+
   return createPortal(
     <div
       ref={menuRef}
@@ -191,27 +255,42 @@ export function MonitorPicker({ onClose, anchorRef }: MonitorPickerProps) {
           {t("player.noDisplaysFound")}
         </div>
       ) : null}
-      {monitors.map((monitor, index) => (
-        <button
-          key={`${monitor.name}-${monitor.width}-${monitor.height}-${index}`}
-          type="button"
-          onClick={() => {
-            void handleMonitorSelect(index);
-          }}
-          className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12px] text-[var(--color-text)] transition-colors hover:bg-[var(--color-hover)] hover:text-[var(--color-text)]"
-        >
-          <Monitor size={14} className="text-[var(--color-text-dim)]" />
-          <div className="min-w-0 flex-1">
-            <div className="truncate">{monitor.name}</div>
-            <div className="text-[10px] text-[var(--color-text-dimmer)]">
-              {t("player.monitor", { index: index + 1 })}
+      <div
+        role="listbox"
+        aria-label={t("player.localDisplayOutput")}
+        tabIndex={-1}
+        onKeyDown={handleListboxKeyDown}
+      >
+        {monitors.map((monitor, index) => (
+          <button
+            key={`${monitor.name}-${monitor.width}-${monitor.height}-${index}`}
+            ref={(el) => {
+              optionRefs.current[index] = el;
+            }}
+            type="button"
+            role="option"
+            aria-selected={index === focusedIndex}
+            tabIndex={index === focusedIndex ? 0 : -1}
+            onClick={() => {
+              void handleMonitorSelect(index);
+            }}
+            onMouseEnter={() => setFocusedIndex(index)}
+            onFocus={() => setFocusedIndex(index)}
+            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12px] text-[var(--color-text)] transition-colors hover:bg-[var(--color-hover)] hover:text-[var(--color-text)]"
+          >
+            <Monitor size={14} className="text-[var(--color-text-dim)]" />
+            <div className="min-w-0 flex-1">
+              <div className="truncate">{monitor.name}</div>
+              <div className="text-[10px] text-[var(--color-text-dimmer)]">
+                {t("player.monitor", { index: index + 1 })}
+              </div>
             </div>
-          </div>
-          <span className="ml-auto text-[10px] text-[var(--color-text-dimmer)]">
-            {monitor.width}x{monitor.height}
-          </span>
-        </button>
-      ))}
+            <span className="ml-auto text-[10px] text-[var(--color-text-dimmer)]">
+              {monitor.width}x{monitor.height}
+            </span>
+          </button>
+        ))}
+      </div>
     </div>,
     document.body,
   );

--- a/src/components/Player/QueueButton.tsx
+++ b/src/components/Player/QueueButton.tsx
@@ -26,7 +26,10 @@ export function QueueButton() {
       >
         <ListMusic size={18} />
         {queue.length > 0 && (
-          <span className="absolute -right-1.5 -top-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-[var(--color-accent)] text-[8px] font-bold text-[var(--color-on-accent)]">
+          <span
+            aria-hidden="true"
+            className="absolute -right-1.5 -top-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-[var(--color-accent)] text-[8px] font-bold text-[var(--color-on-accent)]"
+          >
             {queue.length > 9 ? "9+" : queue.length}
           </span>
         )}

--- a/src/components/Player/QueuePanel.tsx
+++ b/src/components/Player/QueuePanel.tsx
@@ -204,7 +204,7 @@ function SortableQueueItem({
                 type="button"
                 onClick={onMoveUp}
                 disabled={index === 0}
-                className="motion-icon-button rounded text-[var(--color-text-dimmer)] hover:text-[var(--color-control-primary)] disabled:opacity-20"
+                className="motion-icon-button flex min-h-[24px] min-w-[24px] items-center justify-center rounded text-[var(--color-text-dimmer)] hover:text-[var(--color-control-primary)] disabled:opacity-20"
                 aria-label={moveUpLabel}
               >
                 <ChevronUp size={10} />
@@ -215,7 +215,7 @@ function SortableQueueItem({
                 type="button"
                 onClick={onMoveDown}
                 disabled={index === queueLength - 1}
-                className="motion-icon-button rounded text-[var(--color-text-dimmer)] hover:text-[var(--color-control-primary)] disabled:opacity-20"
+                className="motion-icon-button flex min-h-[24px] min-w-[24px] items-center justify-center rounded text-[var(--color-text-dimmer)] hover:text-[var(--color-control-primary)] disabled:opacity-20"
                 aria-label={moveDownLabel}
               >
                 <ChevronDown size={10} />
@@ -252,12 +252,14 @@ function DragOverlayQueueItem({
       isOverlay
       className="w-[272px]"
       handle={
-        <div
+        <button
+          type="button"
+          tabIndex={-1}
           className="-m-1 shrink-0 rounded-md bg-[var(--color-ghost-hover)] p-1 text-[var(--color-control-primary)] shadow-[0_8px_18px_rgba(0,0,0,0.2)]"
           aria-label={dragLabel}
         >
           <GripVertical size={12} />
-        </div>
+        </button>
       }
     />
   );

--- a/src/components/Player/RemoteReconnectIndicator.tsx
+++ b/src/components/Player/RemoteReconnectIndicator.tsx
@@ -42,6 +42,8 @@ export function RemoteReconnectIndicator() {
   if (reconnectState === "reconnecting") {
     return (
       <span
+        role="status"
+        aria-live="polite"
         data-testid="remote-reconnect-indicator"
         data-reconnect-state="reconnecting"
         className="flex items-center gap-1.5 rounded-md bg-[var(--color-accent)]/10 px-2 py-0.5 text-[11px] text-[var(--color-accent)]"
@@ -60,6 +62,8 @@ export function RemoteReconnectIndicator() {
   if (reconnectState === "resync") {
     return (
       <span
+        role="status"
+        aria-live="polite"
         data-testid="remote-reconnect-indicator"
         data-reconnect-state="resync"
         className="flex items-center gap-1.5 rounded-md bg-[var(--color-ghost-hover)] px-2 py-0.5 text-[11px] text-[var(--color-text-dim)]"
@@ -75,6 +79,8 @@ export function RemoteReconnectIndicator() {
   // failed
   return (
     <span
+      role="alert"
+      aria-live="assertive"
       data-testid="remote-reconnect-indicator"
       data-reconnect-state="failed"
       className="flex items-center gap-1.5 rounded-md bg-[var(--color-destructive)]/10 px-2 py-0.5 text-[11px] text-[var(--color-destructive)]"

--- a/src/components/Player/RotationControls.tsx
+++ b/src/components/Player/RotationControls.tsx
@@ -33,7 +33,7 @@ function AddSingerInput({ onAdd }: AddSingerInputProps) {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="flex items-center gap-1 rounded border border-dashed border-[var(--color-border)] px-2 py-0.5 text-[11px] text-[var(--color-text-dim)] transition-colors hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
+        className="flex min-h-[24px] items-center gap-1 rounded border border-dashed border-[var(--color-border)] px-2 py-0.5 text-[11px] text-[var(--color-text-dim)] transition-colors hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
       >
         + Add Singer
       </button>

--- a/src/components/Player/VolumeSliders.test.tsx
+++ b/src/components/Player/VolumeSliders.test.tsx
@@ -188,7 +188,7 @@ describe("VolumeSliders", () => {
     mockPlayerState.snapshot.stem_mode = "four_stem";
     const markup = renderToStaticMarkup(<VolumeSliders />);
 
-    expect(markup).toContain("h-4 w-4");
+    expect(markup).toContain("h-6 w-6");
     expect(markup).toContain("rounded-full");
     expect(markup).toContain('data-playback-action="stem-mixer"');
   });

--- a/src/components/Player/VolumeSliders.tsx
+++ b/src/components/Player/VolumeSliders.tsx
@@ -543,7 +543,7 @@ export function VolumeSliders({
               aria-pressed={isExpanded}
               data-playback-action="stem-mixer"
               data-active={isExpanded ? "true" : undefined}
-              className="motion-icon-button flex h-4 w-4 items-center justify-center rounded-full text-[var(--color-text-dimmer)] hover:bg-[var(--color-ghost-hover)] hover:text-[var(--color-control-primary)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]"
+              className="motion-icon-button flex h-6 w-6 items-center justify-center rounded-full text-[var(--color-text-dimmer)] hover:bg-[var(--color-ghost-hover)] hover:text-[var(--color-control-primary)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]"
             >
               <ChevronDown
                 size={12}


### PR DESCRIPTION
## Summary

Audit the codebase against the six standards profiles introduced in #295 and apply fixes for the violations found. Six parallel audit subagents scanned the codebase (one per profile), then six parallel fix subagents applied non-overlapping changes.

### Interaction and accessibility (WCAG 2.2 AA, WAI-ARIA APG)
- **ContextMenu**: `role=menu`, `role=menuitem`/`menuitemcheckbox`, arrow/Home/End/Enter/Space navigation, type-ahead, submenu ARIA, focus return to trigger.
- **MonitorPicker**: `role=listbox`, `role=option`, `aria-selected`, arrow navigation, focus return to anchor.
- **QueuePanel**: drag handle changed from `<div>` to `<button>`; 24×24 target size on move buttons.
- **SongListItem, SongPropertiesDialog, RotationControls, VolumeSliders, QueueButton**: interactive target sizes increased to 24×24 CSS px minimum (visual icon sizes unchanged; only hit areas enlarged).
- **RemoteReconnectIndicator, UpdateBanner**: `aria-live` regions for status and progress announcements.

### Security, privacy, and release
- **SECURITY.md**: private reporting channel (GitHub vulnerability reporting), CVSS severity classification, response SLA, 90-day coordinated disclosure.
- **.github/dependency-review.yml**: license allowlist and severity threshold for NIST SSDF dependency policy.

### Lifecycle, quality, and testing
- **ADR 0015**: lyrics multi-source fallback chain (local-first: cache → embedded → sidecar → LRCLIB → LrcApi).
- **ADR 0016**: local source separation via ONNX Runtime (privacy, offline, no per-use cost).
- **Issue template**: added user-outcome and acceptance-criteria fields.
- **PR template**: added acceptance-criteria section.

### Interfaces and compatibility
- Documented ~30 undocumented IPC commands and 8 events across `library.md`, `separation.md`, `lyrics.md`, `settings.md`, `model-bootstrap.md`, `playback.md`.

### Models, media, and operations
- Added `evaluation_fixture`, `capability_limit`, and `known_user_effect` fields to the model catalog schema (`catalog.rs`).
- Populated all 7 shipped models in `release-manifest.json` with real values derived from the separation code (44.1 kHz, stereo, 7.8s segments, spectral contract fixture reference).
- Updated `stable-pointer.json` checksum to match the modified manifest.

### Tests
- Added `ContextMenu.keyboard.test.tsx` (23 tests) covering WAI-ARIA keyboard navigation, ARIA attributes, submenu open/close, type-ahead, and mouse handlers.
- Extended `MonitorPicker.test.tsx` (10 new tests) covering listbox keyboard navigation, ARIA attributes, and mouse focus management.

## User-visible changes

These fixes have user-visible impact (flagged per request):

1. **Larger click targets** — several small buttons in the library, player, and dialogs now have larger clickable areas (24×24 CSS px min) per WCAG 2.2 target size. Visual icon sizes unchanged.
2. **Screen reader announcements** — remote reconnect status and update download progress now announce via `aria-live`. No visual change.
3. **Keyboard navigation for custom menus** — ContextMenu and MonitorPicker now support full keyboard navigation (arrows, Home/End, Enter/Space, Escape). No visual change.
4. **Focusable drag handle** — QueuePanel drag handle is now a focusable button instead of a div.
5. **SECURITY.md** — visible in the repo root; provides a private vulnerability reporting channel.
6. **Issue/PR templates** — contributors see new user-outcome and acceptance-criteria fields.

## Not fixed (intentionally deferred)

- **Numeric field unit naming** (19 fields like `sample_rate` → `sample_rate_hz`): these are wire-format renames across Rust + TypeScript + IPC contracts that require a compatibility window per ADR 0003. Recommend a separate PR.
- **Test description quality**: some tests describe implementation details rather than behavior. Style improvement, not a violation.
- **SLSA/SPDX artifacts**: no claims are made, so no violation exists. Adding provenance generation is a release-workflow change.
- **Diagnostics user control**: a feature change, deferred.

#### Test plan
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm build` — success
- [x] `pnpm test` — 2141 tests passed (187 files + 2 new test files)
- [x] `cargo check` + `cargo test --lib` — 1073 Rust tests passed
- [x] `node scripts/check-standards.mjs` — standards route valid
- [x] `pnpm check:patch-coverage` — 97.5% patch coverage (target 80%)
- [x] `pnpm format` — clean
- [x] `cargo fmt --check` — clean
- [ ] CI browser accessibility gate (axe WCAG 2.2 A/AA)