### PR TITLE
fix(ci): dispatch nightly-hardening with a ref, not a bare SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,10 +147,11 @@ jobs:
             --json databaseId,status \
             --jq '[.[] | select(.status == "queued" or .status == "in_progress" or .status == "pending" or .status == "waiting")] | .[0].databaseId // empty')"
           if [ -z "${in_flight}" ]; then
-            echo "No recent Nightly evidence and no in-flight run; dispatching nightly-hardening for ${GITHUB_SHA}."
+            echo "No recent Nightly evidence and no in-flight run; dispatching nightly-hardening for ${GITHUB_SHA} on ref ${GITHUB_REF_NAME}."
+            # workflow_dispatch rejects bare SHAs; release runs carry the tag ref.
             gh workflow run nightly-hardening.yml \
               --repo "${GH_REPO}" \
-              --ref "${GITHUB_SHA}"
+              --ref "${GITHUB_REF_NAME}"
           else
             echo "Nightly run ${in_flight} already in flight for ${GITHUB_SHA}; waiting on it."
           fi


### PR DESCRIPTION
## Summary

`Release`'s `verify-nightly-evidence` job dispatches `nightly-hardening` when no recent successful evidence exists for the release commit. It passed `GITHUB_SHA` to `gh workflow run --ref`, but `workflow_dispatch` only accepts a branch or tag ref — a bare SHA returns HTTP 422 and fails the release. Release runs are dispatched on the release tag, so this uses `GITHUB_REF_NAME` instead.

## Impact

This blocked the **0.13.1 release** (run 31244923529): the `v0.13.1` commit `9a3b3d5` had no prior successful nightly run, the fallback dispatch 422'd with `No ref found for: 9a3b3d5…`, and every downstream release job was skipped.

`0.13.0` passed only by luck — a successful nightly already existed for its commit, so the dispatch path was never hit.

## Root cause

Introduced in #342 ("self-sufficient release nightly-evidence gate"), which added the dispatch fallback but used `--ref "${GITHUB_SHA}"`.

## Verification

- Confirmed the failed run error: `could not create workflow dispatch event: HTTP 422: No ref found for: 9a3b3d5…`
- Confirmed `nightly-hardening` accepts `workflow_dispatch` and runs on `github.ref_name` concurrency group
- Confirmed the Release run was dispatched on ref `v0.13.1` (`headBranch: v0.13.1`), so `GITHUB_REF_NAME` is the tag — a valid ref

## Follow-up

After this merges, I'll re-dispatch the Release workflow for `v0.13.1`; the gate will then correctly dispatch `nightly-hardening` on the `v0.13.1` ref.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nightly evidence dispatch reliability by using the release tag reference.
  * Added clearer reference details to dispatch logs for easier run tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->