### PR TITLE
fix(release): separate macOS updater assets

### DIFF
--- a/.github/workflows/reusable-macos-installed-app-smoke.yml
+++ b/.github/workflows/reusable-macos-installed-app-smoke.yml
@@ -176,27 +176,38 @@ jobs:
         if: ${{ inputs.release_build }}
         env:
           BUNDLE_DIR: src-tauri/target/${{ inputs.rust_target }}/release/bundle
+          RELEASE_TARGET: ${{ inputs.updater_target }}
+          RELEASE_VERSION: ${{ inputs.openkara_version }}
+          UPDATER_DIR: ${{ runner.temp }}/macos-updater
         run: |
           set -euo pipefail
+          archive_count="$(find "$BUNDLE_DIR" -type f -name "*.tar.gz" -print | wc -l | tr -d '[:space:]')"
+          if [ "$archive_count" -ne 1 ]; then
+            echo "::error::Expected exactly one macOS updater archive, found ${archive_count}."
+            exit 1
+          fi
           archive="$(find "$BUNDLE_DIR" -type f -name "*.tar.gz" -print -quit)"
-          signature="$(find "$BUNDLE_DIR" -type f -name "*.sig" -print -quit)"
-          if [ -z "$archive" ]; then
+          signature="${archive}.sig"
+          if [ ! -f "$archive" ]; then
             echo "::error::No macOS updater archive was produced."
             exit 1
           fi
-          if [ -z "$signature" ]; then
+          if [ ! -f "$signature" ]; then
             echo "::error::No macOS updater signature was produced."
             exit 1
           fi
+
+          updater_name="OpenKara_${RELEASE_VERSION}_${RELEASE_TARGET}.app.tar.gz"
+          mkdir -p "$UPDATER_DIR"
+          cp "$archive" "$UPDATER_DIR/$updater_name"
+          cp "$signature" "$UPDATER_DIR/$updater_name.sig"
 
       - name: Upload macOS updater artifacts
         if: ${{ inputs.release_build }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.artifact_prefix }}-updater
-          path: |
-            src-tauri/target/${{ inputs.rust_target }}/release/bundle/**/*.tar.gz
-            src-tauri/target/${{ inputs.rust_target }}/release/bundle/**/*.sig
+          path: ${{ runner.temp }}/macos-updater
           if-no-files-found: error
           retention-days: ${{ inputs.retention_days }}
 

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -224,7 +224,18 @@ describe("release workflow", () => {
     );
     expect(macOSValidationStep).toContain("if: ${{ inputs.release_build }}");
     expect(macOSValidationStep).toContain('-name "*.tar.gz"');
-    expect(macOSValidationStep).toContain('-name "*.sig"');
+    expect(macOSValidationStep).toContain(
+      "RELEASE_TARGET: ${{ inputs.updater_target }}",
+    );
+    expect(macOSValidationStep).toContain(
+      'updater_name="OpenKara_${RELEASE_VERSION}_${RELEASE_TARGET}.app.tar.gz"',
+    );
+    expect(macOSValidationStep).toContain(
+      'cp "$archive" "$UPDATER_DIR/$updater_name"',
+    );
+    expect(macOSValidationStep).toContain(
+      'cp "$signature" "$UPDATER_DIR/$updater_name.sig"',
+    );
     expect(macOSValidationStep).toContain(
       "No macOS updater archive was produced.",
     );
@@ -277,12 +288,17 @@ describe("release workflow", () => {
       "Upload macOS updater artifacts",
     );
     expect(macOSUpdaterStep).toContain(
-      "src-tauri/target/${{ inputs.rust_target }}/release/bundle/**/*.tar.gz",
-    );
-    expect(macOSUpdaterStep).toContain(
-      "src-tauri/target/${{ inputs.rust_target }}/release/bundle/**/*.sig",
+      "path: ${{ runner.temp }}/macos-updater",
     );
     expect(macOSUpdaterStep).toContain("if-no-files-found: error");
+
+    const macOSEvidenceStep = readWorkflowStep(
+      macOSWorkflow,
+      "Generate Rust release evidence fragment",
+    );
+    expect(macOSEvidenceStep).toContain(
+      'find "${RUNNER_TEMP}/updater" -type f',
+    );
 
     const linuxUpdaterStep = readWorkflowStep(
       linuxWorkflow,


### PR DESCRIPTION
## Summary
- give each macOS updater archive a target-specific release asset name
- validate one archive and its matching signature before upload
- keep release evidence, latest.json, and SHA256SUMS aligned with unique assets

## Validation
- `pnpm test:release:gate`
- `actionlint .github/workflows/reusable-macos-installed-app-smoke.yml .github/workflows/release.yml`
- pre-push checks: 195 test files, 2226 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS updater release validation to ensure exactly one archive and its matching signature are included.
  * Standardized updater artifact names using the release version and target.
  * Prevented ambiguous or incomplete updater artifacts from being uploaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->