### PR TITLE
feat(lyrics): fullscreen alignment toggle and audience truncation fixes

### DIFF
--- a/src/components/Lyrics/LyricLine.tsx
+++ b/src/components/Lyrics/LyricLine.tsx
@@ -16,6 +16,7 @@ interface LyricLineProps {
   presentation?: "standard" | "audience";
   lyricsFontStep: number;
   romanizedText?: string;
+  alignment?: "center" | "left";
 }
 
 const STANDARD_SEEKABLE_HOVER_CLASS =
@@ -48,6 +49,14 @@ const STANDARD_SECONDARY_TEXT_SIZE_CLASSES = {
   [2]: "text-lg md:text-2xl xl:text-3xl",
 } as const;
 
+const LEFT_ROMAN_TEXT_SIZE_CLASSES = {
+  [-2]: "text-base font-medium tracking-tight md:text-lg",
+  [-1]: "text-lg font-medium tracking-tight md:text-xl",
+  [0]: "text-xl font-medium tracking-tight md:text-2xl",
+  [1]: "text-2xl font-medium tracking-tight md:text-3xl xl:text-4xl",
+  [2]: "text-3xl font-medium tracking-tight md:text-4xl xl:text-5xl",
+} as const;
+
 function getLyricsTextSizeClass(
   presentation: "standard" | "audience",
   lyricsFontStep: number,
@@ -72,6 +81,16 @@ function getLyricsSecondaryTextSizeClass(lyricsFontStep: number): string {
     | 1
     | 2;
   return STANDARD_SECONDARY_TEXT_SIZE_CLASSES[clampedStep];
+}
+
+function getLyricsRomanTextSizeClass(lyricsFontStep: number): string {
+  const clampedStep = Math.max(-2, Math.min(2, lyricsFontStep)) as
+    | -2
+    | -1
+    | 0
+    | 1
+    | 2;
+  return LEFT_ROMAN_TEXT_SIZE_CLASSES[clampedStep];
 }
 
 function shouldEmphasize(word: {
@@ -106,7 +125,8 @@ function areLyricLinePropsEqual(
     previous.state !== next.state ||
     previous.presentation !== next.presentation ||
     previous.lyricsFontStep !== next.lyricsFontStep ||
-    previous.romanizedText !== next.romanizedText
+    previous.romanizedText !== next.romanizedText ||
+    previous.alignment !== next.alignment
   ) {
     return false;
   }
@@ -126,12 +146,15 @@ export const LyricLine = memo(function LyricLine({
   presentation = "standard",
   lyricsFontStep,
   romanizedText,
+  alignment = "center",
 }: LyricLineProps) {
   const seek = usePlayerStore((s) => s.seek);
   const isSeekable = state !== "plain";
+  const isLeftAligned = alignment === "left";
   const textSizeClass = getLyricsTextSizeClass(presentation, lyricsFontStep);
   const secondaryTextSizeClass =
     getLyricsSecondaryTextSizeClass(lyricsFontStep);
+  const romanTextSizeClass = getLyricsRomanTextSizeClass(lyricsFontStep);
   const audiencePresentationSpec =
     buildAudiencePresentationSpec(lyricsFontStep);
 
@@ -195,13 +218,21 @@ export const LyricLine = memo(function LyricLine({
     [lineIndex],
   );
 
-  const lineClassName = `flex flex-col items-center gap-1.5 text-center ${
-    isSeekable ? "cursor-pointer group/line" : ""
-  }`;
+  const lineClassName = isLeftAligned
+    ? `grid w-full ${
+        presentation === "audience"
+          ? "grid-cols-[minmax(0,1fr)_auto]"
+          : "grid-cols-[minmax(0,1fr)_220px]"
+      } items-baseline gap-x-8 gap-y-1.5 text-left ${
+        isSeekable ? "cursor-pointer group/line" : ""
+      }`
+    : `flex flex-col items-center gap-1.5 text-center ${
+        isSeekable ? "cursor-pointer group/line" : ""
+      }`;
   const lineStyle = {
     fontFamily:
       '-apple-system, BlinkMacSystemFont, "Helvetica Neue", "Noto Sans SC", "Noto Sans JP", "Noto Sans KR", system-ui, sans-serif',
-    ...(presentation === "audience"
+    ...(presentation === "audience" && !isLeftAligned
       ? {
           transform:
             state === "active"
@@ -210,226 +241,272 @@ export const LyricLine = memo(function LyricLine({
         }
       : undefined),
   };
-  const lineContent = (
-    <>
-      {hasWords ? (
-        <span
-          className={(presentation === "audience"
-            ? `tracking-tight ${hoverClass}`
-            : `${textSizeClass} ${hoverClass}`
-          ).trim()}
-          style={{
-            fontWeight: state === "active" ? 500 : 400,
-            ...(presentation === "audience"
-              ? {
-                  fontSize: audiencePresentationSpec.fontSizePx,
-                  lineHeight: audiencePresentationSpec.lineHeightMultiple,
-                }
-              : undefined),
-          }}
-        >
-          {line.words!.map((word, idx) => {
-            const wordState =
-              state === "plain"
-                ? "active"
-                : state === "active"
-                  ? idx < activeWordIndex
-                    ? "past"
-                    : idx === activeWordIndex
-                      ? "active"
-                      : "future"
-                  : state === "past"
-                    ? "past"
-                    : "future";
 
-            const isActiveWord = wordState === "active";
-
-            if (
-              shouldEmphasize(word) &&
-              isActiveWord &&
-              presentation !== "audience"
-            ) {
-              const wordDuration = word.end_ms - word.time_ms;
-              const last = isLastWord(idx, line.words!.length);
-              return (
-                <span
-                  key={idx}
-                  ref={(el) => {
-                    if (el) wordElsRef.current[idx] = el;
-                  }}
-                  className="motion-surface relative inline-block text-[var(--color-lyrics-active)]"
-                  style={{
-                    textShadow: "var(--shadow-lyrics-glow)",
-                    animation: last
-                      ? `lyric-char-glow-last ${wordDuration * 1.2}ms ease-in-out`
-                      : `lyric-char-glow ${wordDuration}ms ease-in-out`,
-                  }}
-                >
-                  {word.text}
-                  {idx < line.words!.length - 1 ? " " : ""}
-                </span>
-              );
+  const mainText = hasWords ? (
+    <span
+      className={(presentation === "audience"
+        ? `tracking-tight min-w-0 break-words ${hoverClass}`
+        : `${textSizeClass} min-w-0 break-words ${hoverClass}`
+      ).trim()}
+      style={{
+        fontWeight: state === "active" ? 500 : 400,
+        ...(presentation === "audience"
+          ? {
+              fontSize: audiencePresentationSpec.fontSizePx,
+              lineHeight: audiencePresentationSpec.lineHeightMultiple,
             }
+          : undefined),
+      }}
+    >
+      {line.words!.map((word, idx) => {
+        const wordState =
+          state === "plain"
+            ? "active"
+            : state === "active"
+              ? idx < activeWordIndex
+                ? "past"
+                : idx === activeWordIndex
+                  ? "active"
+                  : "future"
+              : state === "past"
+                ? "past"
+                : "future";
 
-            return (
-              <span
-                key={idx}
-                ref={(el) => {
-                  if (el) wordElsRef.current[idx] = el;
-                }}
-                className={
-                  presentation === "audience"
-                    ? "motion-surface"
-                    : `motion-surface relative inline-block ${
-                        wordState === "active"
-                          ? "text-[var(--color-lyrics-active)]"
-                          : wordState === "past"
-                            ? "text-[var(--color-lyrics-past)]"
-                            : "text-[var(--color-lyrics-future)]"
-                      }`
-                }
-                style={{
-                  ...(presentation === "audience"
-                    ? {
-                        color: colorToCss(
-                          wordState === "active"
-                            ? audiencePresentationSpec.activeTextColor
-                            : wordState === "past"
-                              ? audiencePresentationSpec.pastTextColor
-                              : audiencePresentationSpec.futureTextColor,
-                        ),
-                        textShadow:
-                          wordState === "active"
-                            ? `0 0 ${audiencePresentationSpec.activeGlowBlurPx}px ${colorToCss(
-                                audiencePresentationSpec.activeGlowColor,
-                              )}`
-                            : undefined,
-                      }
-                    : isActiveWord
-                      ? {
-                          textShadow: isLastWord(idx, line.words!.length)
-                            ? "var(--shadow-lyrics-glow-strong)"
-                            : "var(--shadow-lyrics-glow)",
-                        }
-                      : undefined),
-                }}
-              >
-                {word.text}
-                {idx < line.words!.length - 1 ? " " : ""}
-              </span>
-            );
-          })}
-        </span>
-      ) : hasOnlyBackgroundWords ? null : (
-        <span
-          className={(presentation === "audience"
-            ? `motion-surface font-bold tracking-tight ${hoverClass}`
-            : `motion-surface ${textSizeClass} ${
-                state === "plain" || state === "active"
-                  ? "text-[var(--color-lyrics-active)]"
-                  : state === "past"
-                    ? "text-[var(--color-lyrics-past)]"
-                    : "text-[var(--color-lyrics-future)]"
-              } ${hoverClass}`
-          ).trim()}
-          style={
-            presentation === "audience"
-              ? {
-                  fontSize: audiencePresentationSpec.fontSizePx,
-                  lineHeight: audiencePresentationSpec.lineHeightMultiple,
-                  color: colorToCss(
-                    state === "plain" || state === "active"
-                      ? audiencePresentationSpec.activeTextColor
-                      : state === "past"
-                        ? audiencePresentationSpec.pastTextColor
-                        : audiencePresentationSpec.futureTextColor,
-                  ),
-                  textShadow:
-                    state === "active"
-                      ? `0 0 ${audiencePresentationSpec.activeGlowBlurPx}px ${colorToCss(
-                          audiencePresentationSpec.activeGlowColor,
-                        )}`
-                      : undefined,
-                }
-              : undefined
-          }
-        >
-          {line.text}
-        </span>
-      )}
-      {line.bg_words && line.bg_words.length > 0 ? (
-        <span
-          className={
-            presentation === "audience"
-              ? "motion-surface font-medium tracking-tight"
-              : `motion-surface ${secondaryTextSizeClass} font-medium ${
-                  state === "plain" || state === "active"
-                    ? "text-[var(--color-text-dim)]"
-                    : state === "past"
-                      ? "text-[var(--color-text-dimmer)]"
-                      : "text-[var(--color-text-dim)]"
-                }`
-          }
-          style={{
-            ...(presentation === "audience"
-              ? {
-                  fontSize: audiencePresentationSpec.fontSizePx * 0.55,
-                  lineHeight: audiencePresentationSpec.lineHeightMultiple,
-                  color: colorToCss(
-                    state === "plain" || state === "active"
-                      ? audiencePresentationSpec.activeTextColor
-                      : state === "past"
-                        ? audiencePresentationSpec.pastTextColor
-                        : audiencePresentationSpec.futureTextColor,
-                  ),
-                }
-              : undefined),
-            transition: "opacity 0.3s ease, transform 0.3s ease",
-            opacity: state === "active" ? 0.4 : 0,
-            transform: state === "active" ? "translateY(0)" : "translateY(8px)",
-          }}
-        >
-          {line.bg_words.map((word, idx) => (
-            <span key={idx}>
+        const isActiveWord = wordState === "active";
+
+        if (
+          shouldEmphasize(word) &&
+          isActiveWord &&
+          presentation !== "audience"
+        ) {
+          const wordDuration = word.end_ms - word.time_ms;
+          const last = isLastWord(idx, line.words!.length);
+          return (
+            <span
+              key={idx}
+              ref={(el) => {
+                if (el) wordElsRef.current[idx] = el;
+              }}
+              className="motion-surface relative inline-block text-[var(--color-lyrics-active)]"
+              style={{
+                textShadow: "var(--shadow-lyrics-glow)",
+                animation: last
+                  ? `lyric-char-glow-last ${wordDuration * 1.2}ms ease-in-out`
+                  : `lyric-char-glow ${wordDuration}ms ease-in-out`,
+              }}
+            >
               {word.text}
-              {idx < line.bg_words!.length - 1 ? " " : ""}
+              {idx < line.words!.length - 1 ? " " : ""}
             </span>
-          ))}
-        </span>
-      ) : null}
-      {romanizedText ? (
-        <span
-          className={
-            presentation === "audience"
-              ? "motion-surface font-medium tracking-tight opacity-50"
-              : `motion-surface ${secondaryTextSizeClass} font-medium ${
+          );
+        }
+
+        return (
+          <span
+            key={idx}
+            ref={(el) => {
+              if (el) wordElsRef.current[idx] = el;
+            }}
+            className={
+              presentation === "audience"
+                ? "motion-surface"
+                : `motion-surface relative inline-block ${
+                    wordState === "active"
+                      ? "text-[var(--color-lyrics-active)]"
+                      : wordState === "past"
+                        ? "text-[var(--color-lyrics-past)]"
+                        : "text-[var(--color-lyrics-future)]"
+                  }`
+            }
+            style={{
+              ...(presentation === "audience"
+                ? {
+                    color: colorToCss(
+                      wordState === "active"
+                        ? audiencePresentationSpec.activeTextColor
+                        : wordState === "past"
+                          ? audiencePresentationSpec.pastTextColor
+                          : audiencePresentationSpec.futureTextColor,
+                    ),
+                    textShadow:
+                      wordState === "active"
+                        ? `0 0 ${audiencePresentationSpec.activeGlowBlurPx}px ${colorToCss(
+                            audiencePresentationSpec.activeGlowColor,
+                          )}`
+                        : undefined,
+                  }
+                : isActiveWord
+                  ? {
+                      textShadow: isLastWord(idx, line.words!.length)
+                        ? "var(--shadow-lyrics-glow-strong)"
+                        : "var(--shadow-lyrics-glow)",
+                    }
+                  : undefined),
+            }}
+          >
+            {word.text}
+            {idx < line.words!.length - 1 ? " " : ""}
+          </span>
+        );
+      })}
+    </span>
+  ) : hasOnlyBackgroundWords ? null : (
+    <span
+      className={(presentation === "audience"
+        ? `motion-surface font-bold tracking-tight min-w-0 break-words ${hoverClass}`
+        : `motion-surface ${textSizeClass} min-w-0 break-words ${
+            state === "plain" || state === "active"
+              ? "text-[var(--color-lyrics-active)]"
+              : state === "past"
+                ? "text-[var(--color-lyrics-past)]"
+                : "text-[var(--color-lyrics-future)]"
+          } ${hoverClass}`
+      ).trim()}
+      style={
+        presentation === "audience"
+          ? {
+              fontSize: audiencePresentationSpec.fontSizePx,
+              lineHeight: audiencePresentationSpec.lineHeightMultiple,
+              color: colorToCss(
+                state === "plain" || state === "active"
+                  ? audiencePresentationSpec.activeTextColor
+                  : state === "past"
+                    ? audiencePresentationSpec.pastTextColor
+                    : audiencePresentationSpec.futureTextColor,
+              ),
+              textShadow:
+                state === "active"
+                  ? `0 0 ${audiencePresentationSpec.activeGlowBlurPx}px ${colorToCss(
+                      audiencePresentationSpec.activeGlowColor,
+                    )}`
+                  : undefined,
+            }
+          : undefined
+      }
+    >
+      {line.text}
+    </span>
+  );
+
+  const bgWords =
+    line.bg_words && line.bg_words.length > 0 ? (
+      <span
+        className={
+          presentation === "audience"
+            ? "motion-surface font-medium tracking-tight min-w-0 break-words"
+            : `motion-surface ${secondaryTextSizeClass} font-medium min-w-0 break-words ${
+                state === "plain" || state === "active"
+                  ? "text-[var(--color-text-dim)]"
+                  : state === "past"
+                    ? "text-[var(--color-text-dimmer)]"
+                    : "text-[var(--color-text-dim)]"
+              }`
+        }
+        style={{
+          ...(presentation === "audience"
+            ? {
+                fontSize: audiencePresentationSpec.fontSizePx * 0.55,
+                lineHeight: audiencePresentationSpec.lineHeightMultiple,
+                color: colorToCss(
                   state === "plain" || state === "active"
-                    ? "text-[var(--color-text-dim)]"
+                    ? audiencePresentationSpec.activeTextColor
                     : state === "past"
-                      ? "text-[var(--color-text-dimmer)]"
-                      : "text-[var(--color-text-dim)]"
-                }`
-          }
-          style={
-            presentation === "audience"
-              ? {
-                  fontSize: audiencePresentationSpec.fontSizePx * 0.55,
-                  lineHeight: audiencePresentationSpec.lineHeightMultiple,
-                  color: colorToCss(
+                      ? audiencePresentationSpec.pastTextColor
+                      : audiencePresentationSpec.futureTextColor,
+                ),
+              }
+            : undefined),
+          transition: "opacity 0.3s ease, transform 0.3s ease",
+          opacity: state === "active" ? 0.4 : 0,
+          transform: state === "active" ? "translateY(0)" : "translateY(8px)",
+        }}
+      >
+        {line.bg_words.map((word, idx) => (
+          <span key={idx}>
+            {word.text}
+            {idx < line.bg_words!.length - 1 ? " " : ""}
+          </span>
+        ))}
+      </span>
+    ) : null;
+
+  const romanStateColor =
+    state === "plain" || state === "active"
+      ? audiencePresentationSpec.activeTextColor
+      : state === "past"
+        ? audiencePresentationSpec.pastTextColor
+        : audiencePresentationSpec.futureTextColor;
+
+  const romanText = romanizedText ? (
+    <span
+      className={
+        isLeftAligned
+          ? `motion-surface font-medium tracking-tight min-w-0 break-words ${hoverClass} ${
+              presentation === "standard"
+                ? `${romanTextSizeClass} ${
                     state === "plain" || state === "active"
-                      ? audiencePresentationSpec.activeTextColor
+                      ? "text-[var(--color-lyrics-active)]"
                       : state === "past"
-                        ? audiencePresentationSpec.pastTextColor
-                        : audiencePresentationSpec.futureTextColor,
-                  ),
-                  opacity: 0.45,
-                }
-              : undefined
-          }
-        >
-          {romanizedText}
-        </span>
-      ) : null}
+                        ? "text-[var(--color-lyrics-past)]"
+                        : "text-[var(--color-lyrics-future)]"
+                  }`
+                : ""
+            }`
+          : presentation === "audience"
+            ? "motion-surface font-medium tracking-tight opacity-50"
+            : `motion-surface ${secondaryTextSizeClass} font-medium ${
+                state === "plain" || state === "active"
+                  ? "text-[var(--color-text-dim)]"
+                  : state === "past"
+                    ? "text-[var(--color-text-dimmer)]"
+                    : "text-[var(--color-text-dim)]"
+              }`
+      }
+      style={
+        isLeftAligned
+          ? {
+              ...(presentation === "audience"
+                ? {
+                    fontSize: audiencePresentationSpec.fontSizePx * 0.7,
+                    lineHeight: audiencePresentationSpec.lineHeightMultiple,
+                    color: colorToCss(romanStateColor),
+                    textShadow:
+                      state === "active"
+                        ? `0 0 ${audiencePresentationSpec.activeGlowBlurPx}px ${colorToCss(
+                            audiencePresentationSpec.activeGlowColor,
+                          )}`
+                        : undefined,
+                    opacity: 0.85,
+                  }
+                : undefined),
+            }
+          : presentation === "audience"
+            ? {
+                fontSize: audiencePresentationSpec.fontSizePx * 0.55,
+                lineHeight: audiencePresentationSpec.lineHeightMultiple,
+                color: colorToCss(romanStateColor),
+                opacity: 0.45,
+              }
+            : undefined
+      }
+    >
+      {romanizedText}
+    </span>
+  ) : null;
+
+  const lineContent = isLeftAligned ? (
+    <>
+      <span className="flex min-w-0 flex-col break-words">
+        {mainText}
+        {bgWords}
+      </span>
+      {romanText}
+    </>
+  ) : (
+    <>
+      {mainText}
+      {bgWords}
+      {romanText}
     </>
   );
 

--- a/src/components/Lyrics/LyricLine.tsx
+++ b/src/components/Lyrics/LyricLine.tsx
@@ -494,18 +494,16 @@ export const LyricLine = memo(function LyricLine({
     </span>
   ) : null;
 
-  const lineContent = isLeftAligned ? (
+  const lineContent = (
     <>
-      <span className="flex min-w-0 flex-col break-words">
+      <span
+        className={`flex flex-col ${
+          isLeftAligned ? "min-w-0 break-words" : "items-center"
+        }`}
+      >
         {mainText}
         {bgWords}
       </span>
-      {romanText}
-    </>
-  ) : (
-    <>
-      {mainText}
-      {bgWords}
       {romanText}
     </>
   );

--- a/src/components/Lyrics/LyricLine.tsx
+++ b/src/components/Lyrics/LyricLine.tsx
@@ -438,7 +438,7 @@ export const LyricLine = memo(function LyricLine({
       <button
         type="button"
         onClick={handleClick}
-        className={`${lineClassName} appearance-none border-0 bg-transparent p-0 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]`}
+        className={`${lineClassName} w-full appearance-none border-0 bg-transparent p-0 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]`}
         style={lineStyle}
       >
         {lineContent}

--- a/src/components/Lyrics/LyricsEditDialog.tsx
+++ b/src/components/Lyrics/LyricsEditDialog.tsx
@@ -81,13 +81,13 @@ function LyricsEditDialogContent({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+    <div className="fixed inset-0 z-[60] flex items-start justify-center p-4 pt-12">
       <DialogBackdrop
         ariaLabel={t("common.close")}
         onDismiss={() => {
           if (!saving) onClose();
         }}
-        className="absolute inset-0 bg-black/60"
+        className="absolute inset-0 bg-black/30"
       />
       <div
         ref={dialogRef}
@@ -96,7 +96,7 @@ function LyricsEditDialogContent({
         aria-labelledby={headingId}
         aria-busy={saving}
         tabIndex={-1}
-        className="relative flex w-full max-w-lg flex-col gap-4 overflow-hidden rounded-xl border border-[var(--color-border-light)] bg-[var(--color-sidebar)] p-6 shadow-2xl"
+        className="relative flex w-full max-w-5xl max-h-[90vh] flex-col gap-4 overflow-hidden rounded-xl border border-[var(--color-border-light)] bg-[var(--color-sidebar)] p-6 shadow-2xl"
       >
         <h2
           id={headingId}
@@ -114,7 +114,7 @@ function LyricsEditDialogContent({
           value={text}
           onChange={(e) => setText(e.target.value)}
           placeholder={t("lyrics.pastePlaceholder")}
-          className="h-64 w-full resize-y rounded-md border border-[var(--color-border-light)] bg-[var(--color-hover)] px-3 py-2 text-[13px] text-[var(--color-text)] placeholder:text-[var(--color-text-dim)] transition-colors focus:border-[color-mix(in_srgb,var(--color-accent)_24%,var(--color-border-light))] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]/30"
+          className="h-[min(70vh,560px)] max-h-[calc(90vh-10rem)] min-h-32 w-full resize-y rounded-md border border-[var(--color-border-light)] bg-[var(--color-hover)] px-3 py-2 text-[13px] text-[var(--color-text)] placeholder:text-[var(--color-text-dim)] transition-colors focus:border-[color-mix(in_srgb,var(--color-accent)_24%,var(--color-border-light))] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]/30"
           spellCheck={false}
         />
 

--- a/src/components/Lyrics/LyricsPanel.test.tsx
+++ b/src/components/Lyrics/LyricsPanel.test.tsx
@@ -70,7 +70,9 @@ const {
     romanizedLines: [],
     isRomanizing: false,
     showRomanized: false,
+    lyricsAlignment: "left" as "center" | "left",
     toggleRomanized: vi.fn(),
+    toggleLyricsAlignment: vi.fn(),
     songId: "song-1",
     adjustOffset: vi.fn(),
   } as {
@@ -83,7 +85,9 @@ const {
     romanizedLines: string[];
     isRomanizing: boolean;
     showRomanized: boolean;
+    lyricsAlignment: "center" | "left";
     toggleRomanized: ReturnType<typeof vi.fn>;
+    toggleLyricsAlignment: ReturnType<typeof vi.fn>;
     songId: string;
     adjustOffset: ReturnType<typeof vi.fn>;
   },
@@ -385,7 +389,7 @@ describe("LyricsPanel contextual reveal", () => {
       <LyricsPanel presentation="audience" />,
     );
 
-    expect(markup).toContain("max-width:min(92vw, 1600px)");
+    expect(markup).toContain("max-width:100%");
     expect(markup).toContain("min-h-full");
     expect(markup).not.toContain("contextual-reveal absolute right-4 top-4");
     expect(markup).not.toContain("absolute inset-x-0 bottom-0");

--- a/src/components/Lyrics/LyricsPanel.test.tsx
+++ b/src/components/Lyrics/LyricsPanel.test.tsx
@@ -212,6 +212,7 @@ describe("LyricsPanel contextual reveal", () => {
     mockLyricsState.isRomanizing = false;
     mockLyricsState.showRomanized = false;
     mockLyricsState.toggleRomanized.mockReset();
+    mockLyricsState.toggleLyricsAlignment.mockReset();
     mockLyricsState.songId = "song-1";
     mockLyricsState.adjustOffset.mockReset();
     mockSettingsState.lyricsFontStep = 0;
@@ -626,5 +627,34 @@ describe("LyricsPanel contextual reveal", () => {
     await act(async () => {
       root.unmount();
     });
+  });
+
+  test("clicking the alignment button toggles lyrics alignment", () => {
+    mockLyricsState.lines = [
+      line({ time_ms: 0, text: "line one", words: null }),
+    ];
+    mockLyricsState.rawLrc = "[00:00.00]line one";
+
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    act(() => {
+      root.render(<LyricsPanel />);
+    });
+
+    const button = host.querySelector(
+      "[aria-label='Switch to centered lyrics']",
+    ) as HTMLButtonElement;
+    expect(button).toBeTruthy();
+    act(() => {
+      button.click();
+    });
+
+    expect(mockLyricsState.toggleLyricsAlignment).toHaveBeenCalled();
+
+    act(() => {
+      root.unmount();
+    });
+    host.remove();
   });
 });

--- a/src/components/Lyrics/LyricsPanel.tsx
+++ b/src/components/Lyrics/LyricsPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import {
+  AlignLeft,
   ChevronDown,
   ChevronUp,
   Edit2,
@@ -62,6 +63,8 @@ export function LyricsPanel({ presentation = "standard" }: LyricsPanelProps) {
   const lyricsFontStep = useSettingsStore((s) => s.lyricsFontStep);
   const [editOpen, setEditOpen] = useState(false);
   const [userScrollUnlocked, setUserScrollUnlocked] = useState(false);
+  const lyricsAlignment = useLyricsStore((s) => s.lyricsAlignment);
+  const toggleLyricsAlignment = useLyricsStore((s) => s.toggleLyricsAlignment);
   const utilityControlsPinned = offsetMs !== 0 || lyricsFontStep !== 0;
   const isAudience = presentation === "audience";
   const spaciousStageLayout = !isAudience;
@@ -258,6 +261,30 @@ export function LyricsPanel({ presentation = "standard" }: LyricsPanelProps) {
                 <Edit2 size={14} />
               </button>
             </Tooltip>
+            <Tooltip
+              label={
+                lyricsAlignment === "left"
+                  ? "Switch to centered lyrics"
+                  : "Switch to left-aligned lyrics"
+              }
+            >
+              <button
+                type="button"
+                onClick={toggleLyricsAlignment}
+                aria-label={
+                  lyricsAlignment === "left"
+                    ? "Switch to centered lyrics"
+                    : "Switch to left-aligned lyrics"
+                }
+                className={`motion-icon-button rounded-full border p-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]/50 ${
+                  lyricsAlignment === "left"
+                    ? "border-[color-mix(in_srgb,var(--color-accent)_40%,var(--color-border-light))] bg-[color-mix(in_srgb,var(--color-accent)_18%,var(--color-sidebar))] text-[var(--color-control-primary)]"
+                    : "border-[var(--color-border-light)] bg-[var(--color-sidebar)] text-[var(--color-text-dim)] hover:border-[color-mix(in_srgb,var(--color-accent)_28%,var(--color-border-light))] hover:bg-[var(--color-hover)] hover:text-[var(--color-control-primary)]"
+                }`}
+              >
+                <AlignLeft size={14} />
+              </button>
+            </Tooltip>
           </div>
           <LyricsEditDialog
             open={editOpen}
@@ -347,7 +374,10 @@ export function LyricsPanel({ presentation = "standard" }: LyricsPanelProps) {
           style={
             isAudience
               ? {
-                  maxWidth: `min(${audiencePresentationSpec.contentWidthRatio * 100}vw, ${audiencePresentationSpec.contentMaxWidthPx}px)`,
+                  maxWidth:
+                    lyricsAlignment === "left"
+                      ? "100%"
+                      : `min(${audiencePresentationSpec.contentWidthRatio * 100}vw, ${audiencePresentationSpec.contentMaxWidthPx}px)`,
                   gap: audiencePresentationSpec.lineGapPx,
                 }
               : undefined
@@ -392,6 +422,7 @@ export function LyricsPanel({ presentation = "standard" }: LyricsPanelProps) {
                   activeWordIndex={
                     absoluteIndex === activeLineIndex ? activeWordIndex : -1
                   }
+                  alignment={lyricsAlignment}
                 />
               </div>
             );
@@ -419,7 +450,10 @@ export function LyricsPanel({ presentation = "standard" }: LyricsPanelProps) {
               ref={measurementRef}
               className="mx-auto flex w-full flex-col items-center"
               style={{
-                maxWidth: `min(${audiencePresentationSpec.contentWidthRatio * 100}vw, ${audiencePresentationSpec.contentMaxWidthPx}px)`,
+                maxWidth:
+                  lyricsAlignment === "left"
+                    ? "100%"
+                    : `min(${audiencePresentationSpec.contentWidthRatio * 100}vw, ${audiencePresentationSpec.contentMaxWidthPx}px)`,
                 gap: audiencePresentationSpec.lineGapPx,
               }}
             >
@@ -438,6 +472,7 @@ export function LyricsPanel({ presentation = "standard" }: LyricsPanelProps) {
                     romanizedText={
                       showRomanized ? romanizedLines[idx] : undefined
                     }
+                    alignment={lyricsAlignment}
                   />
                 </div>
               ))}

--- a/src/components/Player/FullscreenControls.test.tsx
+++ b/src/components/Player/FullscreenControls.test.tsx
@@ -418,3 +418,65 @@ describe("FullscreenControls auto-hide", () => {
     expect(getFooter().getAttribute("data-idle")).toBe("true");
   });
 });
+
+describe("FullscreenControls alignment button", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    mockLyricsStore.showRomanized = false;
+    mockLyricsStore.isRomanizing = false;
+    mockLyricsStore.songId = "song-1";
+    mockLyricsStore.lines = [{ time_ms: 0, text: "hello" }];
+    mockLyricsStore.lyricsAlignment = "left";
+    mockLyricsStore.toggleLyricsAlignment = vi.fn(() => {
+      mockLyricsStore.lyricsAlignment =
+        mockLyricsStore.lyricsAlignment === "left" ? "center" : "left";
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function getAlignmentButton(): HTMLButtonElement {
+    const button = container.querySelector<HTMLButtonElement>(
+      '[data-testid="fullscreen-alignment-button"]',
+    );
+    if (!button) throw new Error("alignment button not rendered");
+    return button;
+  }
+
+  test("toggles lyrics alignment when lyrics are available", async () => {
+    await act(async () => {
+      root.render(<FullscreenControls />);
+    });
+
+    await act(async () => {
+      getAlignmentButton().click();
+    });
+
+    expect(mockLyricsStore.toggleLyricsAlignment).toHaveBeenCalled();
+  });
+
+  test("is disabled and does not toggle when no lyrics are available", async () => {
+    mockLyricsStore.lines = [];
+    mockLyricsStore.songId = null;
+
+    await act(async () => {
+      root.render(<FullscreenControls />);
+    });
+
+    expect(getAlignmentButton().disabled).toBe(true);
+
+    await act(async () => {
+      getAlignmentButton().click();
+    });
+
+    expect(mockLyricsStore.toggleLyricsAlignment).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Player/FullscreenControls.test.tsx
+++ b/src/components/Player/FullscreenControls.test.tsx
@@ -33,12 +33,23 @@ const {
     isRomanizing: false,
     songId: null as string | null,
     lines: [] as { time_ms: number; text: string }[],
+    lyricsAlignment: "left" as "center" | "left",
+    setRomanizedVisibility: (show: boolean) => {
+      mockLyricsStore.showRomanized = show;
+    },
+    toggleLyricsAlignment: () => {
+      mockLyricsStore.lyricsAlignment =
+        mockLyricsStore.lyricsAlignment === "left" ? "center" : "left";
+    },
     subscribe: vi.fn(),
     getState: () => ({
       showRomanized: mockLyricsStore.showRomanized,
       isRomanizing: mockLyricsStore.isRomanizing,
       songId: mockLyricsStore.songId,
       lines: mockLyricsStore.lines,
+      lyricsAlignment: mockLyricsStore.lyricsAlignment,
+      setRomanizedVisibility: mockLyricsStore.setRomanizedVisibility,
+      toggleLyricsAlignment: mockLyricsStore.toggleLyricsAlignment,
     }),
   },
   mockT: vi.fn((key: string) => key),
@@ -288,7 +299,7 @@ describe("FullscreenControls Romanize button", () => {
     });
   });
 
-  test("clicking does not optimistically mutate the fullscreen projection", async () => {
+  test("clicking immediately updates the fullscreen projection", async () => {
     mockLyricsStore.showRomanized = false;
     await act(async () => {
       root.render(<FullscreenControls />);
@@ -298,7 +309,7 @@ describe("FullscreenControls Romanize button", () => {
       getRomanizeButton().click();
     });
 
-    expect(mockLyricsStore.showRomanized).toBe(false);
+    expect(mockLyricsStore.showRomanized).toBe(true);
   });
 });
 

--- a/src/components/Player/FullscreenControls.tsx
+++ b/src/components/Player/FullscreenControls.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Languages, LoaderCircle } from "lucide-react";
+import { AlignCenter, AlignLeft, Languages, LoaderCircle } from "lucide-react";
 import { PeakMeter } from "./PeakMeter";
 import { PlayControls } from "./PlayControls";
 import { SeekBar } from "./SeekBar";
@@ -70,15 +70,27 @@ export function FullscreenControls() {
   const isRomanizing = useLyricsStore((s) => s.isRomanizing);
   const lyricSongId = useLyricsStore((s) => s.songId);
   const hasLyrics = useLyricsStore((s) => s.lines.length > 0);
+  const setRomanizedVisibility = useLyricsStore(
+    (s) => s.setRomanizedVisibility,
+  );
+  const lyricsAlignment = useLyricsStore((s) => s.lyricsAlignment);
+  const toggleLyricsAlignment = useLyricsStore((s) => s.toggleLyricsAlignment);
   const romanizeDisabled = !hasLyrics || !lyricSongId || isRomanizing;
 
   const handleRomanizeClick = () => {
     if (!lyricSongId || romanizeDisabled) return;
+    const next = !showRomanized;
+    setRomanizedVisibility(next);
     const request: LocalAudienceRomanizeSetRequest = {
       songId: lyricSongId,
-      showRomanized: !showRomanized,
+      showRomanized: next,
     };
     void emitLocalAudienceRomanizeSetRequest(request).catch(() => {});
+  };
+
+  const handleAlignmentClick = () => {
+    if (!lyricSongId || !hasLyrics) return;
+    toggleLyricsAlignment();
   };
 
   useEffect(() => {
@@ -186,6 +198,29 @@ export function FullscreenControls() {
             <LoaderCircle size={14} className="animate-spin" />
           ) : (
             <Languages size={14} />
+          )}
+        </button>
+        <button
+          type="button"
+          data-testid="fullscreen-alignment-button"
+          onClick={handleAlignmentClick}
+          aria-label={
+            lyricsAlignment === "left"
+              ? "Switch to centered lyrics"
+              : "Switch to left-aligned lyrics"
+          }
+          aria-pressed={lyricsAlignment === "left"}
+          disabled={!hasLyrics || !lyricSongId}
+          className={`motion-icon-button rounded-full border p-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]/50 ${
+            lyricsAlignment === "left"
+              ? "border-[color-mix(in_srgb,var(--color-accent)_40%,var(--color-border-light))] bg-[color-mix(in_srgb,var(--color-accent)_18%,var(--color-sidebar))] text-[var(--color-control-primary)]"
+              : "border-[var(--color-border-light)] bg-[var(--color-sidebar)] text-[var(--color-text-dim)] hover:border-[color-mix(in_srgb,var(--color-accent)_28%,var(--color-border-light))] hover:bg-[var(--color-hover)] hover:text-[var(--color-control-primary)]"
+          }`}
+        >
+          {lyricsAlignment === "left" ? (
+            <AlignLeft size={14} />
+          ) : (
+            <AlignCenter size={14} />
           )}
         </button>
       </div>

--- a/src/stores/lyrics-store.test.ts
+++ b/src/stores/lyrics-store.test.ts
@@ -1133,3 +1133,27 @@ describe("lyrics-store stale Worker result after song change", () => {
     expect(useLyricsStore.getState().romanizedLines).toEqual([]);
   });
 });
+
+describe("lyrics-store lyricsAlignment", () => {
+  beforeEach(resetStore);
+
+  test("setLyricsAlignment updates the alignment", () => {
+    expect(useLyricsStore.getState().lyricsAlignment).toBe("left");
+
+    useLyricsStore.getState().setLyricsAlignment("center");
+    expect(useLyricsStore.getState().lyricsAlignment).toBe("center");
+
+    useLyricsStore.getState().setLyricsAlignment("left");
+    expect(useLyricsStore.getState().lyricsAlignment).toBe("left");
+  });
+
+  test("toggleLyricsAlignment switches between left and center", () => {
+    useLyricsStore.setState({ lyricsAlignment: "left" });
+
+    useLyricsStore.getState().toggleLyricsAlignment();
+    expect(useLyricsStore.getState().lyricsAlignment).toBe("center");
+
+    useLyricsStore.getState().toggleLyricsAlignment();
+    expect(useLyricsStore.getState().lyricsAlignment).toBe("left");
+  });
+});

--- a/src/stores/lyrics-store.test.ts
+++ b/src/stores/lyrics-store.test.ts
@@ -59,6 +59,7 @@ const DEFAULT_STATE = {
   romanizedLinesIdentity: null,
   isRomanizing: false,
   showRomanized: false,
+  lyricsAlignment: "left" as const,
 };
 
 function resetStore() {

--- a/src/stores/lyrics-store.ts
+++ b/src/stores/lyrics-store.ts
@@ -79,6 +79,7 @@ interface LyricsState {
   romanizedLinesIdentity: string | null;
   isRomanizing: boolean;
   showRomanized: boolean;
+  lyricsAlignment: "center" | "left";
 
   fetchLyrics: (songId: string) => Promise<void>;
   setOffset: (songId: string, ms: number) => Promise<void>;
@@ -91,6 +92,8 @@ interface LyricsState {
   setRomanizedVisibility: (show: boolean) => void;
   applyRemoteRomanizeState: (state: LocalAudienceRomanizeState) => void;
   romanizeCurrentLyrics: () => Promise<void>;
+  setLyricsAlignment: (alignment: "center" | "left") => void;
+  toggleLyricsAlignment: () => void;
   clear: () => void;
 }
 
@@ -107,6 +110,7 @@ export const useLyricsStore = create<LyricsState>((set, get) => ({
   romanizedLinesIdentity: null,
   isRomanizing: false,
   showRomanized: false,
+  lyricsAlignment: "left",
 
   fetchLyrics: async (songId) => {
     const gen = ++fetchGeneration;
@@ -272,6 +276,13 @@ export const useLyricsStore = create<LyricsState>((set, get) => ({
       romanizedLinesIdentity: state.lyricsIdentity,
     });
   },
+
+  setLyricsAlignment: (alignment) => set({ lyricsAlignment: alignment }),
+
+  toggleLyricsAlignment: () =>
+    set((state) => ({
+      lyricsAlignment: state.lyricsAlignment === "left" ? "center" : "left",
+    })),
 
   romanizeCurrentLyrics: async () => {
     const { lines, isRomanizing } = get();


### PR DESCRIPTION
## Summary
- Adds a lyric alignment toggle (center / left) to the fullscreen audience controls.
- Lifts `lyricsAlignment` into `LyricsStore` so both the main window and the fullscreen window can switch the layout.
- Makes left-aligned audience lyrics fill the padded viewport, removing the large side black bars.
- Switches the left-aligned audience grid to `1fr auto` so the primary lyric takes the remaining width and romanization sizes to its content.
- Adds `min-w-0 break-words` to primary and background lyric text to prevent overflow.
- Stabilizes `LyricLine` children so toggling alignment no longer remounts the word spans and triggers a global color flash.

Also includes the previously uncommitted Edit Lyrics dialog sizing, z-index, and backdrop fixes.

## Test plan
- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (2167 tests)
- [x] `pnpm tauri build` succeeds