### PR TITLE
fix(ci): self-sufficient release nightly-evidence gate + stabilize Home/End e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,7 +318,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11.13.0
+          version: 11.20.0
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -374,7 +374,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11.13.0
+          version: 11.20.0
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -472,7 +472,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11.13.0
+          version: 11.20.0
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -562,7 +562,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11.13.0
+          version: 11.20.0
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -821,7 +821,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11.13.0
+          version: 11.20.0
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -936,7 +936,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11.13.0
+          version: 11.20.0
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -1096,7 +1096,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11.13.0
+          version: 11.20.0
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/nightly-hardening.yml
+++ b/.github/workflows/nightly-hardening.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11.13.0
+          version: 11.20.0
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -196,7 +196,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11.13.0
+          version: 11.20.0
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,9 @@ jobs:
     needs: prepare-release
     runs-on: ubuntu-latest
     timeout-minutes: 45 # Resolves or waits for a full Nightly build (macOS Intel leg ~30m).
+    concurrency:
+      group: verify-nightly-evidence-${{ github.repository }}-${{ github.sha }}
+      cancel-in-progress: false
     permissions:
       actions: write # Dispatch same-commit Nightly run when no recent evidence exists.
       contents: read # Checks out the evidence verifier.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,9 +87,9 @@ jobs:
     name: Verify Nightly evidence
     needs: prepare-release
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 45 # Resolves or waits for a full Nightly build (macOS Intel leg ~30m).
     permissions:
-      actions: read # Downloads same-commit Nightly evidence.
+      actions: write # Dispatch same-commit Nightly run when no recent evidence exists.
       contents: read # Checks out the evidence verifier.
     steps:
       - name: Checkout
@@ -103,28 +103,89 @@ jobs:
           node-version: 24
           package-manager-cache: false # Release workflow: disable cache to prevent poisoning.
 
-      - name: Download Nightly evidence for the candidate commit
+      - name: Resolve or build candidate Nightly evidence
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+          EVIDENCE_DIR: ${{ runner.temp }}/nightly-evidence
         run: |
           set -euo pipefail
-          run_id="$(gh run list \
+          mkdir -p "${EVIDENCE_DIR}"
+
+          fresh_run() {
+            gh run list \
+              --repo "${GH_REPO}" \
+              --workflow nightly-hardening.yml \
+              --commit "${GITHUB_SHA}" \
+              --status success \
+              --limit 1 \
+              --json databaseId,createdAt \
+              --jq "[.[] | select(.createdAt >= \"$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)\")] | .[0].databaseId // empty"
+          }
+
+          reused_run="$(fresh_run)"
+          if [ -n "${reused_run}" ]; then
+            echo "Reusing successful Nightly run ${reused_run} for ${GITHUB_SHA}."
+            gh run download "${reused_run}" \
+              --repo "${GH_REPO}" \
+              --name nightly-evidence \
+              --dir "${EVIDENCE_DIR}"
+            exit 0
+          fi
+
+          # No fresh reusable evidence. Dispatch Nightly on the release commit,
+          # guarding against an already-in-flight run so a retried Release does
+          # not double-dispatch.
+          in_flight="$(gh run list \
             --repo "${GH_REPO}" \
             --workflow nightly-hardening.yml \
             --commit "${GITHUB_SHA}" \
-            --status success \
-            --limit 1 \
-            --json databaseId \
-            --jq '.[0].databaseId // empty')"
-          if [ -z "${run_id}" ]; then
-            echo "::error::No successful Nightly run exists for candidate commit ${GITHUB_SHA}."
+            --limit 5 \
+            --json databaseId,status \
+            --jq '[.[] | select(.status == "queued" or .status == "in_progress" or .status == "pending" or .status == "waiting")] | .[0].databaseId // empty')"
+          if [ -z "${in_flight}" ]; then
+            echo "No recent Nightly evidence and no in-flight run; dispatching nightly-hardening for ${GITHUB_SHA}."
+            gh workflow run nightly-hardening.yml \
+              --repo "${GH_REPO}" \
+              --ref "${GITHUB_SHA}"
+          else
+            echo "Nightly run ${in_flight} already in flight for ${GITHUB_SHA}; waiting on it."
+          fi
+
+          deadline=$(( $(date +%s) + 40 * 60 ))
+          nightly_run=""
+          while [ "$(date +%s)" -lt "${deadline}" ]; do
+            nightly_run="$(gh run list \
+              --repo "${GH_REPO}" \
+              --workflow nightly-hardening.yml \
+              --commit "${GITHUB_SHA}" \
+              --limit 1 \
+              --json databaseId,status,conclusion \
+              --jq '.[0] | select(.status == "completed") | .databaseId // empty')"
+            if [ -n "${nightly_run}" ]; then
+              break
+            fi
+            sleep 30
+          done
+
+          if [ -z "${nightly_run}" ]; then
+            echo "::error::Dispatched Nightly run did not finish within 40 minutes for commit ${GITHUB_SHA}."
             exit 1
           fi
-          gh run download "${run_id}" \
+
+          conclusion="$(gh run view "${nightly_run}" \
+            --repo "${GH_REPO}" \
+            --json conclusion \
+            --jq '.conclusion')"
+          if [ "${conclusion}" != "success" ]; then
+            echo "::error::Nightly run ${nightly_run} for commit ${GITHUB_SHA} ended with ${conclusion}. Fix the failure before releasing."
+            exit 1
+          fi
+
+          gh run download "${nightly_run}" \
             --repo "${GH_REPO}" \
             --name nightly-evidence \
-            --dir "${RUNNER_TEMP}/nightly-evidence"
+            --dir "${EVIDENCE_DIR}"
 
       - name: Verify candidate Nightly evidence
         run: |
@@ -389,7 +450,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11.13.0
+          version: 11.20.0
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/reusable-linux-installed-app-smoke.yml
+++ b/.github/workflows/reusable-linux-installed-app-smoke.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11.13.0
+          version: 11.20.0
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/reusable-macos-installed-app-smoke.yml
+++ b/.github/workflows/reusable-macos-installed-app-smoke.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11.13.0
+          version: 11.20.0
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/reusable-separation-smoke.yml
+++ b/.github/workflows/reusable-separation-smoke.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11.13.0
+          version: 11.20.0
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/reusable-windows-installed-app.yml
+++ b/.github/workflows/reusable-windows-installed-app.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11.13.0
+          version: 11.20.0
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -77,11 +77,12 @@ setting.
    cut also opens a GitHub issue titled `Release cut failed for vX.Y.Z`.
 3. **Watch the Release workflow.** It requires a successful Nightly
    hardening run for the tag commit from the last 24 hours. The nightly
-   cron runs at 04:00 UTC on `main`. When the tag points at a commit the
-   nightly has not covered, dispatch `nightly-hardening.yml` on `main`
-   first, or wait for the next cron run. The workflow then runs smoke
-   tests, uploads assets, publishes the GitHub Release, and submits WinGet
-   and Flatpak when configured.
+   cron runs at 04:00 UTC on `main`. When no fresh Nightly evidence exists
+   for the tag commit, the Release workflow's `Verify Nightly evidence`
+   job dispatches `nightly-hardening.yml` on the tag commit and waits for
+   it, so manual dispatch is only needed if that dispatched run fails. The
+   workflow then runs smoke tests, uploads assets, publishes the GitHub
+   Release, and submits WinGet and Flatpak when configured.
 4. **Confirm the published release.** Asset names match the tag, e.g.
    `OpenKara_0.11.0_x64-setup.exe`. `SHA256SUMS` and `latest.json` are
    attached. `/releases/latest` points at the new plain tag.

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   },
   "engines": {
     "node": ">=24 <25",
-    "pnpm": "11.13.0"
+    "pnpm": "11.20.0"
   },
-  "packageManager": "pnpm@11.13.0"
+  "packageManager": "pnpm@11.20.0"
 }

--- a/packaging/flatpak/io.github.thedavidweng.OpenKara.yml.in
+++ b/packaging/flatpak/io.github.thedavidweng.OpenKara.yml.in
@@ -57,8 +57,8 @@ modules:
         strip-components: 1
       - cargo-sources.json
       - type: archive
-        url: https://registry.npmjs.org/pnpm/-/pnpm-11.13.0.tgz
-        sha256: 865c76bd9111a45ca41f6eeed4067ff0ecdfee9eac83aad24179c83ffebe7599
+        url: https://registry.npmjs.org/pnpm/-/pnpm-11.20.0.tgz
+        sha256: 34e198cb1e43237517ecedfd31f9ae26a6c0a3e5366ce58a2d05f4b21fb5f19a
         dest: pnpm-package
       # ONNX Runtime archives come from the openkara-models catalog snapshot;
       # the renderer injects the URL and digest so no version is hand-pinned

--- a/tests/e2e/virtualized-large-library.spec.ts
+++ b/tests/e2e/virtualized-large-library.spec.ts
@@ -286,12 +286,7 @@ test.describe("Virtualized large library (5,000 songs)", () => {
 
     const renderedRows = songList.locator("[data-song-hash]");
 
-    // Each Enter triggers an estimated virtualizer.scrollToIndex that only
-    // re-measures on later rAF frames. Wait for the first navigation to settle
-    // before issuing the second so two estimate→remeasure passes cannot queue
-    // under one assertion. End lands on #, which has no songs and falls back to
-    // the nearest mapped bucket (H for the 5,000-song catalog), so the rows
-    // must leave A before Home navigates back.
+    // Let each navigation settle before issuing the next.
     const firstButton = rail.locator("button").first();
     await firstButton.focus();
     await page.keyboard.press("End");
@@ -300,7 +295,6 @@ test.describe("Virtualized large library (5,000 songs)", () => {
       timeout: 10000,
     });
 
-    // Press Home to move roving back to A and Enter to navigate to A songs.
     await page.keyboard.press("Home");
     await page.keyboard.press("Enter");
     await expect(renderedRows.first()).toContainText(/^A Song/, {

--- a/tests/e2e/virtualized-large-library.spec.ts
+++ b/tests/e2e/virtualized-large-library.spec.ts
@@ -284,31 +284,28 @@ test.describe("Virtualized large library (5,000 songs)", () => {
       /^A Song/,
     );
 
-    // Focus the rail, press End to move roving to #, then Enter to navigate.
+    const renderedRows = songList.locator("[data-song-hash]");
+
+    // Each Enter triggers an estimated virtualizer.scrollToIndex that only
+    // re-measures on later rAF frames. Wait for the first navigation to settle
+    // before issuing the second so two estimate→remeasure passes cannot queue
+    // under one assertion. End lands on #, which has no songs and falls back to
+    // the nearest mapped bucket (H for the 5,000-song catalog), so the rows
+    // must leave A before Home navigates back.
     const firstButton = rail.locator("button").first();
     await firstButton.focus();
     await page.keyboard.press("End");
     await page.keyboard.press("Enter");
+    await expect(renderedRows.first()).not.toContainText(/^A Song/, {
+      timeout: 10000,
+    });
 
-    // End goes to # which falls back to nearest mapped. Then press Home
-    // to go back to A and Enter to navigate to A songs.
+    // Press Home to move roving back to A and Enter to navigate to A songs.
     await page.keyboard.press("Home");
     await page.keyboard.press("Enter");
-
-    const renderedRows = songList.locator("[data-song-hash]");
-    await expect
-      .poll(
-        async () => {
-          const count = await renderedRows.count();
-          for (let i = 0; i < Math.min(count, 10); i++) {
-            const text = await renderedRows.nth(i).textContent();
-            if (text && /^A Song/.test(text)) return true;
-          }
-          return false;
-        },
-        { timeout: 5000 },
-      )
-      .toBe(true);
+    await expect(renderedRows.first()).toContainText(/^A Song/, {
+      timeout: 10000,
+    });
   });
 
   test("keyboard Space activates the focused bucket", async ({ page }) => {

--- a/tests/issue-303-closure.test.ts
+++ b/tests/issue-303-closure.test.ts
@@ -49,15 +49,16 @@ describe("issue 303 acceptance wiring", () => {
     expect(driver).not.toContain("accepting control presence");
   });
 
-  test("release requires fresh Nightly evidence for the candidate commit", () => {
+  test("release resolves or builds fresh Nightly evidence for the candidate commit", () => {
     const release = readProjectFile(".github/workflows/release.yml");
     const nightly = readProjectFile(".github/workflows/nightly-hardening.yml");
 
     expect(release).toContain("verify-nightly-evidence:");
-    expect(release).toContain("actions: read");
+    expect(release).toContain("actions: write");
     expect(release).toContain("nightly-evidence.mjs verify");
     expect(release).toContain("--max-age-hours 24");
     expect(release).toContain("verify-nightly-evidence");
+    expect(release).toContain("gh workflow run nightly-hardening.yml");
     expect(nightly).toContain("nightly-evidence.mjs create");
     expect(nightly).toContain("nightly-evidence.json");
     expect(nightly).toContain("NEEDS_JSON: ${{ toJson(needs) }}");


### PR DESCRIPTION
## What changed

Root-cause fix for failed run 31134818908 (`Verify Nightly evidence`: `No successful Nightly run exists for candidate commit ed3400a…`).

The Release workflow's evidence gate only looked for a pre-existing successful `nightly-hardening.yml` run on the exact release SHA, but nothing guaranteed one existed. It is now self-sufficient: reuse a fresh (<24h) successful run when present, otherwise dispatch `nightly-hardening.yml` on the release commit (with an in-flight de-dupe guard) and poll to completion. Any non-success terminal state, timeout, or missing evidence hard-fails the release so a broken commit cannot ship. Permissions gain `actions: write` (minimum scope for `gh workflow run`); job timeout rises 10 → 45 min to cover the macOS Intel leg (~30m). `docs/RELEASING.md` updated to match.

The dispatched Nightly still has to pass, which surfaced the second root cause: `tests/e2e/virtualized-large-library.spec.ts` keyboard Home and End test was flaky on Windows WebKit — two estimated `virtualizer.scrollToIndex` navigations dispatched back-to-back before a single 5s `expect.poll`, so two rAF-bounded estimate→remeasure passes queued under one window. Fixed by waiting for the first navigation to settle before issuing the second, replacing the hand-rolled poll with Playwright's native auto-retrying locator, and correcting the post-End assertion (`#` falls back to the nearest mapped bucket — H for the 5,000-song catalog — so the rows must leave A before Home returns them to A).

Side fix: bump the broken `pnpm@11.13.0` pin (its `@pnpm/exe` build shipped without a binary) to **11.20.0** across `package.json`, every `pnpm/action-setup` workflow pin, and the Flatpak manifest's pinned pnpm tarball (sha256 `34e198cb…`). The issue-303 contract test is updated to assert the new gate (`actions: write` + dispatch behavior).

## Verification
- [x] `pnpm exec playwright test tests/e2e/virtualized-large-library.spec.ts --project chromium-ui --project webkit-ui` — 24/24 PASS
- [x] Flaky test: 5 consecutive runs each on chromium-ui and webkit-ui — 10/10 PASS (no flakes)
- [x] `pnpm exec vitest run tests/flatpak-packaging.test.ts tests/issue-303-closure.test.ts` — 18/18 PASS
- [x] Pre-push full suite (`vitest run --coverage`) — 197 files / 2265 tests PASS
- [x] lint + format-check — clean
- [x] `python3 -c yaml.safe_load(release.yml)` — YAML valid
- [ ] Full `nightly-hardening.yml` + `release.yml` end-to-end — verified on merge via CI (cannot run multi-OS release pipeline locally)

## Residual risk
- The Release gate now waits up to 40 min for a freshly-dispatched Nightly; if Nightly is red, the release hard-fails by design (operator fixes the commit). No retry-on-failure, per the chosen behavior.
- pnpm 11.20.0 lockfile verified compatible via `pnpm install --frozen-lockfile` (Already up to date).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Improvements**
  * Release validation can now automatically obtain fresh Nightly verification evidence when needed, wait for completion, and reuse recent successful results.
  * Release processes are more resilient when verification evidence is unavailable.

* **Documentation**
  * Updated release guidance to explain the automated Nightly verification process.

* **Maintenance**
  * Updated the project’s required package manager version across development, packaging, and release workflows.

* **Tests**
  * Improved navigation test stability and expanded release verification coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->