### PR TITLE
fix(release): avoid duplicate Windows installer artifacts

### DIFF
--- a/.github/workflows/reusable-windows-installed-app.yml
+++ b/.github/workflows/reusable-windows-installed-app.yml
@@ -268,9 +268,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.artifact_prefix }}-updater
-          path: |
-            src-tauri/target/release/bundle/**/*setup.exe
-            src-tauri/target/release/bundle/**/*setup.exe.sig
+          path: src-tauri/target/release/bundle/**/*setup.exe.sig
           if-no-files-found: error
           retention-days: ${{ inputs.retention_days }}
 

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -289,10 +289,10 @@ describe("release workflow", () => {
       "Upload Windows updater artifacts",
     );
     expect(windowsUpdaterStep).toContain(
-      "src-tauri/target/release/bundle/**/*setup.exe",
-    );
-    expect(windowsUpdaterStep).toContain(
       "src-tauri/target/release/bundle/**/*setup.exe.sig",
+    );
+    expect(windowsUpdaterStep).not.toContain(
+      "src-tauri/target/release/bundle/**/*setup.exe\n",
     );
     expect(windowsUpdaterStep).toContain("if-no-files-found: error");
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Windows updater releases now upload only signed installer artifacts, improving release integrity and preventing unsigned installers from being distributed.
* **Tests**
  * Updated release validation to confirm that only signature files are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->