### PR TITLE
chore: ignore .zcode/ local CLI tooling dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ playwright-report/
 
 # Local worktrees / ephemeral tooling
 .worktrees/
+.zcode/
 .sisyphus/
 .omx/
 .pnpm-store/


### PR DESCRIPTION
## What changed
Add `.zcode/` to `.gitignore` under the existing "Local worktrees / ephemeral tooling" section. The ZCode CLI drops local state (plans, exec logs) under this directory at the repo root; it is per-developer tooling and should never be tracked.

## Verification
- [x] `git check-ignore .zcode/` → matches
- [x] pre-push full `vitest --coverage` — 2276/2276 PASS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Excluded local worktree and ephemeral tooling files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->