### PR TITLE
fix(ci): re-create draft releases bound to the real tag

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -76,10 +76,11 @@ jobs:
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push
 
-  # GITHUB_TOKEN events do not start other workflows. release-please may also
-  # leave a draft release with an untagged-* placeholder. Ensure the tag
-  # exists, bind the draft release to it, apply the release footer, then
-  # dispatch Release explicitly.
+  # GITHUB_TOKEN events do not start other workflows. release-please also
+  # leaves its draft release tagged untagged-*: it creates the draft before
+  # the tag exists, and GitHub never binds such a draft afterwards. Ensure
+  # the tag exists, re-create the draft bound to it, apply the release
+  # footer, then dispatch Release explicitly.
   ensure-tag-and-dispatch-release:
     name: Ensure tag and dispatch Release
     needs: [release-please, sync-native-versions]
@@ -115,6 +116,22 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+          # Tag pushes from GITHUB_TOKEN do not start other workflows, so a
+          # dispatched Release run is the only ship path. Bail when one is
+          # already in flight for this tag instead of rebuilding its drafts.
+          existing_run="$(gh run list \
+            --repo "${GH_REPO}" \
+            --workflow release.yml \
+            --branch "${TAG_NAME}" \
+            --limit 5 \
+            --json databaseId,status,event,url \
+            --jq '[.[] | select(.status == "queued" or .status == "in_progress" or .status == "pending" or .status == "waiting")] | .[0].url // empty')"
+          if [ -n "${existing_run}" ]; then
+            echo "Release workflow already running for ${TAG_NAME}: ${existing_run}"
+            echo "Skipping draft repair and workflow_dispatch"
+            exit 0
+          fi
+
           # Prefer main HEAD after native-manifest sync so the tag tree matches
           # package.json + Cargo.toml. Fall back to release-please's SHA.
           target_sha="$(git rev-parse HEAD)"
@@ -134,55 +151,58 @@ jobs:
             git push origin "refs/tags/${TAG_NAME}"
           fi
 
-          # Draft releases created without a git ref show as untagged-*. Find
-          # an existing formal draft first. If only an untagged draft exists,
-          # create a second draft with the real tag after the tag is present.
-          # GitHub does not support changing an existing draft's tag in place.
-          release_id="$(gh api "repos/${GH_REPO}/releases" --paginate \
-            --jq "[.[] | select(.draft == true and .tag_name == \"${TAG_NAME}\")] | .[0].id // empty")"
-          if [ -z "${release_id}" ]; then
-            source_release_id="$(gh api "repos/${GH_REPO}/releases" --paginate \
-              --jq "[.[] | select(.draft == true and .name == \"${TAG_NAME}\")] | .[0].id // empty")"
-          fi
-          if [ -z "${release_id}" ] && [ -z "${source_release_id:-}" ]; then
+          # release-please creates its draft release before the tag exists.
+          # GitHub rewrites such drafts to untagged-* and never binds them, so
+          # a draft's tag_name can claim a binding that GitHub later removes.
+          # Match the draft by name only and always create a fresh formal
+          # draft AFTER the tag is present; GitHub does not rewrite drafts
+          # whose tag exists, and it does not support changing a draft's tag
+          # in place.
+          source_release_id="$(gh api "repos/${GH_REPO}/releases" --paginate \
+            --jq "[.[] | select(.draft == true and .name == \"${TAG_NAME}\")] | .[0].id // empty")"
+          if [ -z "${source_release_id}" ]; then
             source_release_id="$(gh api "repos/${GH_REPO}/releases" --paginate \
               --jq "[.[] | select(.draft == true and .name == \"OpenKara ${TAG_NAME}\")] | .[0].id // empty")"
           fi
-          if [ -z "${release_id}" ] && [ -z "${source_release_id:-}" ]; then
+          if [ -z "${source_release_id}" ]; then
             echo "::error::No draft GitHub Release was found for ${TAG_NAME}."
             exit 1
           fi
 
-          if [ -z "${release_id}" ]; then
-            source_endpoint="repos/${GH_REPO}/releases/${source_release_id}"
-            release_name="$(gh api "${source_endpoint}" --jq '.name // empty')"
-            if [ -z "${release_name}" ]; then
-              echo "::error::Draft GitHub Release ${source_release_id} has no name."
-              exit 1
-            fi
-            gh api "${source_endpoint}" --jq '.body // empty' > RELEASE_NOTES.md
-            if ! grep -Fq "## Installation" RELEASE_NOTES.md; then
-              printf '\n\n' >> RELEASE_NOTES.md
-              cat .github/release-notes-installation.md >> RELEASE_NOTES.md
-            fi
-            release_id="$(gh api --method POST "repos/${GH_REPO}/releases" \
-              -f "tag_name=${TAG_NAME}" \
-              -f "target_commitish=${target_sha}" \
-              -f "name=${release_name}" \
-              -F "draft=true" \
-              -F "body=@RELEASE_NOTES.md" \
-              --jq '.id')"
-            echo "Created formal draft release ${release_id} for ${TAG_NAME}"
+          source_endpoint="repos/${GH_REPO}/releases/${source_release_id}"
+          release_name="$(gh api "${source_endpoint}" --jq '.name // empty')"
+          if [ -z "${release_name}" ]; then
+            echo "::error::Draft GitHub Release ${source_release_id} has no name."
+            exit 1
           fi
-
-          release_endpoint="repos/${GH_REPO}/releases/${release_id}"
-          gh api "${release_endpoint}" --jq '.body // empty' > RELEASE_NOTES.md
+          gh api "${source_endpoint}" --jq '.body // empty' > RELEASE_NOTES.md
           if ! grep -Fq "## Installation" RELEASE_NOTES.md; then
             printf '\n\n' >> RELEASE_NOTES.md
             cat .github/release-notes-installation.md >> RELEASE_NOTES.md
-            gh api --method PATCH "${release_endpoint}" \
-              -F "body=@RELEASE_NOTES.md" >/dev/null
           fi
+
+          release_id="$(gh api --method POST "repos/${GH_REPO}/releases" \
+            -f "tag_name=${TAG_NAME}" \
+            -f "target_commitish=${target_sha}" \
+            -f "name=${release_name}" \
+            -F "draft=true" \
+            -F "body=@RELEASE_NOTES.md" \
+            --jq '.id')"
+          echo "Created formal draft release ${release_id} for ${TAG_NAME} at ${target_sha}"
+
+          # Keep exactly one draft for this tag: the fresh formal draft. The
+          # in-flight check above guarantees no running Release run still
+          # references the stale drafts.
+          stale_releases="$(gh api "repos/${GH_REPO}/releases" --paginate \
+            --jq "[.[] | select(.draft == true and (.name == \"${TAG_NAME}\" or .name == \"OpenKara ${TAG_NAME}\" or .tag_name == \"${TAG_NAME}\")) | .id] | join(\" \")")"
+          for stale_id in ${stale_releases}; do
+            if [ "${stale_id}" = "${release_id}" ]; then
+              continue
+            fi
+            gh api --method DELETE "repos/${GH_REPO}/releases/${stale_id}" >/dev/null \
+              || echo "Warning: could not delete stale draft release ${stale_id}"
+          done
+
           echo "Verified formal draft release ${release_id} for ${TAG_NAME} at ${target_sha}"
           echo "Applied release installation notes to ${TAG_NAME}"
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -7,18 +7,22 @@ every push to `main` and maintains a running release PR that bumps
 `.release-please-manifest.json`.
 
 When the release PR is merged, release-please opens a **draft** GitHub
-Release with changelog notes. The Release Please workflow creates the final
-tag, ensures the draft release is bound to that tag, applies the installation
-section, and dispatches the Release workflow. The Release workflow also
-supports manual dispatch for an existing draft release.
+Release with changelog notes. release-please creates the draft before the
+git tag exists. GitHub leaves such drafts tagged `untagged-*` and never
+binds them afterwards. The Release Please workflow therefore creates the
+final tag, re-creates the draft release bound to that tag (copying the
+release-please notes), applies the installation section, and dispatches the
+Release workflow. The Release workflow also supports manual dispatch for an
+existing draft release.
 
 The Release Please workflow:
 
 1. Syncs native manifests (`Cargo.toml`, `tauri.conf.json`, …) via
    `scripts/sync-version.mjs`.
-2. Ensures the git tag `vX.Y.Z` exists (draft releases can land untagged
-   when only `GITHUB_TOKEN` is used).
-3. Creates a formal draft when the provider leaves only an untagged draft.
+2. Ensures the git tag `vX.Y.Z` exists on the post-sync `main` HEAD.
+3. Re-creates the draft release bound to that tag. The job matches the
+   release-please draft by name, creates a fresh draft after the tag
+   exists, and deletes the stale drafts for the same tag.
 4. Applies `.github/release-notes-installation.md`. The template includes
    Homebrew and WinGet install commands.
 5. Dispatches the [`Release` workflow](../.github/workflows/release.yml)
@@ -45,9 +49,11 @@ gates are the automated quality gate. There is no separate manual Publish
 click on the GitHub Release page for plain version tags.
 
 Release Please owns the version, changelog text, draft release, and final
-release body. The Release workflow owns the tested asset pipeline. Set
-`force-tag-creation` so a draft release has its real tag. Keep the installation
-section in the checked-in template file and apply it from the Release Please
+release body. The Release workflow owns the tested asset pipeline. Keep
+`force-tag-creation` so release-please pushes the real tag; the ensure job
+still re-creates the draft bound to it because GitHub never binds a draft
+that release-please created before the tag. Keep the installation section
+in the checked-in template file and apply it from the Release Please
 workflow. The release-please config has no static release-body template
 setting.
 
@@ -64,13 +70,18 @@ setting.
    commit on `main`). The sync job may push a follow-up commit with
    `GITHUB_TOKEN`. That push does not re-run full CI, so `main` HEAD can
    look green while the release cut failed on the previous commit. The
-   workflow must create (or repair) `vX.Y.Z` and start a Release run. If
-   either is missing, create the tag on the release commit and run
+   workflow must create (or repair) `vX.Y.Z`, re-create the draft release
+   bound to it, and start a Release run. If either is missing, create the
+   tag on the release commit, bind a draft release to it, and run
    `gh workflow run release.yml --ref vX.Y.Z -f version=X.Y.Z`. A failed
    cut also opens a GitHub issue titled `Release cut failed for vX.Y.Z`.
-3. **Watch the Release workflow.** It runs smoke tests, uploads assets,
-   publishes the GitHub Release, then submits WinGet and Flatpak when
-   configured.
+3. **Watch the Release workflow.** It requires a successful Nightly
+   hardening run for the tag commit from the last 24 hours. The nightly
+   cron runs at 04:00 UTC on `main`. When the tag points at a commit the
+   nightly has not covered, dispatch `nightly-hardening.yml` on `main`
+   first, or wait for the next cron run. The workflow then runs smoke
+   tests, uploads assets, publishes the GitHub Release, and submits WinGet
+   and Flatpak when configured.
 4. **Confirm the published release.** Asset names match the tag, e.g.
    `OpenKara_0.11.0_x64-setup.exe`. `SHA256SUMS` and `latest.json` are
    attached. `/releases/latest` points at the new plain tag.
@@ -87,9 +98,11 @@ setting.
 | `package.json` / `.release-please-manifest.json` on `main` | What release-please already bumped when a release PR merged      |
 
 If those three disagree, stop and repair before cutting the next release.
-A common failure is: release PR merged → draft Release exists → **no git
-tag** → Release workflow never runs → users still see the previous
-published version.
+A common failure is: release PR merged → draft Release exists but tagged
+`untagged-*` → the Release workflow's draft gate fails → users still see
+the previous published version. The ensure job now always re-creates the
+draft bound to the real tag, which is the state the Release workflow
+requires.
 
 ## Native manifest sync
 

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -428,7 +428,7 @@ describe("release workflow", () => {
       "cat .github/release-notes-installation.md >> RELEASE_NOTES.md",
     );
     expect(releasePleaseWorkflow).toContain(
-      'gh api --method PATCH "${release_endpoint}"',
+      "gh api \"${source_endpoint}\" --jq '.body // empty' > RELEASE_NOTES.md",
     );
     expect(releasePleaseWorkflow).toContain('-F "body=@RELEASE_NOTES.md"');
     expect(releasePleaseConfig).toContain('"force-tag-creation": true');
@@ -439,9 +439,10 @@ describe("release workflow", () => {
 
   test("release-please ensures a git tag and dispatches the Release workflow", () => {
     // GITHUB_TOKEN tag/release events do not start other workflows. The
-    // release-please path must create a missing tag, create a formal draft
-    // release, and workflow_dispatch release.yml so installed-app smokes and
-    // publish run.
+    // release-please path must ensure the tag, always re-create the formal
+    // draft bound to it (release-please's own draft stays untagged-*),
+    // delete the stale drafts, and workflow_dispatch release.yml so
+    // installed-app smokes and publish run.
     const releasePleaseWorkflow = readProjectFile(
       ".github/workflows/release-please.yml",
     );
@@ -457,13 +458,20 @@ describe("release workflow", () => {
     expect(releasePleaseWorkflow).toContain("actions: write");
     expect(releasePleaseWorkflow).toContain("git tag -a");
     expect(releasePleaseWorkflow).toContain("untagged-*");
+    expect(releasePleaseWorkflow).toContain(
+      "Skipping draft repair and workflow_dispatch",
+    );
+    expect(releasePleaseWorkflow).toContain(
+      "Match the draft by name only and always create a fresh formal",
+    );
+    expect(releasePleaseWorkflow).toContain("stale_releases=");
     expect(releasePleaseWorkflow).toContain(".tag_name ==");
     expect(releasePleaseWorkflow).toContain(".name ==");
     expect(releasePleaseWorkflow).toContain(
       'gh api --method POST "repos/${GH_REPO}/releases"',
     );
     expect(releasePleaseWorkflow).toContain(
-      "GitHub does not support changing an existing draft's tag in place",
+      "does not support changing a draft's tag",
     );
     expect(releasePleaseWorkflow).toContain(
       "No draft GitHub Release was found",


### PR DESCRIPTION
## What changed

Fixes release-please shipping (PR #314, v0.12.1 landed as a stuck `untagged-*` draft).

**Root cause:** release-please creates its draft GitHub Release *before* the git tag exists. GitHub rewrites such drafts to `untagged-*` and never binds them. The ensure job's `tag_name == v0.12.1` match transiently succeeded against release-please's draft (before the async rewrite), so it skipped the rebind branch. The Release workflow's draft gate then failed (`No draft GitHub Release is bound to v0.12.1`), no release was published, and the tag push did not trigger a run.

**Fix in `ensure-tag-and-dispatch-release`:**
- Match release-please's draft by **name** only (never by the untrustworthy `tag_name`).
- Always re-create the formal draft bound to the real tag **after** the tag is ensured — a draft created against an existing tag stays bound on GitHub. Copy name/body, append the installation section.
- Delete the stale drafts for the same tag so exactly one bound draft remains.
- Bail out before any draft mutation when a Release run for this tag is already in flight (the check now runs first, not only before dispatch).

Docs updated in `docs/RELEASING.md`; workflow contract tests updated in `tests/release-workflow.test.ts`.

## Verification
- [x] actionlint `.github/workflows/release-please.yml` — PASS
- [x] zizmor (pedantic, min-severity low) — PASS, no findings
- [x] `pnpm vitest run tests/release-workflow.test.ts` — PASS (8 tests)
- [x] pre-push hook `lint`, `format-check`, `cargo-fmt-check`, `standards-route`, `tests` — PASS

## Residual risk
The failing `v0.12.1` cut is repaired out-of-band (formal draft + tag move + nightly evidence + release run), not by this workflow change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release handling to prevent duplicate workflow runs.
  * Automatically repairs missing or stale draft releases and preserves existing release notes.
  * Ensures releases are correctly tied to their tags before publishing.

* **Documentation**
  * Clarified release recovery steps, draft validation, tag creation, and automatic publishing requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->