### PR TITLE
fix(ci): stop silent release-please tag failures after merge

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -108,10 +108,15 @@ jobs:
             exit 1
           fi
 
-          target_sha="${RELEASE_SHA}"
-          if [ -z "${target_sha}" ]; then
-            target_sha="$(git rev-parse HEAD)"
-            echo "release-please sha empty; falling back to main HEAD ${target_sha}"
+          # Annotated tags require a committer identity (same as the sync job).
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Prefer main HEAD after native-manifest sync so the tag tree matches
+          # package.json + Cargo.toml. Fall back to release-please's SHA.
+          target_sha="$(git rev-parse HEAD)"
+          if [ -n "${RELEASE_SHA}" ] && [ "${target_sha}" != "${RELEASE_SHA}" ]; then
+            echo "Tagging post-sync main HEAD ${target_sha} (release-please sha was ${RELEASE_SHA})"
           fi
 
           if git rev-parse -q --verify "refs/tags/${TAG_NAME}" >/dev/null; then
@@ -148,6 +153,22 @@ jobs:
             version="${TAG_NAME#v}"
           fi
 
+          # Prefer an existing in-flight Release run for this tag (tag push or
+          # a prior dispatch). A second dispatch doubles builds and races on
+          # latest.json / asset uploads.
+          existing_run="$(gh run list \
+            --repo "${GH_REPO}" \
+            --workflow release.yml \
+            --branch "${TAG_NAME}" \
+            --limit 5 \
+            --json databaseId,status,event,url \
+            --jq '[.[] | select(.status == "queued" or .status == "in_progress" or .status == "pending" or .status == "waiting")] | .[0].url // empty')"
+          if [ -n "${existing_run}" ]; then
+            echo "Release workflow already running for ${TAG_NAME}: ${existing_run}"
+            echo "Skipping duplicate workflow_dispatch"
+            exit 0
+          fi
+
           # workflow_dispatch is started by the API and is not blocked the way
           # push/tag events from GITHUB_TOKEN are. Checkout the tag so package.json
           # matches the release version gate.
@@ -157,3 +178,72 @@ jobs:
             -f "version=${version}"
 
           echo "Dispatched Release workflow for ${TAG_NAME} (version ${version})"
+
+  # sync-native-versions advances main with GITHUB_TOKEN. That push does not
+  # re-run full CI, so main HEAD can look green while this cut failed on the
+  # previous commit. Open an issue so the failure cannot stay silent.
+  report-release-cut-failure:
+    name: Report release cut failure
+    needs:
+      [release-please, sync-native-versions, ensure-tag-and-dispatch-release]
+    if: >-
+      always()
+      && needs.release-please.outputs.release_created == 'true'
+      && (
+        needs.sync-native-versions.result == 'failure'
+        || needs.ensure-tag-and-dispatch-release.result == 'failure'
+        || needs.ensure-tag-and-dispatch-release.result == 'cancelled'
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write # open a tracking issue when the release cut fails after merge
+    steps:
+      - name: Open tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SYNC_RESULT: ${{ needs.sync-native-versions.result }}
+          ENSURE_RESULT: ${{ needs.ensure-tag-and-dispatch-release.result }}
+        run: |
+          set -euo pipefail
+
+          tag="${TAG_NAME:-unknown}"
+          title="Release cut failed for ${tag}"
+          body="$(cat <<EOF
+          The post-merge release cut for \`${tag}\` failed.
+
+          - Workflow run: ${RUN_URL}
+          - Sync native manifests: \`${SYNC_RESULT}\`
+          - Ensure tag and dispatch Release: \`${ENSURE_RESULT}\`
+
+          Main HEAD can still show green checks after this fails. The sync job
+          may push a follow-up commit with \`GITHUB_TOKEN\`, and that push does
+          not re-run full CI. Check the Release Please run on the release merge
+          commit, not only the latest commit status on \`main\`.
+
+          Repair steps are in \`docs/RELEASING.md\` (create the tag and dispatch
+          \`release.yml\` if either is missing).
+          EOF
+          )"
+
+          existing_issue="$(gh issue list \
+            --repo "${GH_REPO}" \
+            --state open \
+            --search "in:title ${title}" \
+            --json number,title \
+            --jq '.[0].number // empty')"
+
+          if [ -n "${existing_issue}" ]; then
+            gh issue comment "${existing_issue}" --repo "${GH_REPO}" --body "${body}"
+            echo "Commented on existing issue #${existing_issue}"
+          else
+            issue_url="$(gh issue create \
+              --repo "${GH_REPO}" \
+              --title "${title}" \
+              --body "${body}" \
+              --label "bug")"
+            echo "Opened issue: ${issue_url}"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.11.0](https://github.com/thedavidweng/OpenKara/compare/v0.10.0...v0.11.0) (2026-08-01)
 
-
 ### Features
 
-* **automation:** add canonical report schema and contract test for release gate ([6f12a2e](https://github.com/thedavidweng/OpenKara/commit/6f12a2e60b80522faffa48afd0256f3d48b2f15a))
-* **automation:** add openkara_automation_driver and canonical report builder ([8156c88](https://github.com/thedavidweng/OpenKara/commit/8156c885940160d3bd7420ea328539e8be759252))
-* **automation:** validate audio outputs, runtime/model digests, and [#284](https://github.com/thedavidweng/OpenKara/issues/284) assertions ([3b52513](https://github.com/thedavidweng/OpenKara/commit/3b525131d714c347c0ad7cf2b05e677ad1b4b09d))
-
+- **automation:** add canonical report schema and contract test for release gate ([6f12a2e](https://github.com/thedavidweng/OpenKara/commit/6f12a2e60b80522faffa48afd0256f3d48b2f15a))
+- **automation:** add openkara_automation_driver and canonical report builder ([8156c88](https://github.com/thedavidweng/OpenKara/commit/8156c885940160d3bd7420ea328539e8be759252))
+- **automation:** validate audio outputs, runtime/model digests, and [#284](https://github.com/thedavidweng/OpenKara/issues/284) assertions ([3b52513](https://github.com/thedavidweng/OpenKara/commit/3b525131d714c347c0ad7cf2b05e677ad1b4b09d))
 
 ### Bug Fixes
 
-* **automation:** 1.0 desktop and accessibility release gate ([#305](https://github.com/thedavidweng/OpenKara/issues/305)) ([a072087](https://github.com/thedavidweng/OpenKara/commit/a0720879f2777a245f2341fa0435acf595e2d23c))
+- **automation:** 1.0 desktop and accessibility release gate ([#305](https://github.com/thedavidweng/OpenKara/issues/305)) ([a072087](https://github.com/thedavidweng/OpenKara/commit/a0720879f2777a245f2341fa0435acf595e2d23c))
 
 ## [0.10.0](https://github.com/thedavidweng/OpenKara/compare/v0.9.1...v0.10.0) (2026-07-29)
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -34,10 +34,15 @@ starts auto-updating existing installs.
    automatically as conventional commits land on `main`. Merge it when you
    are ready to ship. release-please bumps `package.json` and
    `CHANGELOG.md` and creates a draft GitHub Release with changelog notes.
-2. **Confirm the tag and Release run.** After merge, the Release Please
+2. **Confirm the tag and Release run.** After merge, open the **Release
+   Please** workflow run on the release merge commit (not only the latest
+   commit on `main`). The sync job may push a follow-up commit with
+   `GITHUB_TOKEN`. That push does not re-run full CI, so `main` HEAD can
+   look green while the release cut failed on the previous commit. The
    workflow must create (or repair) `vX.Y.Z` and start a Release run. If
    either is missing, create the tag on the release commit and run
-   `gh workflow run release.yml --ref vX.Y.Z -f version=X.Y.Z`.
+   `gh workflow run release.yml --ref vX.Y.Z -f version=X.Y.Z`. A failed
+   cut also opens a GitHub issue titled `Release cut failed for vX.Y.Z`.
 3. **Watch the Release workflow.** It runs the separation smoke on every
    target, builds the bundles, and uploads assets to the draft release.
 4. **Verify the asset names** on the draft release match the tag, e.g.


### PR DESCRIPTION
## Summary

- **Root cause of 0.11.0 cut failure:** `git tag -a` ran without `user.name` / `user.email`, so Ensure tag and dispatch Release failed and never started `release.yml`.
- **Why main looked green:** `sync-native-versions` pushed a follow-up commit with `GITHUB_TOKEN`. That commit became HEAD with only CodeQL green; the red Release Please run sits on the previous commit.
- **Fixes:** set git identity before annotated tags; tag post-sync main HEAD; skip duplicate Release dispatches when a run is already in flight; open a `Release cut failed for vX.Y.Z` issue when the cut fails; document the check path in `docs/RELEASING.md`.

## Manual repair for 0.11.0 (already done)

- Created tag `v0.11.0` at `151b6a7`
- Release run: https://github.com/thedavidweng/OpenKara/actions/runs/30692203796

## Test plan

- [x] actionlint / YAML parse clean
- [x] pre-push format/lint hooks
- [ ] Merge; next release cut should create tag + dispatch without identity failure
- [ ] Confirm in-flight Release for v0.11.0 completes assets on the draft