### PR TITLE
feat(release): auto-publish after assets, then submit distribution PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -515,13 +515,61 @@ jobs:
           cat SHA256SUMS
           gh release upload "${RELEASE_TAG}" SHA256SUMS --clobber
 
+  # Ship gate: merge of the release-please PR is the human decision. After
+  # platform smoke, signed assets, and SHA256SUMS land, undraft so
+  # /releases/latest and distribution submits see a public release.
+  publish-github-release:
+    name: Publish GitHub Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [prepare-release, publish, publish-windows, generate-checksums]
+    permissions:
+      contents: write # undraft the GitHub Release after assets are complete
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
+          RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          required_assets=(
+            "OpenKara_${RELEASE_VERSION}_x64-setup.exe"
+            "OpenKara_${RELEASE_VERSION}_aarch64.dmg"
+            "OpenKara_${RELEASE_VERSION}_x64.dmg"
+            "OpenKara_${RELEASE_VERSION}_amd64.AppImage"
+            "OpenKara_${RELEASE_VERSION}_amd64.deb"
+            "latest.json"
+            "SHA256SUMS"
+          )
+
+          asset_names="$(gh release view "${RELEASE_TAG}" --repo "${GH_REPO}" --json assets --jq '[.assets[].name] | join("\n")')"
+          missing=0
+          for name in "${required_assets[@]}"; do
+            if ! printf '%s\n' "${asset_names}" | grep -Fxq "${name}"; then
+              echo "::error::Release ${RELEASE_TAG} is missing required asset ${name}"
+              missing=1
+            fi
+          done
+          if [ "${missing}" -ne 0 ]; then
+            exit 1
+          fi
+
+          # releaseDraft stayed true while legs uploaded; undraft only after
+          # the full asset set is present. Prerelease stays set from the tag
+          # (vX.Y.Z-rc.1) so /releases/latest still ignores those tags.
+          gh release edit "${RELEASE_TAG}" --repo "${GH_REPO}" --draft=false
+          echo "Published ${RELEASE_TAG} (assets verified)"
+
   prepare-distribution-manifests:
     name: Prepare distribution manifests
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [prepare-release, publish, publish-windows, generate-checksums]
+    needs: [prepare-release, publish-github-release]
     permissions:
-      contents: write # upload distribution manifests to the draft GitHub Release
+      contents: write # upload distribution manifests to the published GitHub Release
     env:
       GITHUB_TOKEN: ${{ github.token }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,9 +62,9 @@ This project follows [Conventional Commits](https://www.conventionalcommits.org/
 
 ## Releasing
 
-Maintainers: see [docs/RELEASING.md](docs/RELEASING.md) for the tag-driven
-release process (bump `package.json`, `pnpm version:sync`, tag, verify the draft
-release assets, publish).
+Maintainers: see [docs/RELEASING.md](docs/RELEASING.md) for the release-please
+process (merge the release PR; the Release workflow builds, smokes, publishes,
+and submits distribution PRs).
 
 ## License
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -17,14 +17,19 @@ Release with changelog notes. The same workflow then:
    with `workflow_dispatch`. Tag pushes from `GITHUB_TOKEN` do not start
    other workflows, so this explicit dispatch is required.
 
-The Release workflow builds every platform bundle, runs the release-only
-separation and installed-app smoke tests, attaches `SHA256SUMS`, and uploads
-assets to the draft release.
+The Release workflow:
 
-The release stays a draft until a human verifies the asset names and clicks
-**Publish** in the GitHub UI. This last manual step is intentional: the
-in-app updater polls `/releases/latest`, so a published release immediately
-starts auto-updating existing installs.
+1. Builds every platform bundle.
+2. Runs the release-only separation and installed-app smoke tests.
+3. Uploads signed assets and `SHA256SUMS` to the draft release.
+4. **Publishes** the release automatically once the required assets are
+   present (`gh release edit --draft=false`).
+5. Renders WinGet and Flatpak manifests from the published tag URLs and
+   opens or updates the external PRs when fork automation is configured.
+
+**Merge of the release PR is the human ship decision.** Release smoke and
+asset gates are the automated quality gate. There is no separate manual
+Publish click on the GitHub Release page for plain version tags.
 
 [release-please]: https://github.com/googleapis/release-please
 
@@ -43,14 +48,15 @@ starts auto-updating existing installs.
    either is missing, create the tag on the release commit and run
    `gh workflow run release.yml --ref vX.Y.Z -f version=X.Y.Z`. A failed
    cut also opens a GitHub issue titled `Release cut failed for vX.Y.Z`.
-3. **Watch the Release workflow.** It runs the separation smoke on every
-   target, builds the bundles, and uploads assets to the draft release.
-4. **Verify the asset names** on the draft release match the tag, e.g.
-   `OpenKara_0.10.0_x64-setup.exe`. Confirm `SHA256SUMS` and `latest.json`
-   are attached.
-5. **Publish** the draft release from the GitHub UI. Publishing (or the
-   workflow, when configured) drives the Homebrew tap, WinGet, and Flathub
-   submissions.
+3. **Watch the Release workflow.** It runs smoke tests, uploads assets,
+   publishes the GitHub Release, then submits WinGet and Flatpak when
+   configured.
+4. **Confirm the published release.** Asset names match the tag, e.g.
+   `OpenKara_0.11.0_x64-setup.exe`. `SHA256SUMS` and `latest.json` are
+   attached. `/releases/latest` points at the new plain tag.
+5. **Confirm distribution PRs.** WinGet and Flathub automation open or
+   update PRs after publish. Review and merge those external PRs when
+   their bots pass.
 
 ## Current version truth
 
@@ -148,6 +154,15 @@ GitHub's `/releases/latest` — the URL the in-app updater polls — resolves on
 the newest release that is neither a draft nor a prerelease. The workflow
 therefore derives the prerelease flag from the tag: suffixed tags (`v1.0.0-rc.1`,
 `v1.0.0-beta.1`) publish as prereleases the updater ignores; plain tags
-(`v1.0.0`) publish as full releases the updater picks up **once the draft is
-published**. Existing installs only start auto-updating after the first plain
-tag ships as a published, non-prerelease release.
+(`v1.0.0`) undraft as full releases the updater picks up as soon as the Release
+workflow publishes. Existing installs start auto-updating after that plain tag
+ships as a published, non-prerelease release.
+
+## WinGet installer URLs
+
+WinGet manifests always use the stable public form:
+
+`https://github.com/<owner>/<repo>/releases/download/<tag>/<asset>`
+
+Do not use GitHub draft `untagged-*` download paths. Those URLs 404 for
+anonymous clients, and WinGet URL validation fails.

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -11,6 +11,10 @@ Why templates instead of checked-in release manifests:
 - `scripts/render-winget-manifests.mjs` fetches the release metadata from GitHub
   and emits the versioned `manifests/<first-letter>/<publisher>/<package>/<version>/`
   tree used for PRs against `microsoft/winget-pkgs`.
+- Installer URLs always use
+  `https://github.com/<owner>/<repo>/releases/download/<tag>/<asset>`.
+  Do not use draft `untagged-*` download paths; WinGet URL validation returns
+  NotFound for those.
 
 Bootstrap requirements for PR automation:
 

--- a/scripts/release-metadata.mjs
+++ b/scripts/release-metadata.mjs
@@ -82,6 +82,20 @@ export function requireReleaseAsset(release, name) {
   return asset;
 }
 
+// Prefer over asset.browser_download_url: draft releases can report
+// /download/untagged-*/ paths that 404 for anonymous WinGet validation.
+export function canonicalReleaseAssetUrl({ owner, repo, tag, assetName }) {
+  if (!tag || tag.includes("untagged-")) {
+    throw new Error(
+      `refusing release asset URL for unstable tag ${JSON.stringify(tag)}`,
+    );
+  }
+  if (!assetName) {
+    throw new Error("assetName is required for canonicalReleaseAssetUrl");
+  }
+  return `https://github.com/${owner}/${repo}/releases/download/${tag}/${assetName}`;
+}
+
 export function releaseDateISO(release) {
   const published = release.published_at ?? release.created_at;
   if (!published) {

--- a/scripts/render-winget-manifests.mjs
+++ b/scripts/render-winget-manifests.mjs
@@ -1,6 +1,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import {
+  canonicalReleaseAssetUrl,
   fetchReleaseByTag,
   parseArgs,
   requireArg,
@@ -27,9 +28,15 @@ const installerName =
 
 const release = await fetchReleaseByTag({ owner, repo, tag });
 const installer = requireReleaseAsset(release, installerName);
+const installerUrl = canonicalReleaseAssetUrl({
+  owner,
+  repo,
+  tag,
+  assetName: installer.name,
+});
 const installerSha256 =
   installer.digest?.replace(/^sha256:/, "") ??
-  (await sha256ForUrl(installer.browser_download_url));
+  (await sha256ForUrl(installerUrl));
 
 const manifestDir = join(outputDir, "t", "thedavidweng", "OpenKara", version);
 const templateRoot = "packaging/winget/templates";
@@ -42,10 +49,9 @@ const replacements = new Map([
   ["@@PUBLISHER_URL@@", publisherUrl],
   ["@@SUPPORT_URL@@", supportUrl],
   ["@@PACKAGE_URL@@", packageUrl],
-  ["@@INSTALLER_URL@@", installer.browser_download_url],
+  ["@@INSTALLER_URL@@", installerUrl],
   ["@@INSTALLER_SHA256@@", installerSha256],
 ]);
-
 function renderTemplate(fileName) {
   let output = readFileSync(join(templateRoot, fileName), "utf8");
   for (const [token, value] of replacements.entries()) {

--- a/tests/flatpak-packaging.test.ts
+++ b/tests/flatpak-packaging.test.ts
@@ -545,7 +545,13 @@ describe("Flatpak packaging", () => {
     expect(releaseWorkflow).toContain(
       "Initial Flathub submissions must be opened or updated manually",
     );
-    expect(releaseWorkflow).not.toContain("--draft");
+    // Assets upload as draft (tauri-action releaseDraft); the workflow then
+    // undrafts after required assets land, before WinGet/Flatpak submit.
+    expect(releaseWorkflow).toContain("releaseDraft: true");
+    expect(releaseWorkflow).toContain("Publish GitHub Release");
+    expect(releaseWorkflow).toContain("gh release edit");
+    expect(releaseWorkflow).toContain("--draft=false");
+    expect(releaseWorkflow).toContain("publish-github-release");
     expect(releaseWorkflow).not.toContain(
       "Open this prefilled GitHub URL to create the Flathub submission PR",
     );

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -1,10 +1,35 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import { fetchReleaseByTag } from "../scripts/release-metadata.mjs";
+import {
+  canonicalReleaseAssetUrl,
+  fetchReleaseByTag,
+} from "../scripts/release-metadata.mjs";
 
 describe("release metadata helpers", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+  });
+
+  test("builds a tag-based public asset URL instead of draft untagged paths", () => {
+    expect(
+      canonicalReleaseAssetUrl({
+        owner: "thedavidweng",
+        repo: "OpenKara",
+        tag: "v0.11.0",
+        assetName: "OpenKara_0.11.0_x64-setup.exe",
+      }),
+    ).toBe(
+      "https://github.com/thedavidweng/OpenKara/releases/download/v0.11.0/OpenKara_0.11.0_x64-setup.exe",
+    );
+
+    expect(() =>
+      canonicalReleaseAssetUrl({
+        owner: "thedavidweng",
+        repo: "OpenKara",
+        tag: "untagged-1e0dfafd347c46933dba",
+        assetName: "OpenKara_0.11.0_x64-setup.exe",
+      }),
+    ).toThrow(/unstable tag/);
   });
 
   test("falls back to the releases list when a draft release is hidden from the tag endpoint", async () => {


### PR DESCRIPTION
## Summary

Implements release design **option A**: merge of the release-please PR is the human ship decision.

- After smoke + signed assets + `SHA256SUMS`, the Release workflow **undrafts** the GitHub Release (`Publish GitHub Release` job).
- WinGet/Flatpak submit only after that publish step.
- WinGet installer URLs always use the stable `.../releases/download/<tag>/...` path (never draft `untagged-*` URLs that 404 for wingetbot).
- Docs (`RELEASING.md`, `CONTRIBUTING.md`, winget README) match the automation.

### Already repaired for 0.11.0

- WinGet PR https://github.com/microsoft/winget-pkgs/pull/410852 updated to the tagged installer URL.

## Test plan

- [x] `vitest` release-metadata + flatpak-packaging workflow contract tests
- [x] pre-push hooks
- [ ] Merge; next release cut should undraft automatically then open WinGet with tag URLs