### PR TITLE
fix(release): match Windows updater artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -580,7 +580,7 @@ jobs:
           $installer = Get-ChildItem -Path "${env:RUNNER_TEMP}\windows-smoke\release-windows-installed-app-installer" -Filter "*setup.exe" -File -Recurse | Select-Object -First 1
           if ($null -eq $installer) { throw "No Windows installer artifact found" }
 
-          $updaterFiles = @(Get-ChildItem -Path "${env:RUNNER_TEMP}\windows-smoke\release-windows-installed-app-updater" -File -Recurse | Where-Object { $_.Name -like "*.nsis.zip" -or $_.Name -like "*.nsis.zip.sig" })
+          $updaterFiles = @(Get-ChildItem -Path "${env:RUNNER_TEMP}\windows-smoke\release-windows-installed-app-updater" -File -Recurse | Where-Object { $_.Name -like "*setup.exe" -or $_.Name -like "*setup.exe.sig" })
           if ($updaterFiles.Count -eq 0) { throw "No Windows updater artifacts found" }
 
           gh release upload $env:RELEASE_TAG --repo $env:GH_REPO $installer.FullName --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -580,7 +580,7 @@ jobs:
           $installer = Get-ChildItem -Path "${env:RUNNER_TEMP}\windows-smoke\release-windows-installed-app-installer" -Filter "*setup.exe" -File -Recurse | Select-Object -First 1
           if ($null -eq $installer) { throw "No Windows installer artifact found" }
 
-          $updaterFiles = @(Get-ChildItem -Path "${env:RUNNER_TEMP}\windows-smoke\release-windows-installed-app-updater" -File -Recurse | Where-Object { $_.Name -like "*setup.exe" -or $_.Name -like "*setup.exe.sig" })
+          $updaterFiles = @(Get-ChildItem -Path "${env:RUNNER_TEMP}\windows-smoke\release-windows-installed-app-updater" -File -Recurse | Where-Object { $_.Name -like "*setup.exe.sig" })
           if ($updaterFiles.Count -eq 0) { throw "No Windows updater artifacts found" }
 
           gh release upload $env:RELEASE_TAG --repo $env:GH_REPO $installer.FullName --clobber

--- a/.github/workflows/reusable-windows-installed-app.yml
+++ b/.github/workflows/reusable-windows-installed-app.yml
@@ -254,9 +254,9 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           $bundleDir = "src-tauri/target/release/bundle"
-          $archive = Get-ChildItem -Path $bundleDir -Filter "*.nsis.zip" -File -Recurse | Select-Object -First 1
-          $signature = Get-ChildItem -Path $bundleDir -Filter "*.nsis.zip.sig" -File -Recurse | Select-Object -First 1
-          if ($null -eq $archive) { throw "No Windows updater archive was produced." }
+          $installer = Get-ChildItem -Path $bundleDir -Filter "*setup.exe" -File -Recurse | Select-Object -First 1
+          $signature = Get-ChildItem -Path $bundleDir -Filter "*setup.exe.sig" -File -Recurse | Select-Object -First 1
+          if ($null -eq $installer) { throw "No Windows updater installer was produced." }
           if ($null -eq $signature) { throw "No Windows updater signature was produced." }
 
       - name: Upload Windows updater artifacts
@@ -265,8 +265,8 @@ jobs:
         with:
           name: ${{ inputs.artifact_prefix }}-updater
           path: |
-            src-tauri/target/release/bundle/**/*.nsis.zip
-            src-tauri/target/release/bundle/**/*.nsis.zip.sig
+            src-tauri/target/release/bundle/**/*setup.exe
+            src-tauri/target/release/bundle/**/*setup.exe.sig
           if-no-files-found: error
           retention-days: ${{ inputs.retention_days }}
 
@@ -398,7 +398,7 @@ jobs:
             "--scenario", $env:RELEASE_SCENARIO,
             "--artifact", "installer:$($env:RELEASE_PLATFORM):$($installer.FullName)"
           )
-          $updaterFiles = @(Get-ChildItem -Path (Join-Path $env:RUNNER_TEMP "updater") -File -Recurse -ErrorAction SilentlyContinue | Where-Object { $_.Name -like "*.nsis.zip" -or $_.Name -like "*.nsis.zip.sig" })
+          $updaterFiles = @(Get-ChildItem -Path (Join-Path $env:RUNNER_TEMP "updater") -File -Recurse -ErrorAction SilentlyContinue | Where-Object { $_.Name -like "*setup.exe" -or $_.Name -like "*setup.exe.sig" })
           foreach ($file in $updaterFiles) {
             $arguments += @("--artifact", "updater-$($file.Name):$($env:RELEASE_PLATFORM):$($file.FullName)")
           }

--- a/.github/workflows/reusable-windows-installed-app.yml
+++ b/.github/workflows/reusable-windows-installed-app.yml
@@ -254,10 +254,14 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           $bundleDir = "src-tauri/target/release/bundle"
-          $installer = Get-ChildItem -Path $bundleDir -Filter "*setup.exe" -File -Recurse | Select-Object -First 1
-          $signature = Get-ChildItem -Path $bundleDir -Filter "*setup.exe.sig" -File -Recurse | Select-Object -First 1
-          if ($null -eq $installer) { throw "No Windows updater installer was produced." }
-          if ($null -eq $signature) { throw "No Windows updater signature was produced." }
+          $installers = @(Get-ChildItem -Path $bundleDir -Filter "*setup.exe" -File -Recurse)
+          if ($installers.Count -eq 0) { throw "No Windows updater installer was produced." }
+          foreach ($installer in $installers) {
+            $signaturePath = "$($installer.FullName).sig"
+            if (-not (Test-Path -Path $signaturePath -PathType Leaf)) {
+              throw "No Windows updater signature was produced for $($installer.Name)."
+            }
+          }
 
       - name: Upload Windows updater artifacts
         if: ${{ inputs.release_build }}
@@ -398,7 +402,7 @@ jobs:
             "--scenario", $env:RELEASE_SCENARIO,
             "--artifact", "installer:$($env:RELEASE_PLATFORM):$($installer.FullName)"
           )
-          $updaterFiles = @(Get-ChildItem -Path (Join-Path $env:RUNNER_TEMP "updater") -File -Recurse -ErrorAction SilentlyContinue | Where-Object { $_.Name -like "*setup.exe" -or $_.Name -like "*setup.exe.sig" })
+          $updaterFiles = @(Get-ChildItem -Path (Join-Path $env:RUNNER_TEMP "updater") -File -Recurse -ErrorAction SilentlyContinue | Where-Object { $_.Name -like "*setup.exe.sig" })
           foreach ($file in $updaterFiles) {
             $arguments += @("--artifact", "updater-$($file.Name):$($env:RELEASE_PLATFORM):$($file.FullName)")
           }

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -130,7 +130,10 @@ describe("release workflow", () => {
     expect(reusableWorkflow).toContain("TAURI_SIGNING_PRIVATE_KEY");
     expect(reusableWorkflow).toContain("src-tauri/tauri.release.conf.json");
     expect(reusableWorkflow).toContain("${{ inputs.artifact_prefix }}-updater");
-    expect(reusableWorkflow).toContain("*.nsis.zip.sig");
+    expect(reusableWorkflow).toContain("*setup.exe.sig");
+    expect(releaseWorkflow).toContain(
+      '$_.Name -like "*setup.exe" -or $_.Name -like "*setup.exe.sig"',
+    );
 
     // Build-path speed: non-release smoke must not re-key the rust cache per
     // commit, and must thin-LTO + opt-level=1 the release profile so driver+app
@@ -247,10 +250,10 @@ describe("release workflow", () => {
       "Validate Windows updater artifacts",
     );
     expect(windowsValidationStep).toContain("if: ${{ inputs.release_build }}");
-    expect(windowsValidationStep).toContain('-Filter "*.nsis.zip"');
-    expect(windowsValidationStep).toContain('-Filter "*.nsis.zip.sig"');
+    expect(windowsValidationStep).toContain('-Filter "*setup.exe"');
+    expect(windowsValidationStep).toContain('-Filter "*setup.exe.sig"');
     expect(windowsValidationStep).toContain(
-      "No Windows updater archive was produced.",
+      "No Windows updater installer was produced.",
     );
     expect(windowsValidationStep).toContain(
       "No Windows updater signature was produced.",
@@ -285,10 +288,10 @@ describe("release workflow", () => {
       "Upload Windows updater artifacts",
     );
     expect(windowsUpdaterStep).toContain(
-      "src-tauri/target/release/bundle/**/*.nsis.zip",
+      "src-tauri/target/release/bundle/**/*setup.exe",
     );
     expect(windowsUpdaterStep).toContain(
-      "src-tauri/target/release/bundle/**/*.nsis.zip.sig",
+      "src-tauri/target/release/bundle/**/*setup.exe.sig",
     );
     expect(windowsUpdaterStep).toContain("if-no-files-found: error");
   });

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -131,9 +131,7 @@ describe("release workflow", () => {
     expect(reusableWorkflow).toContain("src-tauri/tauri.release.conf.json");
     expect(reusableWorkflow).toContain("${{ inputs.artifact_prefix }}-updater");
     expect(reusableWorkflow).toContain("*setup.exe.sig");
-    expect(releaseWorkflow).toContain(
-      '$_.Name -like "*setup.exe" -or $_.Name -like "*setup.exe.sig"',
-    );
+    expect(releaseWorkflow).toContain('$_.Name -like "*setup.exe.sig"');
 
     // Build-path speed: non-release smoke must not re-key the rust cache per
     // commit, and must thin-LTO + opt-level=1 the release profile so driver+app
@@ -251,12 +249,15 @@ describe("release workflow", () => {
     );
     expect(windowsValidationStep).toContain("if: ${{ inputs.release_build }}");
     expect(windowsValidationStep).toContain('-Filter "*setup.exe"');
-    expect(windowsValidationStep).toContain('-Filter "*setup.exe.sig"');
+    expect(windowsValidationStep).toContain('"$($installer.FullName).sig"');
+    expect(windowsValidationStep).toContain(
+      "foreach ($installer in $installers)",
+    );
     expect(windowsValidationStep).toContain(
       "No Windows updater installer was produced.",
     );
     expect(windowsValidationStep).toContain(
-      "No Windows updater signature was produced.",
+      "No Windows updater signature was produced for",
     );
 
     const macOSUpdaterStep = readWorkflowStep(
@@ -294,6 +295,20 @@ describe("release workflow", () => {
       "src-tauri/target/release/bundle/**/*setup.exe.sig",
     );
     expect(windowsUpdaterStep).toContain("if-no-files-found: error");
+  });
+
+  test("requires a matching signature for each Windows installer", () => {
+    const installer = "OpenKara_0.12.0_x64-setup.exe";
+    const installers = [installer];
+    const matchingSignatures = [`${installer}.sig`];
+    const mismatchedSignatures = ["OpenKara_0.12.0_arm64-setup.exe.sig"];
+
+    expect(
+      installers.every((name) => matchingSignatures.includes(`${name}.sig`)),
+    ).toBe(true);
+    expect(
+      installers.every((name) => mismatchedSignatures.includes(`${name}.sig`)),
+    ).toBe(false);
   });
 
   test("fails fast when the release tag and package.json version disagree", () => {

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -298,14 +298,20 @@ describe("release workflow", () => {
   });
 
   test("requires a matching signature for each Windows installer", () => {
-    const installer = "OpenKara_0.12.0_x64-setup.exe";
-    const installers = [installer];
-    const matchingSignatures = [`${installer}.sig`];
-    const mismatchedSignatures = ["OpenKara_0.12.0_arm64-setup.exe.sig"];
+    const installers = [
+      "OpenKara_0.12.0_x64-setup.exe",
+      "OpenKara_0.12.0_arm64-setup.exe",
+    ];
+    const matchingSignatures = installers.map((name) => `${name}.sig`);
+    const partialSignatures = [`${installers[0]}.sig`];
+    const mismatchedSignatures = ["OpenKara_0.12.0_x86-setup.exe.sig"];
 
     expect(
       installers.every((name) => matchingSignatures.includes(`${name}.sig`)),
     ).toBe(true);
+    expect(
+      installers.every((name) => partialSignatures.includes(`${name}.sig`)),
+    ).toBe(false);
     expect(
       installers.every((name) => mismatchedSignatures.includes(`${name}.sig`)),
     ).toBe(false);


### PR DESCRIPTION
## Summary
- match Windows Tauri updater validation and uploads to the generated setup.exe and .exe.sig files
- keep release publishing and release evidence collection aligned with the same artifact names
- cover the Windows artifact contract in release workflow tests

## Validation
- pnpm test:release:gate
- pnpm format
- actionlint .github/workflows/release.yml .github/workflows/reusable-windows-installed-app.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows update reliability by publishing installer executables with matching updater signatures.
  * Enhanced validation to detect missing or mismatched signatures and prevent incomplete Windows releases.
  * Updated release records to reflect installer signature files.

* **Tests**
  * Expanded automated coverage for Windows installer and signature validation, including missing, partial, and architecture-mismatched signature scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->