### PR TITLE
ci: layered PR / main / Nightly / Release gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,10 @@ jobs:
   #   unknown-files       JSON array of unmapped filenames
   #   categories          JSON array of detected categories
   #
-  # For push (to main) and workflow_dispatch, the classifier returns full CI
-  # as a deliberate safety path — the integration branch always gets full
-  # validation regardless of what changed.
+  # PR and main push: path-aware jobs via classify-changes.mjs.
+  # workflow_dispatch: full CI (manual force). Full multi-platform and
+  # accessibility matrices run on Nightly; Release owns signed packages and
+  # Windows #284 core. See docs/CI_LAYERS.md.
   triage:
     name: Triage
     runs-on: ubuntu-24.04

--- a/.github/workflows/nightly-hardening.yml
+++ b/.github/workflows/nightly-hardening.yml
@@ -77,9 +77,9 @@ jobs:
             }
           }
 
+  # Full quality matrix (docs/CI_LAYERS.md). Release reuses recent green
+  # Nightly evidence and only re-runs product packaging + Windows #284 core.
   separation-smoke:
-    # Primary arch per OS. Secondary arches (Linux arm64, macOS Intel) stay as
-    # publish-time packaging coverage rather than full smoke every night.
     name: ${{ matrix.name }}
     needs: []
     strategy:
@@ -90,10 +90,18 @@ jobs:
             os: ubuntu-22.04
             ort_target: x86_64-unknown-linux-gnu
             artifact_prefix: nightly-separation-smoke-x86_64-linux
+          - name: Nightly Linux arm64 smoke
+            os: ubuntu-24.04-arm
+            ort_target: aarch64-unknown-linux-gnu
+            artifact_prefix: nightly-separation-smoke-aarch64-linux
           - name: Nightly macOS Apple Silicon smoke
             os: macos-14
             ort_target: aarch64-apple-darwin
             artifact_prefix: nightly-separation-smoke-aarch64-apple
+          - name: Nightly macOS Intel smoke
+            os: macos-15-intel
+            ort_target: x86_64-apple-darwin
+            artifact_prefix: nightly-separation-smoke-x86_64-apple
     uses: ./.github/workflows/reusable-separation-smoke.yml
     with:
       name: ${{ matrix.name }}
@@ -117,16 +125,28 @@ jobs:
       retention_days: 30
 
   macos-installed-app:
-    # One arch: install lifecycle logic is shared; dual-arch is covered by
-    # publish artifact builds, not duplicate installed-app smoke.
-    name: macOS installed app smoke (Apple Silicon)
+    name: macOS installed app smoke (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Apple Silicon
+            os: macos-14
+            rust_target: aarch64-apple-darwin
+            tauri_target: aarch64-apple-darwin
+            artifact_prefix: nightly-macos-installed-app-aarch64
+          - name: Intel
+            os: macos-15-intel
+            rust_target: x86_64-apple-darwin
+            tauri_target: x86_64-apple-darwin
+            artifact_prefix: nightly-macos-installed-app-x86_64
     uses: ./.github/workflows/reusable-macos-installed-app-smoke.yml
     with:
       openkara_version: "0.0.0-nightly"
-      artifact_prefix: nightly-macos-installed-app-aarch64
-      os: macos-14
-      rust_target: aarch64-apple-darwin
-      tauri_target: aarch64-apple-darwin
+      artifact_prefix: ${{ matrix.artifact_prefix }}
+      os: ${{ matrix.os }}
+      rust_target: ${{ matrix.rust_target }}
+      tauri_target: ${{ matrix.tauri_target }}
       scenario: clean-install
       previous_version: none
       retention_days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,10 +155,13 @@ jobs:
           path: RELEASE_NOTES.md
           retention-days: 5
 
+  # Release gate profile (docs/CI_LAYERS.md):
+  # - Windows: full clean/upgrade + #284 fault recovery + separation after heal
+  # - macOS/Linux installed-app: install lifecycle on primary arch only
+  # - separation: one primary arch sanity (Linux x64 + macOS AS); full 4-arch
+  #   lives on Nightly and may be reused for the same SHA within 24h
+  # - publish: multi-arch signed packages + updater + checksums
   release-separation-smoke:
-    # One primary arch per OS for release gate latency. Native ORT packaging is
-    # still covered by the multi-arch publish matrix below. Nightly keeps the
-    # fuller arch set.
     name: Release separation smoke (${{ matrix.name }})
     needs: prepare-release
     strategy:

--- a/docs/CI_LAYERS.md
+++ b/docs/CI_LAYERS.md
@@ -1,0 +1,84 @@
+# CI layers
+
+OpenKara uses four gate layers. Each layer has a different goal. Do not run
+the full Nightly matrix on every PR or every main push.
+
+## Layer goals
+
+| Layer     | Goal                               | Wall-clock target |
+| --------- | ---------------------------------- | ----------------- |
+| PR        | Fast feedback on the change set    | 10–20 minutes     |
+| Main push | Path-aware integration after merge | 10–15 minutes     |
+| Nightly   | Full quality matrix (non-blocking) | 1–2 hours         |
+| Release   | Signed product + Windows #284 core | 30–45 minutes     |
+
+## PR
+
+Path-aware via `scripts/ci/classify-changes.mjs`.
+
+Always:
+
+- format, lint, typecheck (when frontend/tooling changes)
+- unit tests for affected areas
+- workflow contract tests when workflows change
+
+Conditional:
+
+- model / runtime / catalog change → Windows #284 fast path (branch or reusable smoke)
+- UI / accessibility change → keyboard UIA + axe core
+- installer / release workflow change → package build smoke
+- separation pipeline change → Linux x64 real separation
+
+Web accessibility on PR: Chromium, dark/light, core axe. Full page matrix,
+WebKit, forced-colors, 400% zoom, and locale expansion stay on Nightly.
+
+## Main push
+
+Same path-aware classifier as PR. A docs-only merge does not rebuild every
+platform. Manual `workflow_dispatch` still forces full CI.
+
+## Nightly
+
+Full quality line. Does not block PR merge.
+
+- four-arch separation (Linux x64/arm64, macOS AS/Intel)
+- three-platform installed-app
+- Windows keyboard UIA + display scaling 100/125/150/200%
+- full fault injection on disk
+- full Playwright e2e / accessibility matrix (Chromium + WebKit)
+
+## Release
+
+Product packaging and the Windows #284 contract. Prefer reusing same-SHA
+green Nightly evidence for:
+
+- full accessibility matrix
+- full DPI matrix
+- four-arch separation (when catalog/runtime did not change)
+
+Always on Release:
+
+- signed multi-arch packages
+- Windows clean install, upgrade, cold restart
+- Windows #284 core: catalog identity, install load, cold rediscover, stale
+  Downloading / stale manifest / corrupt file recovery, separation after heal
+- macOS / Linux primary-arch install start + short lifecycle
+- updater manifest, signatures, checksums
+
+## Windows #284 core (must stay green)
+
+- catalog generation, artifact ID, archive SHA, extracted-file SHA agree
+- first install loads runtime/model for real
+- cold start rediscovers installed assets
+- stale Downloading, stale manifest, and on-disk corruption recover
+- real separation succeeds after recovery
+
+These concentrate on the Windows installed-app and fault-recovery path.
+
+## Related files
+
+- `scripts/ci/classify-changes.mjs` — PR / main path gates
+- `.github/workflows/ci.yml` — PR and main
+- `.github/workflows/nightly-hardening.yml` — full matrix
+- `.github/workflows/release.yml` — product + Windows #284 core
+- `.github/workflows/reusable-windows-installed-app.yml` — Windows lifecycle

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,6 +9,9 @@ job in `.github/workflows/ci.yml` and `.github/workflows/packaging.yml`.
 
 - **Input:** newline-delimited filenames (`--files`) or JSON array (`--json`),
   plus event type (`--event pull_request|push|workflow_dispatch`)
+- **Events:** `pull_request` and `push` are path-aware; `workflow_dispatch`
+  forces full CI. Full multi-platform matrices live on Nightly — see
+  `docs/CI_LAYERS.md`.
 - **Output:** JSON to stdout; `GITHUB_OUTPUT` entries (`expected-jobs`,
   `run_<job>` booleans, `unknown-files`, `categories`) and
   `GITHUB_STEP_SUMMARY` markdown table when those env vars are set

--- a/scripts/ci/classify-changes.mjs
+++ b/scripts/ci/classify-changes.mjs
@@ -347,9 +347,11 @@ const HEAVY_JOBS = new Set([
 /**
  * Classify changed files and derive expected jobs.
  *
- * For `push` (to main) and `workflow_dispatch`, returns full CI (all jobs)
- * as a deliberate safety path — the integration branch always gets full
- * validation regardless of what changed.
+ * - `pull_request` and `push` (main): path-aware job set from categories.
+ * - `workflow_dispatch`: full CI (manual force / safety path).
+ *
+ * Full multi-platform and accessibility matrices live on Nightly, not on
+ * every main push. Release owns product packaging + Windows #284 core.
  *
  * @param {string[]} files - changed file paths
  * @param {string} event - "pull_request" | "push" | "workflow_dispatch"
@@ -389,11 +391,10 @@ export function classifyChanges(files, event) {
     }
   }
 
-  // Push to main and workflow_dispatch always run full CI as a deliberate
-  // safety path — the integration branch always gets full validation
-  // regardless of what changed. Categories are still populated above so
-  // downstream consumers (e.g. packaging triage) can inspect them.
-  if (event === "push" || event === "workflow_dispatch") {
+  // Manual dispatch is the only event that always forces full CI. Main push
+  // and PRs share path-aware gating so a docs-only merge does not rebuild
+  // every platform again after PR green.
+  if (event === "workflow_dispatch") {
     const allJobs = ALL_JOBS.filter((job) =>
       JOB_RULES[job](new Set(["unknown"]), event),
     );
@@ -408,7 +409,7 @@ export function classifyChanges(files, event) {
     };
   }
 
-  // PR: derive expected jobs from the category union.
+  // PR and main push: derive expected jobs from the category union.
   const expectedJobs = ALL_JOBS.filter((job) =>
     JOB_RULES[job](categorySet, event),
   );

--- a/tests/ci/classify-changes.test.ts
+++ b/tests/ci/classify-changes.test.ts
@@ -492,11 +492,13 @@ describe("synthetic fixtures", () => {
 // ── Event type behavior ───────────────────────────────────────────────
 
 describe("event type behavior", () => {
-  test("push to main always runs full CI regardless of files", () => {
+  test("push to main is path-aware (docs-only skips heavy jobs)", () => {
     const result = classifyChanges(["docs/guide.md"], "push");
-    // Even docs-only changes on push trigger full CI
+    expect(result.expectedJobs).toContain("triage");
+    expect(result.expectedJobs).toContain("ci-gate");
+    expect(result.expectedJobs).toContain("standards-reference");
     for (const job of FULL_CI_HEAVY) {
-      expect(result.expectedJobs).toContain(job);
+      expect(result.expectedJobs).not.toContain(job);
     }
   });
 
@@ -513,10 +515,15 @@ describe("event type behavior", () => {
     expect(
       result.categoriesByFile["packaging/com.openkara.OpenKara.yml"],
     ).toContain("packaging_inputs");
-    // expectedJobs is still full CI (safety path).
-    for (const job of FULL_CI_HEAVY) {
-      expect(result.expectedJobs).toContain(job);
-    }
+    // Path-aware: packaging-only + docs does not force full Tauri build.
+    expect(result.expectedJobs).not.toContain("tauri-build");
+  });
+
+  test("push with Rust sources runs the rust heavy set", () => {
+    const result = classifyChanges(["src-tauri/src/lib.rs"], "push");
+    expect(result.expectedJobs).toContain("rust-test");
+    expect(result.expectedJobs).toContain("tauri-build");
+    expect(result.expectedJobs).not.toContain("conventional-commits");
   });
 
   test("workflow_dispatch always runs full CI", () => {


### PR DESCRIPTION
## What changed

Implements the post-#305 CI layering plan: stop re-running the full matrix on every main push, put full quality on Nightly, keep Release on product packaging + Windows #284 core.

### PR / main
- `classify-changes.mjs`: **path-aware for `push` (main)** as well as `pull_request`
- Only **`workflow_dispatch`** forces full CI
- Docs-only main merges no longer rebuild every platform after PR green

### Nightly (full quality, non-blocking)
- Restore **4-arch separation** (Linux x64/arm64, macOS AS/Intel)
- Restore **dual macOS installed-app** + Windows display matrix + full UIA/faults

### Release (product + #284 core)
- Keep primary-arch installed-app / separation smokes (from #305)
- Document layer intent in `release.yml` comments

### Docs
- New `docs/CI_LAYERS.md` — four-layer goals, #284 core must-keeps, reuse rules

## Verification
- [x] `pnpm exec vitest run tests/ci/classify-changes.test.ts tests/ci/ci-workflow-contract.test.ts tests/release-workflow.test.ts` — 78 passed

## Residual risk
- Further PR-time a11y splits (Chromium core vs Nightly matrix) and path-conditional Release separation are **not** in this PR; Nightly full matrix + path-aware main is the first cut.
- Formal “reuse same-SHA Nightly within 24h” is documented policy, not automated skip logic yet.

## Out of scope (follow-ups)
- Conditional Release separation when only catalog/runtime changes
- Automated Nightly-evidence reuse for Release skip
- Fault matrix PR-vs-Nightly split in scripts
- a11y suite split between PR core and Nightly expansion