### PR TITLE
fix(release): build macOS updater artifacts in smoke

### DIFF
--- a/.github/workflows/reusable-linux-installed-app-smoke.yml
+++ b/.github/workflows/reusable-linux-installed-app-smoke.yml
@@ -209,7 +209,7 @@ jobs:
           path: |
             src-tauri/target/${{ inputs.rust_target }}/release/bundle/**/*.tar.gz
             src-tauri/target/${{ inputs.rust_target }}/release/bundle/**/*.sig
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: ${{ inputs.retention_days }}
 
   clean-install:

--- a/.github/workflows/reusable-linux-installed-app-smoke.yml
+++ b/.github/workflows/reusable-linux-installed-app-smoke.yml
@@ -201,6 +201,23 @@ jobs:
           if-no-files-found: error
           retention-days: ${{ inputs.retention_days }}
 
+      - name: Validate Linux updater artifacts
+        if: ${{ inputs.release_build }}
+        env:
+          BUNDLE_DIR: src-tauri/target/${{ inputs.rust_target }}/release/bundle
+        run: |
+          set -euo pipefail
+          archive="$(find "$BUNDLE_DIR" -type f -name "*.tar.gz" -print -quit)"
+          signature="$(find "$BUNDLE_DIR" -type f -name "*.sig" -print -quit)"
+          if [ -z "$archive" ]; then
+            echo "::error::No Linux updater archive was produced."
+            exit 1
+          fi
+          if [ -z "$signature" ]; then
+            echo "::error::No Linux updater signature was produced."
+            exit 1
+          fi
+
       - name: Upload Linux updater artifacts
         if: ${{ inputs.release_build }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/reusable-macos-installed-app-smoke.yml
+++ b/.github/workflows/reusable-macos-installed-app-smoke.yml
@@ -172,6 +172,23 @@ jobs:
           if-no-files-found: error
           retention-days: ${{ inputs.retention_days }}
 
+      - name: Validate macOS updater artifacts
+        if: ${{ inputs.release_build }}
+        env:
+          BUNDLE_DIR: src-tauri/target/${{ inputs.rust_target }}/release/bundle
+        run: |
+          set -euo pipefail
+          archive="$(find "$BUNDLE_DIR" -type f -name "*.tar.gz" -print -quit)"
+          signature="$(find "$BUNDLE_DIR" -type f -name "*.sig" -print -quit)"
+          if [ -z "$archive" ]; then
+            echo "::error::No macOS updater archive was produced."
+            exit 1
+          fi
+          if [ -z "$signature" ]; then
+            echo "::error::No macOS updater signature was produced."
+            exit 1
+          fi
+
       - name: Upload macOS updater artifacts
         if: ${{ inputs.release_build }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/reusable-macos-installed-app-smoke.yml
+++ b/.github/workflows/reusable-macos-installed-app-smoke.yml
@@ -134,7 +134,7 @@ jobs:
           # enable automation-driver: Tauri would pack that second binary into
           # the DMG. Driver is a separate CI artifact in the next step.
           if [ "${RELEASE_BUILD}" = "true" ]; then
-            pnpm tauri build --ci --bundles dmg --target "${TAURI_TARGET}" --features automation-smoke --config src-tauri/tauri.release.conf.json -- --bin openkara
+            pnpm tauri build --ci --bundles app,dmg --target "${TAURI_TARGET}" --features automation-smoke --config src-tauri/tauri.release.conf.json -- --bin openkara
           else
             pnpm tauri build --ci --bundles dmg --target "${TAURI_TARGET}" --features automation-smoke --no-sign -- --bin openkara
           fi
@@ -180,7 +180,7 @@ jobs:
           path: |
             src-tauri/target/${{ inputs.rust_target }}/release/bundle/**/*.tar.gz
             src-tauri/target/${{ inputs.rust_target }}/release/bundle/**/*.sig
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: ${{ inputs.retention_days }}
 
   clean-install:

--- a/.github/workflows/reusable-windows-installed-app.yml
+++ b/.github/workflows/reusable-windows-installed-app.yml
@@ -256,7 +256,7 @@ jobs:
           path: |
             src-tauri/target/release/bundle/**/*.nsis.zip
             src-tauri/target/release/bundle/**/*.nsis.zip.sig
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: ${{ inputs.retention_days }}
 
   clean-install:

--- a/.github/workflows/reusable-windows-installed-app.yml
+++ b/.github/workflows/reusable-windows-installed-app.yml
@@ -248,6 +248,17 @@ jobs:
           if-no-files-found: error
           retention-days: ${{ inputs.retention_days }}
 
+      - name: Validate Windows updater artifacts
+        if: ${{ inputs.release_build }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $bundleDir = "src-tauri/target/release/bundle"
+          $archive = Get-ChildItem -Path $bundleDir -Filter "*.nsis.zip" -File -Recurse | Select-Object -First 1
+          $signature = Get-ChildItem -Path $bundleDir -Filter "*.nsis.zip.sig" -File -Recurse | Select-Object -First 1
+          if ($null -eq $archive) { throw "No Windows updater archive was produced." }
+          if ($null -eq $signature) { throw "No Windows updater signature was produced." }
+
       - name: Upload Windows updater artifacts
         if: ${{ inputs.release_build }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -3,5 +3,11 @@
   "singleQuote": false,
   "trailingComma": "all",
   "printWidth": 80,
-  "ignorePatterns": ["dist", "node_modules", "src-tauri", "**/*.toml"]
+  "ignorePatterns": [
+    "dist",
+    "node_modules",
+    "src-tauri",
+    "**/*.toml",
+    "CHANGELOG.md"
+  ]
 }

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -214,9 +214,47 @@ describe("release workflow", () => {
     expect(macOSWorkflow).toContain(
       "name: ${{ inputs.artifact_prefix }}-updater",
     );
-    expect(macOSWorkflow).toContain("Validate macOS updater artifacts");
-    expect(linuxWorkflow).toContain("Validate Linux updater artifacts");
-    expect(windowsWorkflow).toContain("Validate Windows updater artifacts");
+    const macOSValidationStep = readWorkflowStep(
+      macOSWorkflow,
+      "Validate macOS updater artifacts",
+    );
+    expect(macOSValidationStep).toContain("if: ${{ inputs.release_build }}");
+    expect(macOSValidationStep).toContain('-name "*.tar.gz"');
+    expect(macOSValidationStep).toContain('-name "*.sig"');
+    expect(macOSValidationStep).toContain(
+      "No macOS updater archive was produced.",
+    );
+    expect(macOSValidationStep).toContain(
+      "No macOS updater signature was produced.",
+    );
+
+    const linuxValidationStep = readWorkflowStep(
+      linuxWorkflow,
+      "Validate Linux updater artifacts",
+    );
+    expect(linuxValidationStep).toContain("if: ${{ inputs.release_build }}");
+    expect(linuxValidationStep).toContain('-name "*.tar.gz"');
+    expect(linuxValidationStep).toContain('-name "*.sig"');
+    expect(linuxValidationStep).toContain(
+      "No Linux updater archive was produced.",
+    );
+    expect(linuxValidationStep).toContain(
+      "No Linux updater signature was produced.",
+    );
+
+    const windowsValidationStep = readWorkflowStep(
+      windowsWorkflow,
+      "Validate Windows updater artifacts",
+    );
+    expect(windowsValidationStep).toContain("if: ${{ inputs.release_build }}");
+    expect(windowsValidationStep).toContain('-Filter "*.nsis.zip"');
+    expect(windowsValidationStep).toContain('-Filter "*.nsis.zip.sig"');
+    expect(windowsValidationStep).toContain(
+      "No Windows updater archive was produced.",
+    );
+    expect(windowsValidationStep).toContain(
+      "No Windows updater signature was produced.",
+    );
 
     const macOSUpdaterStep = readWorkflowStep(
       macOSWorkflow,

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -178,6 +178,34 @@ describe("release workflow", () => {
     );
   });
 
+  test("builds and requires macOS updater artifacts in release smoke", () => {
+    const macOSWorkflow = readProjectFile(
+      ".github/workflows/reusable-macos-installed-app-smoke.yml",
+    );
+    const linuxWorkflow = readProjectFile(
+      ".github/workflows/reusable-linux-installed-app-smoke.yml",
+    );
+    const windowsWorkflow = readProjectFile(
+      ".github/workflows/reusable-windows-installed-app.yml",
+    );
+
+    expect(macOSWorkflow).toContain(
+      'tauri build --ci --bundles app,dmg --target "${TAURI_TARGET}"',
+    );
+    expect(macOSWorkflow).toContain(
+      "name: ${{ inputs.artifact_prefix }}-updater",
+    );
+    expect(macOSWorkflow).toMatch(
+      /- name: Upload macOS updater artifacts[\s\S]*?if-no-files-found: error/,
+    );
+    expect(linuxWorkflow).toMatch(
+      /- name: Upload Linux updater artifacts[\s\S]*?if-no-files-found: error/,
+    );
+    expect(windowsWorkflow).toMatch(
+      /- name: Upload Windows updater artifacts[\s\S]*?if-no-files-found: error/,
+    );
+  });
+
   test("fails fast when the release tag and package.json version disagree", () => {
     // The bundle version comes from package.json (scripts/sync-version.mjs),
     // while the tag drives asset naming and the winget/flatpak manifests. If

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -9,6 +9,25 @@ function readProjectFile(path: string) {
   return readFileSync(join(projectRoot, path), "utf8");
 }
 
+function readWorkflowStep(workflow: string, name: string) {
+  const marker = `      - name: ${name}`;
+  const start = workflow.indexOf(marker);
+  if (start === -1) {
+    return "";
+  }
+
+  const bodyStart = start + marker.length;
+  const nextStep = workflow.indexOf("\n      - name:", bodyStart);
+  const nextJobOffset = workflow.slice(bodyStart).search(/\n  [A-Za-z0-9_-]+:/);
+  const nextJob = nextJobOffset === -1 ? -1 : bodyStart + nextJobOffset;
+  const end =
+    [nextStep, nextJob]
+      .filter((index) => index >= 0)
+      .sort((left, right) => left - right)[0] ?? workflow.length;
+
+  return workflow.slice(start, end);
+}
+
 describe("release workflow", () => {
   test("gates release publishing on release-only native and installed-app smoke", () => {
     const releaseWorkflow = readProjectFile(".github/workflows/release.yml");
@@ -195,15 +214,45 @@ describe("release workflow", () => {
     expect(macOSWorkflow).toContain(
       "name: ${{ inputs.artifact_prefix }}-updater",
     );
-    expect(macOSWorkflow).toMatch(
-      /- name: Upload macOS updater artifacts[\s\S]*?if-no-files-found: error/,
+    expect(macOSWorkflow).toContain("Validate macOS updater artifacts");
+    expect(linuxWorkflow).toContain("Validate Linux updater artifacts");
+    expect(windowsWorkflow).toContain("Validate Windows updater artifacts");
+
+    const macOSUpdaterStep = readWorkflowStep(
+      macOSWorkflow,
+      "Upload macOS updater artifacts",
     );
-    expect(linuxWorkflow).toMatch(
-      /- name: Upload Linux updater artifacts[\s\S]*?if-no-files-found: error/,
+    expect(macOSUpdaterStep).toContain(
+      "src-tauri/target/${{ inputs.rust_target }}/release/bundle/**/*.tar.gz",
     );
-    expect(windowsWorkflow).toMatch(
-      /- name: Upload Windows updater artifacts[\s\S]*?if-no-files-found: error/,
+    expect(macOSUpdaterStep).toContain(
+      "src-tauri/target/${{ inputs.rust_target }}/release/bundle/**/*.sig",
     );
+    expect(macOSUpdaterStep).toContain("if-no-files-found: error");
+
+    const linuxUpdaterStep = readWorkflowStep(
+      linuxWorkflow,
+      "Upload Linux updater artifacts",
+    );
+    expect(linuxUpdaterStep).toContain(
+      "src-tauri/target/${{ inputs.rust_target }}/release/bundle/**/*.tar.gz",
+    );
+    expect(linuxUpdaterStep).toContain(
+      "src-tauri/target/${{ inputs.rust_target }}/release/bundle/**/*.sig",
+    );
+    expect(linuxUpdaterStep).toContain("if-no-files-found: error");
+
+    const windowsUpdaterStep = readWorkflowStep(
+      windowsWorkflow,
+      "Upload Windows updater artifacts",
+    );
+    expect(windowsUpdaterStep).toContain(
+      "src-tauri/target/release/bundle/**/*.nsis.zip",
+    );
+    expect(windowsUpdaterStep).toContain(
+      "src-tauri/target/release/bundle/**/*.nsis.zip.sig",
+    );
+    expect(windowsUpdaterStep).toContain("if-no-files-found: error");
   });
 
   test("fails fast when the release tag and package.json version disagree", () => {


### PR DESCRIPTION
## What changed

- Build the macOS release smoke bundle with `app,dmg` so Tauri emits the updater archive as well as the DMG.
- Fail immediately when a release updater artifact is missing on macOS, Linux, or Windows.
- Add regression coverage for the bundle target and required updater uploads.
- Exclude the release-please-managed `CHANGELOG.md` from Oxfmt checks so generated release content is not rewritten by hooks.

## Verification

- `pnpm lint` — PASS
- `pnpm build` — PASS
- `pnpm test` — PASS (195 files, 2225 tests)
- `cd src-tauri && cargo test -q` — PASS (1262 passed, 13 ignored)
- `pnpm tauri build --ci --bundles app,dmg --target aarch64-apple-darwin --features automation-smoke --config src-tauri/tauri.release.conf.json --no-sign -- --bin openkara` — PASS; generated `OpenKara.app.tar.gz` and the DMG
- `pnpm test:release:gate` — PASS
- `pnpm check:standards` — PASS
- `pnpm check:patch-coverage` — PASS
- `actionlint` — PASS
- pre-push hooks — PASS

## Residual risk

The already-started v0.12.0 release run has a stale macOS artifact failure. After this PR merges, rerun the release workflow for tag `v0.12.0` and verify the release assets before publishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release validation across macOS, Linux, and Windows.
  * Builds now fail when required updater artifacts are missing, preventing incomplete release packages from being published.
  * macOS release builds now include both the application bundle and DMG installer.
  * Missing updater files are now reported as errors instead of warnings.

* **Tests**
  * Added automated coverage to verify updater artifact generation and upload behavior across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->