### PR TITLE
fix(release): apply installation template to draft releases

### DIFF
--- a/.github/release-notes-installation.md
+++ b/.github/release-notes-installation.md
@@ -1,0 +1,30 @@
+---
+
+## Installation
+
+Download the latest build for your platform from the assets below:
+
+| Platform              | Format                  |
+| --------------------- | ----------------------- |
+| macOS (Apple Silicon) | `.dmg`                  |
+| macOS (Intel)         | `.dmg`                  |
+| Windows               | `.exe` (NSIS installer) |
+| Linux                 | `.AppImage` / `.deb`    |
+
+**macOS (Homebrew):**
+
+```bash
+brew install thedavidweng/tap/openkara
+```
+
+**Windows (winget):**
+
+```bash
+winget install thedavidweng.OpenKara
+```
+
+**macOS Gatekeeper note:** If macOS says the app is damaged or can't be opened, run:
+
+```bash
+xattr -rd com.apple.quarantine /Applications/OpenKara.app
+```

--- a/.github/release-notes-installation.md
+++ b/.github/release-notes-installation.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD041 -->
+
 ---
 
 ## Installation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,6 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
-      release_body: ${{ steps.notes.outputs.body }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -75,7 +74,6 @@ jobs:
           echo "package.json version ${package_version} matches release ${RELEASE_TAG}."
 
       - name: Build release notes
-        id: notes
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
@@ -91,7 +89,7 @@ jobs:
             echo "Found release for ${RELEASE_TAG} via tag endpoint"
           else
             release_body="$(gh api "repos/${GH_REPO}/releases" --paginate \
-              --jq "[.[] | select(.tag_name == \"${RELEASE_TAG}\")] | .[0].body // empty" 2>/dev/null || true)"
+              --jq "[.[] | select(.tag_name == \"${RELEASE_TAG}\")] | .[0].body // empty")"
             if [ -n "${release_body}" ]; then
               echo "${release_body}" > RELEASE_NOTES.md
               echo "Found draft release for ${RELEASE_TAG} via releases list"
@@ -103,50 +101,37 @@ jobs:
 
           # Append installation section. Mirrors README "Install from Release"
           # so users can install straight from the GitHub Release page.
-          cat >> RELEASE_NOTES.md <<'INSTALL_EOF'
+          if ! grep -Fq "## Installation" RELEASE_NOTES.md; then
+            cat .github/release-notes-installation.md >> RELEASE_NOTES.md
+          fi
 
-          ---
-
-          ## Installation
-
-          Download the latest build for your platform from the assets below:
-
-          | Platform              | Format                  |
-          | --------------------- | ----------------------- |
-          | macOS (Apple Silicon) | `.dmg`                  |
-          | macOS (Intel)         | `.dmg`                  |
-          | Windows               | `.exe` (NSIS installer) |
-          | Linux                 | `.AppImage` / `.deb`    |
-
-          **macOS (Homebrew):**
-
-          ```bash
-          brew install thedavidweng/tap/openkara
-          ```
-
-          **Windows (winget):**
-
-          ```bash
-          winget install thedavidweng.OpenKara
-          ```
-
-          **macOS Gatekeeper note:** If macOS says the app is damaged or can't be opened, run:
-
-          ```bash
-          xattr -rd com.apple.quarantine /Applications/OpenKara.app
-          ```
-          INSTALL_EOF
-
-          {
-            echo 'body<<RELEASE_NOTES_EOF'
-            cat RELEASE_NOTES.md
-            if [ -n "${INPUT_NOTES}" ]; then
+          if [ -n "${INPUT_NOTES}" ]; then
+            {
               echo ""
               echo "---"
               echo "${INPUT_NOTES}"
+            } >> RELEASE_NOTES.md
+          fi
+
+          release_id="$(gh api "repos/${GH_REPO}/releases" --paginate \
+            --jq "[.[] | select(.tag_name == \"${RELEASE_TAG}\")] | .[0].id // empty")"
+          if [ -n "${release_id}" ]; then
+            gh api --method PATCH "repos/${GH_REPO}/releases/${release_id}" \
+              -F "body=@RELEASE_NOTES.md" >/dev/null
+            echo "Updated release notes for ${RELEASE_TAG}"
+          else
+            prerelease_args=()
+            if [[ "${RELEASE_TAG}" == *-* ]]; then
+              prerelease_args+=(--prerelease)
             fi
-            echo 'RELEASE_NOTES_EOF'
-          } >> "$GITHUB_OUTPUT"
+            gh release create "${RELEASE_TAG}" \
+              --repo "${GH_REPO}" \
+              --draft \
+              --title "OpenKara v${RELEASE_TAG#v}" \
+              --notes-file RELEASE_NOTES.md \
+              "${prerelease_args[@]}"
+            echo "Created draft release for ${RELEASE_TAG}"
+          fi
 
       - name: Upload release notes
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -345,28 +330,13 @@ jobs:
           name: release-evidence
           path: ${{ runner.temp }}/release-evidence
 
-      - name: Create draft release and upload evidence
+      - name: Upload release evidence
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
-          RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
-          RELEASE_BODY: ${{ needs.prepare-release.outputs.release_body }}
-          RELEASE_PRERELEASE: ${{ contains(needs.prepare-release.outputs.tag, '-') }}
         run: |
           set -euo pipefail
-          if ! gh release view "$RELEASE_TAG" --repo "$GH_REPO" >/dev/null 2>&1; then
-            prerelease_args=()
-            if [ "$RELEASE_PRERELEASE" = "true" ]; then
-              prerelease_args+=(--prerelease)
-            fi
-            gh release create "$RELEASE_TAG" \
-              --repo "$GH_REPO" \
-              --draft \
-              --title "OpenKara v${RELEASE_VERSION}" \
-              --notes "$RELEASE_BODY" \
-              "${prerelease_args[@]}"
-          fi
           gh release upload "$RELEASE_TAG" --repo "$GH_REPO" \
             "${RUNNER_TEMP}/release-evidence/release-evidence.json" --clobber
 
@@ -527,26 +497,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
-          RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
-          RELEASE_BODY: ${{ needs.prepare-release.outputs.release_body }}
-          RELEASE_PRERELEASE: ${{ contains(needs.prepare-release.outputs.tag, '-') }}
           CANDIDATE_ROOT: ${{ runner.temp }}/release-candidate
         run: |
           set -euo pipefail
-
-          if ! gh release view "$RELEASE_TAG" --repo "$GH_REPO" >/dev/null 2>&1; then
-            if [ "$RELEASE_PRERELEASE" = "true" ]; then
-              prerelease_flag="--prerelease"
-            else
-              prerelease_flag=""
-            fi
-            gh release create "$RELEASE_TAG" \
-              --repo "$GH_REPO" \
-              --draft \
-              --title "OpenKara v${RELEASE_VERSION}" \
-              --notes "$RELEASE_BODY" \
-              $prerelease_flag
-          fi
 
           files=()
           while IFS= read -r -d '' file; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,7 @@ jobs:
           # Append installation section. Mirrors README "Install from Release"
           # so users can install straight from the GitHub Release page.
           if ! grep -Fq "## Installation" RELEASE_NOTES.md; then
+            printf '\n\n' >> RELEASE_NOTES.md
             cat .github/release-notes-installation.md >> RELEASE_NOTES.md
           fi
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -7,7 +7,8 @@ every push to `main` and maintains a running release PR that bumps
 `.release-please-manifest.json`.
 
 When the release PR is merged, release-please opens a **draft** GitHub
-Release with changelog notes. The same workflow then:
+Release with changelog notes. The Release workflow also supports manual
+dispatch and creates the draft when it is missing. The same workflow then:
 
 1. Syncs native manifests (`Cargo.toml`, `tauri.conf.json`, …) via
    `scripts/sync-version.mjs`.
@@ -19,19 +20,27 @@ Release with changelog notes. The same workflow then:
 
 The Release workflow:
 
-1. Builds every platform bundle.
-2. Runs the release-only separation and installed-app smoke tests.
-3. Uploads the tested signed assets and canonical `release-evidence.json` to
+1. Creates or updates the draft release and applies
+   `.github/release-notes-installation.md`. The template includes Homebrew and
+   WinGet install commands.
+2. Builds every platform bundle.
+3. Runs the release-only separation and installed-app smoke tests.
+4. Uploads the tested signed assets and canonical `release-evidence.json` to
    the draft release.
-4. Generates `latest.json` and `SHA256SUMS` from that evidence.
-5. **Publishes** the release automatically once the required assets are
+5. Generates `latest.json` and `SHA256SUMS` from that evidence.
+6. **Publishes** the release automatically once the required assets are
    present (`gh release edit --draft=false`).
-6. Renders WinGet and Flatpak manifests from the published tag URLs and
+7. Renders WinGet and Flatpak manifests from the published tag URLs and
    opens or updates the external PRs when fork automation is configured.
 
 **Merge of the release PR is the human ship decision.** Release smoke and
 asset gates are the automated quality gate. There is no separate manual
 Publish click on the GitHub Release page for plain version tags.
+
+Release Please owns the version and changelog text. The Release workflow owns
+the final GitHub Release body because it also creates and publishes release
+assets. Keep the installation section in the checked-in template file instead
+of adding it to `release-please-config.json`.
 
 [release-please]: https://github.com/googleapis/release-please
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -33,9 +33,9 @@ The Release workflow:
 7. Renders WinGet and Flatpak manifests from the published tag URLs and
    opens or updates the external PRs when fork automation is configured.
 
-**Merge of the release PR is the human ship decision.** Release smoke and
-asset gates are the automated quality gate. There is no separate manual
-Publish click on the GitHub Release page for plain version tags.
+**A human decides when to merge the release PR.** Release smoke and asset
+gates are the automated quality gate. There is no separate manual Publish
+click on the GitHub Release page for plain version tags.
 
 Release Please owns the version and changelog text. The Release workflow owns
 the final GitHub Release body because it also creates and publishes release

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -198,6 +198,36 @@ describe("release workflow", () => {
     );
   });
 
+  test("applies the installation template to an existing draft release", () => {
+    const releaseWorkflow = readProjectFile(".github/workflows/release.yml");
+    const installationTemplate = readProjectFile(
+      ".github/release-notes-installation.md",
+    );
+
+    expect(releaseWorkflow).toContain(
+      'grep -Fq "## Installation" RELEASE_NOTES.md',
+    );
+    expect(releaseWorkflow).toContain(
+      "cat .github/release-notes-installation.md >> RELEASE_NOTES.md",
+    );
+    expect(installationTemplate).toContain(
+      "brew install thedavidweng/tap/openkara",
+    );
+    expect(installationTemplate).toContain(
+      "winget install thedavidweng.OpenKara",
+    );
+    expect(releaseWorkflow).toContain(
+      'gh api --method PATCH "repos/${GH_REPO}/releases/${release_id}"',
+    );
+    expect(releaseWorkflow).toContain('-F "body=@RELEASE_NOTES.md"');
+    expect(releaseWorkflow).toMatch(
+      /Build release notes[\s\S]*?gh release create "\$\{RELEASE_TAG\}"[\s\S]*?--notes-file RELEASE_NOTES\.md/,
+    );
+    expect(releaseWorkflow).not.toContain(
+      "RELEASE_BODY: ${{ needs.prepare-release.outputs.release_body }}",
+    );
+  });
+
   test("release-please ensures a git tag and dispatches the Release workflow", () => {
     // GITHUB_TOKEN tag/release events do not start other workflows. The
     // release-please path must create a missing tag, rebind the draft release,

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -207,8 +207,12 @@ describe("release workflow", () => {
     expect(releaseWorkflow).toContain(
       'grep -Fq "## Installation" RELEASE_NOTES.md',
     );
+    expect(releaseWorkflow).toContain("printf '\\n\\n' >> RELEASE_NOTES.md");
     expect(releaseWorkflow).toContain(
       "cat .github/release-notes-installation.md >> RELEASE_NOTES.md",
+    );
+    expect(installationTemplate).toMatch(
+      /^<!-- markdownlint-disable MD041 -->\n\n---\n/,
     );
     expect(installationTemplate).toContain(
       "brew install thedavidweng/tap/openkara",
@@ -225,6 +229,12 @@ describe("release workflow", () => {
     );
     expect(releaseWorkflow).not.toContain(
       "RELEASE_BODY: ${{ needs.prepare-release.outputs.release_body }}",
+    );
+
+    const releaseBodyWithoutTrailingNewline = "## Release v0.12.0";
+    const composedNotes = `${releaseBodyWithoutTrailingNewline}\n\n${installationTemplate}`;
+    expect(composedNotes).toContain(
+      `${releaseBodyWithoutTrailingNewline}\n\n<!-- markdownlint-disable MD041 -->\n\n---`,
     );
   });
 


### PR DESCRIPTION
## Summary
- keep release-please responsible for versioning and changelog generation
- store the installation section in a checked-in release-notes template
- compose and update the draft release through the Releases API by release ID
- create the draft once in `prepare-release` so upload jobs do not race to create it

## Validation
- `pnpm test:release:gate`
- `pnpm test` via pre-push hook: 2,224 tests passed
- `pnpm check:standards`
- `pnpm format`
- `actionlint .github/workflows/release.yml .github/workflows/release-please.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added installation instructions for macOS, Windows, and Linux release builds.
  * Release notes now include download options, Homebrew and WinGet commands, and macOS Gatekeeper guidance.
  * Releases can be created or updated with installation information applied automatically.

* **Documentation**
  * Clarified the release workflow, including draft release creation and publishing responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->