### PR TITLE
fix(runtime): harden ORT DLL load on slow/AV-heavy Windows VMs (#284)

### DIFF
--- a/src-tauri/src/commands/runtime_bootstrap.rs
+++ b/src-tauri/src/commands/runtime_bootstrap.rs
@@ -31,7 +31,7 @@ pub const RUNTIME_BOOTSTRAP_ERROR_EVENT: &str = "runtime-bootstrap-error";
 pub const LEGACY_RUNTIME_VERSION: &str = "legacy";
 const CPU_FALLBACK_NOTICE: &str = "cpu-runtime-fallback-after-directml-timeout";
 
-const RUNTIME_PARENT_LOAD_TIMEOUT: Duration = Duration::from_secs(60);
+const RUNTIME_PARENT_LOAD_TIMEOUT: Duration = Duration::from_secs(120);
 const RUNTIME_PARENT_LOAD_IN_PROGRESS_MARKER: &str = "runtime_parent_load_in_progress";
 static RUNTIME_PARENT_LOAD_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
 static RUNTIME_PARENT_LOAD_TIMED_OUT: AtomicBool = AtomicBool::new(false);
@@ -372,9 +372,10 @@ pub(crate) fn ensure_runtime_loaded_with_watchdog(path: &Path) -> anyhow::Result
         Err(mpsc::RecvTimeoutError::Timeout) => {
             RUNTIME_PARENT_LOAD_TIMED_OUT.store(true, Ordering::SeqCst);
             anyhow::bail!(
-                "{}: ONNX Runtime load did not finish within {} seconds",
+                "{}: ONNX Runtime load did not finish within {} seconds\n\n{}",
                 crate::commands::runtime_worker::RUNTIME_POST_DOWNLOAD_TIMEOUT_MARKER,
-                RUNTIME_PARENT_LOAD_TIMEOUT.as_secs()
+                RUNTIME_PARENT_LOAD_TIMEOUT.as_secs(),
+                crate::commands::runtime_worker::RUNTIME_POST_DOWNLOAD_TIMEOUT_HINT,
             )
         }
         Err(mpsc::RecvTimeoutError::Disconnected) => {
@@ -1004,13 +1005,20 @@ mod tests {
     #[test]
     fn post_download_timeout_marker_maps_to_a_structured_error() {
         let error = bootstrap_command_error_from_message(&format!(
-            "{}: runtime load did not finish",
-            crate::commands::runtime_worker::RUNTIME_POST_DOWNLOAD_TIMEOUT_MARKER
+            "{}: runtime load did not finish\n\n{}",
+            crate::commands::runtime_worker::RUNTIME_POST_DOWNLOAD_TIMEOUT_MARKER,
+            crate::commands::runtime_worker::RUNTIME_POST_DOWNLOAD_TIMEOUT_HINT,
         ));
 
         assert_eq!(
             error.code,
             crate::commands::error::ErrorCode::RuntimePostDownloadTimeout
+        );
+        assert!(
+            error
+                .message
+                .contains(crate::commands::runtime_worker::RUNTIME_POST_DOWNLOAD_TIMEOUT_HINT),
+            "timeout error must carry the diagnostic hint for the user"
         );
     }
 

--- a/src-tauri/src/commands/runtime_bootstrap.rs
+++ b/src-tauri/src/commands/runtime_bootstrap.rs
@@ -328,9 +328,6 @@ fn report_worker_progress(
     }
 }
 
-/// Construct the parent-process load-timeout error message. Extracted so the
-/// funnel test exercises the production format (including the diagnostic hint)
-/// rather than reconstructing it by hand.
 fn runtime_parent_load_timeout_message() -> String {
     format!(
         "{}: ONNX Runtime load did not finish within {} seconds\n\n{}",

--- a/src-tauri/src/commands/runtime_bootstrap.rs
+++ b/src-tauri/src/commands/runtime_bootstrap.rs
@@ -328,6 +328,18 @@ fn report_worker_progress(
     }
 }
 
+/// Construct the parent-process load-timeout error message. Extracted so the
+/// funnel test exercises the production format (including the diagnostic hint)
+/// rather than reconstructing it by hand.
+fn runtime_parent_load_timeout_message() -> String {
+    format!(
+        "{}: ONNX Runtime load did not finish within {} seconds\n\n{}",
+        crate::commands::runtime_worker::RUNTIME_POST_DOWNLOAD_TIMEOUT_MARKER,
+        RUNTIME_PARENT_LOAD_TIMEOUT.as_secs(),
+        crate::commands::runtime_worker::RUNTIME_POST_DOWNLOAD_TIMEOUT_HINT,
+    )
+}
+
 /// Load ORT in the application process without allowing a native loader hang
 /// to block the command executor forever. A timed-out load poisons this
 /// process; a restart is required before another attempt can use ORT.
@@ -371,12 +383,7 @@ pub(crate) fn ensure_runtime_loaded_with_watchdog(path: &Path) -> anyhow::Result
         Ok(Err(error)) => Err(anyhow::anyhow!(error)),
         Err(mpsc::RecvTimeoutError::Timeout) => {
             RUNTIME_PARENT_LOAD_TIMED_OUT.store(true, Ordering::SeqCst);
-            anyhow::bail!(
-                "{}: ONNX Runtime load did not finish within {} seconds\n\n{}",
-                crate::commands::runtime_worker::RUNTIME_POST_DOWNLOAD_TIMEOUT_MARKER,
-                RUNTIME_PARENT_LOAD_TIMEOUT.as_secs(),
-                crate::commands::runtime_worker::RUNTIME_POST_DOWNLOAD_TIMEOUT_HINT,
-            )
+            anyhow::bail!(runtime_parent_load_timeout_message())
         }
         Err(mpsc::RecvTimeoutError::Disconnected) => {
             anyhow::bail!("ONNX Runtime load watchdog exited before reporting a result")
@@ -1004,11 +1011,7 @@ mod tests {
 
     #[test]
     fn post_download_timeout_marker_maps_to_a_structured_error() {
-        let error = bootstrap_command_error_from_message(&format!(
-            "{}: runtime load did not finish\n\n{}",
-            crate::commands::runtime_worker::RUNTIME_POST_DOWNLOAD_TIMEOUT_MARKER,
-            crate::commands::runtime_worker::RUNTIME_POST_DOWNLOAD_TIMEOUT_HINT,
-        ));
+        let error = bootstrap_command_error_from_message(&runtime_parent_load_timeout_message());
 
         assert_eq!(
             error.code,

--- a/src-tauri/src/commands/runtime_worker.rs
+++ b/src-tauri/src/commands/runtime_worker.rs
@@ -19,8 +19,9 @@ use std::{
 
 pub const RUNTIME_WORKER_ARG: &str = "--runtime-bootstrap-worker";
 pub const RUNTIME_POST_DOWNLOAD_TIMEOUT_MARKER: &str = "runtime_post_download_timeout";
+pub const RUNTIME_POST_DOWNLOAD_TIMEOUT_HINT: &str = "On a VM/server this is usually antivirus or a slow virtual disk. In an Administrator PowerShell, temporarily disable Defender real-time protection (`Set-MpPreference -DisableRealtimeProtection $true`) and retry; if it then loads, add a permanent exclusion with `Add-MpPreference -ExclusionPath \"$env:APPDATA\\com.openkara.desktop\\runtimes\"`.";
 
-const POST_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(60);
+const POST_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(120);
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
 const RUNTIME_DOWNLOAD_CACHE_DIR: &str = "runtime-download-cache";
 const RUNTIME_DOWNLOAD_TEMP_PREFIX: &str = "artifact.download.";
@@ -543,7 +544,7 @@ pub fn install_runtime_with_worker(
                 .unwrap_or_else(|| "post-download".to_owned());
             guard.complete();
             bail!(
-                "{RUNTIME_POST_DOWNLOAD_TIMEOUT_MARKER}: runtime {} did not finish within {} seconds after download (phase={phase}){}",
+                "{RUNTIME_POST_DOWNLOAD_TIMEOUT_MARKER}: runtime {} did not finish within {} seconds after download (phase={phase}){}\n\n{RUNTIME_POST_DOWNLOAD_TIMEOUT_HINT}",
                 runtime.artifact_id,
                 timeout.as_secs_f64(),
                 if details.trim().is_empty() {

--- a/src-tauri/src/commands/runtime_worker.rs
+++ b/src-tauri/src/commands/runtime_worker.rs
@@ -21,7 +21,7 @@ pub const RUNTIME_WORKER_ARG: &str = "--runtime-bootstrap-worker";
 pub const RUNTIME_POST_DOWNLOAD_TIMEOUT_MARKER: &str = "runtime_post_download_timeout";
 
 #[cfg(target_os = "windows")]
-pub const RUNTIME_POST_DOWNLOAD_TIMEOUT_HINT: &str = "On a VM/server this is usually antivirus or a slow virtual disk. In an Administrator PowerShell, temporarily disable Defender real-time monitoring (`Set-MpPreference -DisableRealtimeMonitoring $true`) and retry; if it then loads, add a permanent exclusion with `Add-MpPreference -ExclusionPath \"$env:APPDATA\\com.openkara.desktop\\runtimes\"`.";
+pub const RUNTIME_POST_DOWNLOAD_TIMEOUT_HINT: &str = "On a VM/server this is usually antivirus or a slow virtual disk. In an Administrator PowerShell, temporarily disable Defender real-time monitoring (`Set-MpPreference -DisableRealtimeMonitoring $true`) and retry; afterwards re-enable it with `Set-MpPreference -DisableRealtimeMonitoring $false`. If it then loads, add a permanent exclusion with `Add-MpPreference -ExclusionPath \"$env:APPDATA\\com.openkara.desktop\\runtimes\"`.";
 
 #[cfg(not(target_os = "windows"))]
 pub const RUNTIME_POST_DOWNLOAD_TIMEOUT_HINT: &str = "On a VM/server this is usually antivirus scanning or a slow virtual disk. Temporarily disable real-time antivirus scanning and retry; if it then loads, add a permanent exclusion for the runtimes directory.";

--- a/src-tauri/src/commands/runtime_worker.rs
+++ b/src-tauri/src/commands/runtime_worker.rs
@@ -19,7 +19,12 @@ use std::{
 
 pub const RUNTIME_WORKER_ARG: &str = "--runtime-bootstrap-worker";
 pub const RUNTIME_POST_DOWNLOAD_TIMEOUT_MARKER: &str = "runtime_post_download_timeout";
+
+#[cfg(target_os = "windows")]
 pub const RUNTIME_POST_DOWNLOAD_TIMEOUT_HINT: &str = "On a VM/server this is usually antivirus or a slow virtual disk. In an Administrator PowerShell, temporarily disable Defender real-time monitoring (`Set-MpPreference -DisableRealtimeMonitoring $true`) and retry; if it then loads, add a permanent exclusion with `Add-MpPreference -ExclusionPath \"$env:APPDATA\\com.openkara.desktop\\runtimes\"`.";
+
+#[cfg(not(target_os = "windows"))]
+pub const RUNTIME_POST_DOWNLOAD_TIMEOUT_HINT: &str = "On a VM/server this is usually antivirus scanning or a slow virtual disk. Temporarily disable real-time antivirus scanning and retry; if it then loads, add a permanent exclusion for the runtimes directory.";
 
 const POST_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(120);
 const POLL_INTERVAL: Duration = Duration::from_millis(100);

--- a/src-tauri/src/commands/runtime_worker.rs
+++ b/src-tauri/src/commands/runtime_worker.rs
@@ -19,7 +19,7 @@ use std::{
 
 pub const RUNTIME_WORKER_ARG: &str = "--runtime-bootstrap-worker";
 pub const RUNTIME_POST_DOWNLOAD_TIMEOUT_MARKER: &str = "runtime_post_download_timeout";
-pub const RUNTIME_POST_DOWNLOAD_TIMEOUT_HINT: &str = "On a VM/server this is usually antivirus or a slow virtual disk. In an Administrator PowerShell, temporarily disable Defender real-time protection (`Set-MpPreference -DisableRealtimeProtection $true`) and retry; if it then loads, add a permanent exclusion with `Add-MpPreference -ExclusionPath \"$env:APPDATA\\com.openkara.desktop\\runtimes\"`.";
+pub const RUNTIME_POST_DOWNLOAD_TIMEOUT_HINT: &str = "On a VM/server this is usually antivirus or a slow virtual disk. In an Administrator PowerShell, temporarily disable Defender real-time monitoring (`Set-MpPreference -DisableRealtimeMonitoring $true`) and retry; if it then loads, add a permanent exclusion with `Add-MpPreference -ExclusionPath \"$env:APPDATA\\com.openkara.desktop\\runtimes\"`.";
 
 const POST_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(120);
 const POLL_INTERVAL: Duration = Duration::from_millis(100);

--- a/src-tauri/src/separator/model.rs
+++ b/src-tauri/src/separator/model.rs
@@ -203,14 +203,17 @@ fn init_ort_from_path(runtime_path: &Path) -> Result<()> {
     );
 
     #[cfg(target_os = "windows")]
-    prepare_windows_runtime_dll_search(runtime_path)?;
-
-    // Read the library into the page cache before the loader maps it. On some
-    // Windows VMs (e.g. PVE/KVM), a real-time AV scan or a cold/slow virtual
-    // disk stalls section mapping inside `LoadLibraryW` long enough to trip the
-    // load watchdog; reading first lets the scan finish and warms the disk so
-    // the subsequent load is fast. Best-effort: never block the load on this.
-    let _ = fs::read(runtime_path);
+    {
+        prepare_windows_runtime_dll_search(runtime_path)?;
+        // Synchronously read the library into the page cache before the loader
+        // maps it. On some Windows VMs (e.g. PVE/KVM), a real-time AV scan or a
+        // cold/slow virtual disk stalls section mapping inside `LoadLibraryW`
+        // long enough to trip the load watchdog; reading first lets the scan
+        // finish and warms the disk so the subsequent load is fast. Read errors
+        // are ignored — this is a best-effort hint that must never block the
+        // load.
+        let _ = fs::read(runtime_path);
+    }
 
     let committed = ort::init_from(runtime_path)?.with_name("openkara").commit();
     anyhow::ensure!(

--- a/src-tauri/src/separator/model.rs
+++ b/src-tauri/src/separator/model.rs
@@ -205,6 +205,13 @@ fn init_ort_from_path(runtime_path: &Path) -> Result<()> {
     #[cfg(target_os = "windows")]
     prepare_windows_runtime_dll_search(runtime_path)?;
 
+    // Read the library into the page cache before the loader maps it. On some
+    // Windows VMs (e.g. PVE/KVM), a real-time AV scan or a cold/slow virtual
+    // disk stalls section mapping inside `LoadLibraryW` long enough to trip the
+    // load watchdog; reading first lets the scan finish and warms the disk so
+    // the subsequent load is fast. Best-effort: never block the load on this.
+    let _ = fs::read(runtime_path);
+
     let committed = ort::init_from(runtime_path)?.with_name("openkara").commit();
     anyhow::ensure!(
         committed,

--- a/src/components/Library/SortModeSelector.test.tsx
+++ b/src/components/Library/SortModeSelector.test.tsx
@@ -2,7 +2,7 @@
 
 import { cleanup } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { SortModeSelector } from "./SortModeSelector";
 
 const { mockUseSettingsStore, mockUseTranslation, mockSetLibrarySortMode } =
@@ -100,13 +100,11 @@ describe("SortModeSelector", () => {
       "sort-mode-selector",
     ) as HTMLSelectElement;
     fireEvent.change(select, { target: { value: "title_asc" } });
-    // setIsPending(true) runs inside the change handler's first await; wait
-    // for React to commit that re-render rather than assuming a synchronous
-    // flush (jsdom schedules it as a microtask, which races under load).
-    await screen.findByTestId("sort-mode-selector");
-    expect(select.disabled).toBe(true);
+    // handleChange sets isPending(true) before awaiting setLibrarySortMode(mode),
+    // but React commits that re-render on a microtask. Wait for the disabled
+    // state rather than assuming a synchronous flush (jsdom races under load).
+    await waitFor(() => expect(select.disabled).toBe(true));
     resolveMutation();
-    await screen.findByTestId("sort-mode-selector");
-    expect(select.disabled).toBe(false);
+    await waitFor(() => expect(select.disabled).toBe(false));
   });
 });

--- a/src/components/Library/SortModeSelector.test.tsx
+++ b/src/components/Library/SortModeSelector.test.tsx
@@ -100,6 +100,10 @@ describe("SortModeSelector", () => {
       "sort-mode-selector",
     ) as HTMLSelectElement;
     fireEvent.change(select, { target: { value: "title_asc" } });
+    // setIsPending(true) runs inside the change handler's first await; wait
+    // for React to commit that re-render rather than assuming a synchronous
+    // flush (jsdom schedules it as a microtask, which races under load).
+    await screen.findByTestId("sort-mode-selector");
     expect(select.disabled).toBe(true);
     resolveMutation();
     await screen.findByTestId("sort-mode-selector");


### PR DESCRIPTION
## What changed

Issue #284: on a Windows Server 2022 / PVE-KVM VM, `LoadLibraryW` on `onnxruntime.dll` hangs past the watchdog timeout for **both** the DirectML and the CPU-only ORT builds. Research into ORT source disproved the prior handoff hypothesis (cpuinfo at `DllMain`): ORT's attach-time `DllMain` is effectively empty and cpuinfo is a lazy first-session singleton. The hang is in the **Windows loader environment on this VM** — most likely Windows Defender real-time scanning of the just-extracted DLL, or a cold/slow virtual disk paging the section in. Both are build-independent, which matches the both-builds-hang symptom.

Three minimal, mutually-compatible hardenings so affected users run without waiting for another release cycle:

1. **DLL prewarm** (`separator/model.rs`): `fs::read` the runtime path immediately before `ort::init_from`. Reads the bytes into the page cache so the AV scan and the disk read complete here, not under the loader lock. Best-effort — never blocks the load.
2. **Relax both load watchdogs 60s → 120s** (worker post-download poll and parent-process load watchdog). For genuinely deadlocked users this only delays failure; for slow VMs it gives real headroom on top of the prewarm.
3. **One-line diagnostic hint** appended to the timeout error, guiding the user to temporarily disable Defender real-time protection and, if that works, add a permanent exclusion for the runtimes folder. Surfaces via the existing error-rendering funnel with zero frontend changes.

Plus a drive-by fix to a **flaky frontend test** that was intermittently blocking the pre-push hook for unrelated changes: `SortModeSelector.test.tsx` asserted `select.disabled` synchronously after `fireEvent.change`, before React committed the `setIsPending(true)` re-render (jsdom schedules that commit as a microtask, which races under parallel load). Now awaits the re-render before asserting. Verified stable by running the file x5 in isolation and alongside the heavy parallel files that originally exposed the race.

## Out of scope

- Silent/programmatic Defender exclusion — decided with maintainer: user-run, embedded in the hint instead.
- In-product hang-dump capture — no way to ship `procdump`; the hint covers the equivalent manual step.
- Authenticode-revocation hypothesis — dropped: `LoadLibraryW` on a userspace DLL does not do revocation checks.
- The worker cache/re-extract loop — the user's "re-download" UX is a consequence of the hang + existing rollback logic; once the load succeeds via prewarm, the loop never triggers.

## Verification

- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy --all-targets -- -D warnings` — PASS (no warnings)
- [x] `cargo test --lib` — 1112 passed; 0 failed (includes 56 runtime tests)
- [x] funnel test updated to assert the hint reaches `CommandError.message` — PASS
- [x] `SortModeSelector` test — stable x5 isolated + stable under parallel load
- [ ] `cargo check --target x86_64-pc-windows-msvc` — no Rust-level errors, but C-build of `aws-lc-sys`/`ring`/`ogg_next_sys` cannot run on this macOS host (pre-existing environment limitation; full Windows build runs on CI)

## Contracts / standards

No IPC contract change (backend error message strings only, not the `CommandError` shape, `ErrorCode` enum, payload, or event contract) → `docs/references/contracts/` untouched. No new product surface → no ADR.

EOF 2>&1 | tail -5
__zcode_status=$?
if [ "$__zcode_status" -eq 0 ]; then pwd -P > '/var/folders/8s/9_ghkwqs3qs9rzxt0hsk30z40000gn/T/zcode-6013a038-bfbb-48cf-9ad3-038819955cb1-cwd'; fi
exit "$__zcode_status"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved runtime initialization reliability by allowing more time for downloads, antivirus scans, and startup preparation.
  - Added clearer, platform-specific timeout guidance, including recommendations for checking security software and runtime-directory exclusions.
  - Improved runtime library loading on Windows to reduce startup issues.
  - Improved sort-mode selector state updates while changes are pending.

- **Tests**
  - Improved coverage for runtime timeout diagnostics and pending selector behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->