### PR TITLE
fix(release): include macOS updater archive in metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -553,7 +553,7 @@ jobs:
           set -euo pipefail
           mkdir -p artifacts
           gh release download "${RELEASE_TAG}" --pattern "release-evidence.json" --dir artifacts --clobber
-          gh release download "${RELEASE_TAG}" --pattern "OpenKara_*" --dir artifacts --clobber
+          gh release download "${RELEASE_TAG}" --pattern "OpenKara*" --dir artifacts --clobber
           driver="${RUNNER_TEMP}/evidence-driver/openkara_release_evidence"
           chmod +x "$driver"
           "$driver" latest \

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -88,6 +88,9 @@ describe("release workflow", () => {
     expect(releaseWorkflow).toContain("verify-assets");
     expect(releaseWorkflow).toContain("--output latest.json");
     expect(releaseWorkflow).toContain("--output SHA256SUMS");
+    expect(releaseWorkflow).toContain(
+      'gh release download "${RELEASE_TAG}" --pattern "OpenKara*"',
+    );
     expect(releaseWorkflow).toContain("gh release upload");
     expect(releaseWorkflow).toContain("--clobber");
     expect(releaseWorkflow).toContain("updater_target: windows-x86_64");


### PR DESCRIPTION
## Summary
- download all OpenKara release assets before generating latest.json and SHA256SUMS
- add a workflow contract assertion for the macOS updater archive name

## Validation
- `pnpm exec vitest run tests/release-workflow.test.ts`
- `actionlint .github/workflows/release.yml`
- pre-push checks: 195 test files, 2226 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release metadata generation now downloads all release assets with the `OpenKara` prefix, ensuring relevant assets are included consistently.

* **Tests**
  * Added coverage to verify that all matching release assets are downloaded for the current release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->