### PR TITLE
fix(ci): scope release workflow permissions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,8 @@ concurrency:
   group: release-please-${{ github.ref }}
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   release-please:
     name: Release Please


### PR DESCRIPTION
## What changed

Add an explicit top-level `permissions: {}` block to `.github/workflows/release-please.yml`.

## Why

zizmor alert #407 reported that the workflow relied on repository-default permissions. Job-level permissions remain unchanged and continue to grant only the access each release job needs.

## Verification

- `actionlint .github/workflows/release-please.yml`
- `zizmor --pedantic --min-severity low .github/workflows/release-please.yml`
- `pnpm lint`
- `pnpm build`
- `pnpm test` — 2226 passed
- `cd src-tauri && cargo test -q` — 1262 passed, 13 ignored
- `pnpm tauri build`
- pre-push checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened automated release workflow security by disabling default permissions unless explicitly granted to individual jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->