### PR TITLE
docs(agents): add deliverables self-containment rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,10 @@ Formatting is automated via PostToolUse hook (`pnpm format:write` + `cargo fmt`)
 - Keep code, contracts, and docs aligned. If behavior changes, update the relevant `docs/references/contracts/*.md` in the same change.
 - Treat repo-tracked docs and configs as first-class code.
 
+## Deliverables
+
+- Write deliverables as self-contained final-state artifacts. Incorporate feedback directly without mentioning drafts, versions, review rounds, prior wording, superseded decisions, or the editing process unless the user explicitly requests a changelog, history, or decision record.
+
 ## Source of Truth
 
 **Read code, not docs.** The codebase is the authoritative reference for


### PR DESCRIPTION
## Summary
- Add a `## Deliverables` section to `AGENTS.md` requiring deliverables to be written as self-contained final-state artifacts.
- Feedback is incorporated directly, without surfacing drafts, versions, review rounds, prior wording, superseded decisions, or the editing process — unless the user explicitly requests a changelog, history, or decision record.
- Audited the repo against the new standard; no violations found (ADR `superseded` status, contract schema version identifiers, JSON Schema "draft" spec name, and GitHub "draft release" are all legitimate non-editing-process usages).

#### Test plan
- [x] pre-push hook: lint, format-check, cargo-fmt-check, vitest (2123 passed)
- [x] docs-only change; no IPC, contract, or product-surface impact