### PR TITLE
fix(release): publish only the Linux AppImage updater

### DIFF
--- a/.github/workflows/reusable-linux-installed-app-smoke.yml
+++ b/.github/workflows/reusable-linux-installed-app-smoke.yml
@@ -207,14 +207,14 @@ jobs:
           BUNDLE_DIR: src-tauri/target/${{ inputs.rust_target }}/release/bundle
         run: |
           set -euo pipefail
-          archive="$(find "$BUNDLE_DIR" -type f -name "*.tar.gz" -print -quit)"
-          signature="$(find "$BUNDLE_DIR" -type f -name "*.sig" -print -quit)"
-          if [ -z "$archive" ]; then
-            echo "::error::No Linux updater archive was produced."
+          appimage="$(find "$BUNDLE_DIR/appimage" -maxdepth 1 -type f -name "*.AppImage" -print -quit)"
+          if [ -z "$appimage" ]; then
+            echo "::error::No Linux updater AppImage was produced."
             exit 1
           fi
-          if [ -z "$signature" ]; then
-            echo "::error::No Linux updater signature was produced."
+          signature="${appimage}.sig"
+          if [ ! -f "$signature" ]; then
+            echo "::error::No Linux updater signature was produced for $(basename "$appimage")."
             exit 1
           fi
 
@@ -223,9 +223,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.artifact_prefix }}-updater
-          path: |
-            src-tauri/target/${{ inputs.rust_target }}/release/bundle/**/*.tar.gz
-            src-tauri/target/${{ inputs.rust_target }}/release/bundle/**/*.sig
+          path: src-tauri/target/${{ inputs.rust_target }}/release/bundle/appimage/*.AppImage.sig
           if-no-files-found: error
           retention-days: ${{ inputs.retention_days }}
 
@@ -404,7 +402,7 @@ jobs:
           artifact_args+=(--artifact "deb:${RELEASE_PLATFORM}:${candidate_deb}")
           while IFS= read -r -d '' artifact; do
             artifact_args+=(--artifact "updater-${artifact##*/}:${RELEASE_PLATFORM}:${artifact}")
-          done < <(find "${RUNNER_TEMP}/updater" -type f \( -name "*.tar.gz" -o -name "*.sig" \) -print0)
+          done < <(find "${RUNNER_TEMP}/updater" -type f -name "*.AppImage.sig" -print0)
           "$evidence_driver" fragment-from-automation-report \
             --input "$SMOKE_ROOT/automation-report.json" \
             --repository "$GITHUB_REPOSITORY" \

--- a/.github/workflows/reusable-linux-installed-app-smoke.yml
+++ b/.github/workflows/reusable-linux-installed-app-smoke.yml
@@ -207,11 +207,12 @@ jobs:
           BUNDLE_DIR: src-tauri/target/${{ inputs.rust_target }}/release/bundle
         run: |
           set -euo pipefail
-          appimage="$(find "$BUNDLE_DIR/appimage" -maxdepth 1 -type f -name "*.AppImage" -print -quit)"
-          if [ -z "$appimage" ]; then
-            echo "::error::No Linux updater AppImage was produced."
+          mapfile -d '' appimages < <(find "$BUNDLE_DIR/appimage" -maxdepth 1 -type f -name "*.AppImage" -print0)
+          if ((${#appimages[@]} != 1)); then
+            echo "::error::Expected exactly one Linux updater AppImage, found ${#appimages[@]}."
             exit 1
           fi
+          appimage="${appimages[0]}"
           signature="${appimage}.sig"
           if [ ! -f "$signature" ]; then
             echo "::error::No Linux updater signature was produced for $(basename "$appimage")."

--- a/.github/workflows/reusable-linux-installed-app-smoke.yml
+++ b/.github/workflows/reusable-linux-installed-app-smoke.yml
@@ -213,18 +213,22 @@ jobs:
             exit 1
           fi
           appimage="${appimages[0]}"
-          signature="${appimage}.sig"
-          if [ ! -f "$signature" ]; then
-            echo "::error::No Linux updater signature was produced for $(basename "$appimage")."
+          mapfile -d '' signatures < <(find "$BUNDLE_DIR/appimage" -maxdepth 1 -type f -name "*.AppImage.sig" -print0)
+          if ((${#signatures[@]} != 1)) || [[ "${signatures[0]}" != "${appimage}.sig" ]]; then
+            echo "::error::Expected exactly one Linux updater signature matching $(basename "$appimage")."
             exit 1
           fi
+          signature="${signatures[0]}"
+          updater_dir="${RUNNER_TEMP}/linux-updater"
+          mkdir -p "$updater_dir"
+          cp "$signature" "$updater_dir/"
 
       - name: Upload Linux updater artifacts
         if: ${{ inputs.release_build }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.artifact_prefix }}-updater
-          path: src-tauri/target/${{ inputs.rust_target }}/release/bundle/appimage/*.AppImage.sig
+          path: ${{ runner.temp }}/linux-updater
           if-no-files-found: error
           retention-days: ${{ inputs.retention_days }}
 

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -235,13 +235,17 @@ describe("release workflow", () => {
     );
     expect(linuxValidationStep).toContain("if: ${{ inputs.release_build }}");
     expect(linuxValidationStep).toContain('-name "*.AppImage"');
+    expect(linuxValidationStep).toContain("mapfile -d '' appimages");
+    expect(linuxValidationStep).toContain("${#appimages[@]} != 1");
     expect(linuxValidationStep).toContain('signature="${appimage}.sig"');
     expect(linuxValidationStep).toContain(
-      "No Linux updater AppImage was produced.",
+      "Expected exactly one Linux updater AppImage",
     );
     expect(linuxValidationStep).toContain(
       "No Linux updater signature was produced for",
     );
+    expect(linuxValidationStep).not.toContain("tar.gz");
+    expect(linuxValidationStep).not.toContain('name "*.sig"');
 
     const windowsValidationStep = readWorkflowStep(
       windowsWorkflow,
@@ -280,6 +284,8 @@ describe("release workflow", () => {
       "src-tauri/target/${{ inputs.rust_target }}/release/bundle/appimage/*.AppImage.sig",
     );
     expect(linuxUpdaterStep).toContain("if-no-files-found: error");
+    expect(linuxUpdaterStep).not.toContain("tar.gz");
+    expect(linuxUpdaterStep).not.toContain("*.sig");
 
     const linuxEvidenceStep = readWorkflowStep(
       linuxWorkflow,
@@ -289,6 +295,7 @@ describe("release workflow", () => {
       'find "${RUNNER_TEMP}/updater" -type f -name "*.AppImage.sig"',
     );
     expect(linuxEvidenceStep).not.toContain('name "*.tar.gz"');
+    expect(linuxEvidenceStep).not.toContain('name "*.sig"');
 
     const windowsUpdaterStep = readWorkflowStep(
       windowsWorkflow,

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -234,13 +234,13 @@ describe("release workflow", () => {
       "Validate Linux updater artifacts",
     );
     expect(linuxValidationStep).toContain("if: ${{ inputs.release_build }}");
-    expect(linuxValidationStep).toContain('-name "*.tar.gz"');
-    expect(linuxValidationStep).toContain('-name "*.sig"');
+    expect(linuxValidationStep).toContain('-name "*.AppImage"');
+    expect(linuxValidationStep).toContain('signature="${appimage}.sig"');
     expect(linuxValidationStep).toContain(
-      "No Linux updater archive was produced.",
+      "No Linux updater AppImage was produced.",
     );
     expect(linuxValidationStep).toContain(
-      "No Linux updater signature was produced.",
+      "No Linux updater signature was produced for",
     );
 
     const windowsValidationStep = readWorkflowStep(
@@ -277,12 +277,18 @@ describe("release workflow", () => {
       "Upload Linux updater artifacts",
     );
     expect(linuxUpdaterStep).toContain(
-      "src-tauri/target/${{ inputs.rust_target }}/release/bundle/**/*.tar.gz",
-    );
-    expect(linuxUpdaterStep).toContain(
-      "src-tauri/target/${{ inputs.rust_target }}/release/bundle/**/*.sig",
+      "src-tauri/target/${{ inputs.rust_target }}/release/bundle/appimage/*.AppImage.sig",
     );
     expect(linuxUpdaterStep).toContain("if-no-files-found: error");
+
+    const linuxEvidenceStep = readWorkflowStep(
+      linuxWorkflow,
+      "Generate Rust release evidence fragment",
+    );
+    expect(linuxEvidenceStep).toContain(
+      'find "${RUNNER_TEMP}/updater" -type f -name "*.AppImage.sig"',
+    );
+    expect(linuxEvidenceStep).not.toContain('name "*.tar.gz"');
 
     const windowsUpdaterStep = readWorkflowStep(
       windowsWorkflow,

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -237,13 +237,18 @@ describe("release workflow", () => {
     expect(linuxValidationStep).toContain('-name "*.AppImage"');
     expect(linuxValidationStep).toContain("mapfile -d '' appimages");
     expect(linuxValidationStep).toContain("${#appimages[@]} != 1");
-    expect(linuxValidationStep).toContain('signature="${appimage}.sig"');
+    expect(linuxValidationStep).toContain("mapfile -d '' signatures");
+    expect(linuxValidationStep).toContain("${#signatures[@]} != 1");
+    expect(linuxValidationStep).toContain(
+      '"${signatures[0]}" != "${appimage}.sig"',
+    );
     expect(linuxValidationStep).toContain(
       "Expected exactly one Linux updater AppImage",
     );
     expect(linuxValidationStep).toContain(
-      "No Linux updater signature was produced for",
+      "Expected exactly one Linux updater signature matching",
     );
+    expect(linuxValidationStep).toContain('cp "$signature" "$updater_dir/"');
     expect(linuxValidationStep).not.toContain("tar.gz");
     expect(linuxValidationStep).not.toContain('name "*.sig"');
 
@@ -281,7 +286,7 @@ describe("release workflow", () => {
       "Upload Linux updater artifacts",
     );
     expect(linuxUpdaterStep).toContain(
-      "src-tauri/target/${{ inputs.rust_target }}/release/bundle/appimage/*.AppImage.sig",
+      "path: ${{ runner.temp }}/linux-updater",
     );
     expect(linuxUpdaterStep).toContain("if-no-files-found: error");
     expect(linuxUpdaterStep).not.toContain("tar.gz");


### PR DESCRIPTION
## Summary
- Restrict Linux updater artifacts to the signed AppImage payload.
- Keep Debian packages available as installers without adding a second updater payload for the same target.
- Add release-workflow assertions for exact Linux updater paths so Debian archive internals cannot enter release evidence.

## Root cause
The recursive Linux updater glob collected `control.tar.gz` and `data.tar.gz` from the Debian bundle and both AppImage/deb signatures, so metadata generation correctly rejected multiple updater payloads for `linux-x86_64`.

## Validation
- `pnpm test:release:gate`
- `actionlint .github/workflows/reusable-linux-installed-app-smoke.yml .github/workflows/release.yml`
- Pre-push: 195 test files, 2226 tests passed; lint, formatting, Cargo formatting, and patch coverage passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Linux release validation to verify signed AppImage artifacts and their matching signatures.
  - Updated release evidence to include only valid AppImage signature files, excluding unrelated archive signatures.
  - Strengthened publishing checks to ensure Linux updater packages and signatures are complete and correctly matched.
  - Reduced the risk of distributing unsupported or incorrectly signed Linux downloads.

- **Tests**
  - Expanded automated coverage for AppImage discovery, signature matching, and rejection of unsupported artifact formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->