### PR TITLE
ci: build nightly installers on a schedule and publish a rolling prerelease

### DIFF
--- a/.github/workflows/nightly-installers.yml
+++ b/.github/workflows/nightly-installers.yml
@@ -1,0 +1,314 @@
+name: Nightly installers
+
+# Builds installers from main once per day and publishes them as a rolling
+# `nightly` prerelease so maintainers can test unreleased fixes on real
+# machines without cutting a release. Reuses the same reusable installed-app
+# workflows as Release, but with release_build=false: unsigned bundles, no
+# tauri.release.conf.json overlay, and therefore no updater artifacts.
+#
+# Updater isolation (hard requirement): production apps poll
+# releases/latest/download/latest.json. GitHub resolves releases/latest to the
+# newest non-prerelease release, so the nightly release must always be marked
+# prerelease and must never carry latest.json or *.sig assets. The publish job
+# enforces both invariants.
+
+on:
+  schedule:
+    # 05:37 UTC: off-peak, off the whole/half hour, and after the 04:00 UTC
+    # Nightly hardening run (~45 min) so the two matrices do not compete for
+    # runners or the shared Rust cache.
+    - cron: "37 5 * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Build even when main has no new commits since the last nightly"
+        type: boolean
+        default: false
+
+concurrency:
+  group: nightly-installers
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  check:
+    name: Check for new commits
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      should_build: ${{ steps.decide.outputs.should_build }}
+    steps:
+      - name: Compare main HEAD with the last published nightly
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.sha }}
+          REF_NAME: ${{ github.ref_name }}
+          FORCE: ${{ inputs.force || false }}
+        run: |
+          set -euo pipefail
+          if [ "${REF_NAME}" != "main" ]; then
+            echo "::error::Nightly installers only build from main; got ${REF_NAME}."
+            exit 1
+          fi
+
+          # The rolling nightly tag points at the commit of the last published
+          # nightly. The commits API dereferences the tag; a missing tag (404)
+          # means no nightly exists yet.
+          last_sha="$(gh api "repos/${GH_REPO}/commits/nightly" --jq '.sha' 2>/dev/null || true)"
+
+          if [ "${FORCE}" = "true" ]; then
+            echo "Force build requested via workflow_dispatch."
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+          elif [ -z "${last_sha}" ]; then
+            echo "No nightly tag found; building the first nightly."
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+          elif [ "${last_sha}" = "${HEAD_SHA}" ]; then
+            echo "main (${HEAD_SHA}) already has a published nightly; skipping."
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "New commits since the last nightly (${last_sha} -> ${HEAD_SHA}); building."
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  # release_build stays false on every leg: bundles are unsigned (--no-sign /
+  # no signing identity), the tauri.release.conf.json overlay that enables
+  # createUpdaterArtifacts is not applied, and no signing secrets are passed.
+  windows:
+    name: Nightly Windows installer (x64)
+    needs: check
+    if: needs.check.outputs.should_build == 'true'
+    uses: ./.github/workflows/reusable-windows-installed-app.yml
+    with:
+      openkara_version: "0.0.0-nightly"
+      artifact_prefix: nightly-dist-windows-x64
+      driver_scenario: clean-install
+      run_keyboard_uia: false
+      run_fault_injection: false
+      run_runtime_bootstrap_regression: false
+      run_display_matrix: false
+      previous_version: none
+      retention_days: 7
+
+  macos-aarch64:
+    name: Nightly macOS installer (Apple Silicon)
+    needs: check
+    if: needs.check.outputs.should_build == 'true'
+    uses: ./.github/workflows/reusable-macos-installed-app-smoke.yml
+    with:
+      openkara_version: "0.0.0-nightly"
+      artifact_prefix: nightly-dist-macos-aarch64
+      os: macos-14
+      rust_target: aarch64-apple-darwin
+      tauri_target: aarch64-apple-darwin
+      scenario: clean-install
+      previous_version: none
+      retention_days: 7
+
+  macos-x86_64:
+    name: Nightly macOS installer (Intel)
+    needs: check
+    if: needs.check.outputs.should_build == 'true'
+    uses: ./.github/workflows/reusable-macos-installed-app-smoke.yml
+    with:
+      openkara_version: "0.0.0-nightly"
+      artifact_prefix: nightly-dist-macos-x86_64
+      os: macos-15-intel
+      rust_target: x86_64-apple-darwin
+      tauri_target: x86_64-apple-darwin
+      scenario: clean-install
+      previous_version: none
+      retention_days: 7
+
+  linux:
+    name: Nightly Linux installer (x64)
+    needs: check
+    if: needs.check.outputs.should_build == 'true'
+    uses: ./.github/workflows/reusable-linux-installed-app-smoke.yml
+    with:
+      openkara_version: "0.0.0-nightly"
+      artifact_prefix: nightly-dist-linux-x86_64
+      scenario: clean-install
+      os: ubuntu-22.04
+      rust_target: x86_64-unknown-linux-gnu
+      tauri_target: x86_64-unknown-linux-gnu
+      previous_version: none
+      retention_days: 7
+
+  publish:
+    name: Publish nightly prerelease
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [check, windows, macos-aarch64, macos-x86_64, linux]
+    # The Windows NSIS installer is the hard requirement (clean-VM testing of
+    # Windows-only fixes); macOS/Linux legs are best-effort so a flaky or
+    # queued leg cannot block the Windows package. Per-platform download steps
+    # below only pick up legs that passed their smoke gate.
+    if: >-
+      !cancelled() &&
+      needs.check.outputs.should_build == 'true' &&
+      needs.windows.result == 'success'
+    permissions:
+      contents: write # recreate the rolling nightly tag + prerelease
+    steps:
+      - name: Download Windows installer
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: nightly-dist-windows-x64-installer
+          path: ${{ runner.temp }}/nightly-download/windows-x64
+
+      - name: Download macOS installer (Apple Silicon)
+        if: needs.macos-aarch64.result == 'success'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: nightly-dist-macos-aarch64-installer
+          path: ${{ runner.temp }}/nightly-download/macos-aarch64
+
+      - name: Download macOS installer (Intel)
+        if: needs.macos-x86_64.result == 'success'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: nightly-dist-macos-x86_64-installer
+          path: ${{ runner.temp }}/nightly-download/macos-x86_64
+
+      - name: Download Linux installer
+        if: needs.linux.result == 'success'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: nightly-dist-linux-x86_64-installer
+          path: ${{ runner.temp }}/nightly-download/linux-x86_64
+
+      - name: Stage nightly assets
+        env:
+          DOWNLOAD_ROOT: ${{ runner.temp }}/nightly-download
+          STAGING_DIR: ${{ runner.temp }}/nightly-assets
+        run: |
+          set -euo pipefail
+          mkdir -p "${STAGING_DIR}"
+
+          # Stable asset names give maintainers a permanent download URL
+          # (releases/download/nightly/<name>) that survives version bumps.
+          stage_one() {
+            local dir="$1" pattern="$2" dest="$3"
+            if [ ! -d "${DOWNLOAD_ROOT}/${dir}" ]; then
+              echo "Skipping ${dest}: the ${dir} leg did not pass, no artifact downloaded."
+              return 0
+            fi
+            local matches=()
+            while IFS= read -r -d '' file; do
+              matches+=("${file}")
+            done < <(find "${DOWNLOAD_ROOT}/${dir}" -type f -name "${pattern}" -print0)
+            if [ "${#matches[@]}" -ne 1 ]; then
+              echo "::error::Expected exactly one ${pattern} in ${dir}, found ${#matches[@]}."
+              return 1
+            fi
+            cp "${matches[0]}" "${STAGING_DIR}/${dest}"
+          }
+
+          stage_one windows-x64 '*setup.exe' OpenKara_nightly_x64-setup.exe
+          stage_one macos-aarch64 '*.dmg' OpenKara_nightly_aarch64.dmg
+          stage_one macos-x86_64 '*.dmg' OpenKara_nightly_x64.dmg
+          stage_one linux-x86_64 '*.AppImage' OpenKara_nightly_amd64.AppImage
+
+          # Updater isolation: fail loudly if updater-endpoint assets ever
+          # appear in the download set (they cannot with release_build=false,
+          # but this guards future workflow changes).
+          if find "${DOWNLOAD_ROOT}" -type f \( -name '*.sig' -o -name 'latest.json' \) | grep -q .; then
+            echo "::error::Updater artifacts leaked into the nightly asset set."
+            exit 1
+          fi
+
+          if [ ! -f "${STAGING_DIR}/OpenKara_nightly_x64-setup.exe" ]; then
+            echo "::error::The Windows installer is missing from the staged assets."
+            exit 1
+          fi
+
+          (cd "${STAGING_DIR}" && sha256sum -- * > SHA256SUMS)
+          ls -la "${STAGING_DIR}"
+
+      - name: Compose release title and notes
+        id: notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.sha }}
+          WINDOWS_RESULT: ${{ needs.windows.result }}
+          MACOS_AARCH64_RESULT: ${{ needs.macos-aarch64.result }}
+          MACOS_X86_64_RESULT: ${{ needs.macos-x86_64.result }}
+          LINUX_RESULT: ${{ needs.linux.result }}
+          NOTES_FILE: ${{ runner.temp }}/nightly-notes.md
+        run: |
+          set -euo pipefail
+          subject="$(gh api "repos/${GH_REPO}/commits/${HEAD_SHA}" --jq '.commit.message' | head -n 1)"
+          built_at="$(date -u '+%Y-%m-%d %H:%M UTC')"
+          {
+            printf 'Rolling nightly build of main for maintainer and tester use.\n\n'
+            printf -- '- Source commit: %s\n' "${HEAD_SHA}"
+            printf -- '- Commit subject: %s\n' "${subject}"
+            printf -- '- Built: %s\n\n' "${built_at}"
+            printf '> [!WARNING]\n'
+            printf '> Nightly installers are unsigned CI builds that skip the release verification\n'
+            printf '> gates. They exist for pre-release testing only. Do not redistribute.\n\n'
+            printf 'Nightly releases carry no updater manifest or signatures: installed stable\n'
+            printf 'versions are never offered a nightly, and an installed nightly moves to the\n'
+            printf 'next stable release once it ships.\n\n'
+            printf 'Platform smoke results: Windows %s, macOS Apple Silicon %s, macOS Intel %s, Linux %s.\n' \
+              "${WINDOWS_RESULT}" "${MACOS_AARCH64_RESULT}" "${MACOS_X86_64_RESULT}" "${LINUX_RESULT}"
+          } > "${NOTES_FILE}"
+          cat "${NOTES_FILE}"
+          echo "title=nightly-$(date -u +%Y%m%d)-${HEAD_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - name: Recreate rolling nightly prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TARGET_SHA: ${{ github.sha }}
+          RELEASE_TITLE: ${{ steps.notes.outputs.title }}
+          NOTES_FILE: ${{ runner.temp }}/nightly-notes.md
+          STAGING_DIR: ${{ runner.temp }}/nightly-assets
+        run: |
+          set -euo pipefail
+          # Delete-and-recreate keeps the release rolling: stale assets from a
+          # previous package version can never linger, and the nightly tag
+          # always points at the commit the assets were built from.
+          gh release delete nightly --repo "${GH_REPO}" --cleanup-tag --yes \
+            || echo "No existing nightly release to delete."
+          gh api --method DELETE "repos/${GH_REPO}/git/refs/tags/nightly" 2>/dev/null \
+            || echo "No orphan nightly tag to delete."
+
+          # --prerelease is load-bearing: GitHub resolves releases/latest (the
+          # production updater endpoint) only to non-prerelease releases.
+          gh release create nightly \
+            --repo "${GH_REPO}" \
+            --target "${TARGET_SHA}" \
+            --prerelease \
+            --title "${RELEASE_TITLE}" \
+            --notes-file "${NOTES_FILE}" \
+            "${STAGING_DIR}"/*
+
+      - name: Verify nightly release invariants
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          release_json="$(gh release view nightly --repo "${GH_REPO}" --json isPrerelease,assets)"
+          if [ "$(jq -r '.isPrerelease' <<<"${release_json}")" != "true" ]; then
+            echo "::error::The nightly release must stay a prerelease so releases/latest ignores it."
+            exit 1
+          fi
+          if jq -e '.assets[] | select(.name == "latest.json" or (.name | endswith(".sig")))' <<<"${release_json}" >/dev/null; then
+            echo "::error::The nightly release must not carry updater assets (latest.json / *.sig)."
+            exit 1
+          fi
+          if ! jq -e '.assets[] | select(.name == "OpenKara_nightly_x64-setup.exe")' <<<"${release_json}" >/dev/null; then
+            echo "::error::The Windows installer is missing from the nightly release."
+            exit 1
+          fi
+          echo "Nightly release verified: prerelease with $(jq '.assets | length' <<<"${release_json}") assets."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,16 @@ jobs:
             echo "Nightly run ${in_flight} already in flight for ${GITHUB_SHA}; waiting on it."
           fi
 
+          completed_run() {
+            gh run list \
+              --repo "${GH_REPO}" \
+              --workflow nightly-hardening.yml \
+              --commit "${GITHUB_SHA}" \
+              --limit 1 \
+              --json databaseId,status,conclusion \
+              --jq '.[0] | select(.status == "completed") | .databaseId // empty'
+          }
+
           # Real Nightly runs have taken 43+ minutes; a shorter deadline fails
           # cold releases that would still succeed within the job budget. The
           # job's timeout-minutes reserves headroom above this for the setup
@@ -168,18 +178,19 @@ jobs:
           deadline=$(( $(date +%s) + poll_minutes * 60 ))
           nightly_run=""
           while [ "$(date +%s)" -lt "${deadline}" ]; do
-            nightly_run="$(gh run list \
-              --repo "${GH_REPO}" \
-              --workflow nightly-hardening.yml \
-              --commit "${GITHUB_SHA}" \
-              --limit 1 \
-              --json databaseId,status,conclusion \
-              --jq '.[0] | select(.status == "completed") | .databaseId // empty')"
+            nightly_run="$(completed_run)"
             if [ -n "${nightly_run}" ]; then
               break
             fi
             sleep 30
           done
+
+          # The loop sleeps after each check, so a run that completes in the
+          # final interval would otherwise be reported as a timeout. Check
+          # once more before failing.
+          if [ -z "${nightly_run}" ]; then
+            nightly_run="$(completed_run)"
+          fi
 
           if [ -z "${nightly_run}" ]; then
             echo "::error::Dispatched Nightly run did not finish within ${poll_minutes} minutes for commit ${GITHUB_SHA}."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,11 @@ jobs:
     name: Verify Nightly evidence
     needs: prepare-release
     runs-on: ubuntu-latest
-    timeout-minutes: 45 # Resolves or waits for a full Nightly build (macOS Intel leg ~30m).
+    # Budget: checkout/setup + dispatch (~1-2m), then a 44-minute evidence
+    # poll (real Nightly runs take 43+ minutes), then conclusion + download.
+    # Must stay above the poll deadline so the poll's own error surfaces
+    # instead of the runner killing the job mid-loop.
+    timeout-minutes: 50
     concurrency:
       group: verify-nightly-evidence-${{ github.repository }}-${{ github.sha }}
       cancel-in-progress: false
@@ -156,10 +160,12 @@ jobs:
             echo "Nightly run ${in_flight} already in flight for ${GITHUB_SHA}; waiting on it."
           fi
 
-          # Poll almost up to the job's 45-minute timeout-minutes: real Nightly
-          # runs have taken 43+ minutes, so a shorter deadline fails cold
-          # releases that would still succeed within the job budget.
-          deadline=$(( $(date +%s) + 44 * 60 ))
+          # Real Nightly runs have taken 43+ minutes; a shorter deadline fails
+          # cold releases that would still succeed within the job budget. The
+          # job's timeout-minutes reserves headroom above this for the setup
+          # steps before the poll and the download after it.
+          poll_minutes=44
+          deadline=$(( $(date +%s) + poll_minutes * 60 ))
           nightly_run=""
           while [ "$(date +%s)" -lt "${deadline}" ]; do
             nightly_run="$(gh run list \
@@ -176,7 +182,7 @@ jobs:
           done
 
           if [ -z "${nightly_run}" ]; then
-            echo "::error::Dispatched Nightly run did not finish within 44 minutes for commit ${GITHUB_SHA}."
+            echo "::error::Dispatched Nightly run did not finish within ${poll_minutes} minutes for commit ${GITHUB_SHA}."
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,10 @@ jobs:
             echo "Nightly run ${in_flight} already in flight for ${GITHUB_SHA}; waiting on it."
           fi
 
-          deadline=$(( $(date +%s) + 40 * 60 ))
+          # Poll almost up to the job's 45-minute timeout-minutes: real Nightly
+          # runs have taken 43+ minutes, so a shorter deadline fails cold
+          # releases that would still succeed within the job budget.
+          deadline=$(( $(date +%s) + 44 * 60 ))
           nightly_run=""
           while [ "$(date +%s)" -lt "${deadline}" ]; do
             nightly_run="$(gh run list \
@@ -173,7 +176,7 @@ jobs:
           done
 
           if [ -z "${nightly_run}" ]; then
-            echo "::error::Dispatched Nightly run did not finish within 40 minutes for commit ${GITHUB_SHA}."
+            echo "::error::Dispatched Nightly run did not finish within 44 minutes for commit ${GITHUB_SHA}."
             exit 1
           fi
 

--- a/docs/CI_LAYERS.md
+++ b/docs/CI_LAYERS.md
@@ -48,6 +48,11 @@ candidate commit has no green Nightly evidence from the last 24 hours.
 - full fault injection on disk
 - full Playwright e2e / accessibility matrix (Chromium + WebKit)
 
+A separate nightly-installers workflow builds unsigned installers from main
+(skipping when main has not moved) and publishes them as a rolling `nightly`
+prerelease for pre-release testing. It never ships updater assets
+(latest.json / *.sig), so production auto-update ignores it.
+
 ## Release
 
 Product packaging and the Windows #284 contract. Release requires same-SHA
@@ -81,5 +86,6 @@ These concentrate on the Windows installed-app and fault-recovery path.
 - `scripts/ci/classify-changes.mjs` — PR / main path gates
 - `.github/workflows/ci.yml` — PR and main
 - `.github/workflows/nightly-hardening.yml` — full matrix
+- `.github/workflows/nightly-installers.yml` — rolling nightly prerelease
 - `.github/workflows/release.yml` — product + Windows #284 core
 - `.github/workflows/reusable-windows-installed-app.yml` — Windows lifecycle

--- a/tests/nightly-installers-workflow.test.ts
+++ b/tests/nightly-installers-workflow.test.ts
@@ -14,9 +14,13 @@ describe("nightly installers workflow", () => {
 
   test("runs on a daily schedule with a force-capable manual dispatch", () => {
     expect(workflow).toContain("schedule:");
+    // Any daily time is fine (the exact hour is an operational choice, not a
+    // contract); what must hold is that the schedule stays daily.
     expect(workflow).toMatch(/cron: "\d+ \d+ \* \* \*"/);
     expect(workflow).toContain("workflow_dispatch:");
     expect(workflow).toContain("force:");
+    expect(workflow).toContain("type: boolean");
+    expect(workflow).toContain('if [ "${FORCE}" = "true" ]; then');
     // Scheduled runs skip when main has not moved since the last nightly.
     expect(workflow).toContain('gh api "repos/${GH_REPO}/commits/nightly"');
     expect(workflow).toContain("should_build=false");

--- a/tests/nightly-installers-workflow.test.ts
+++ b/tests/nightly-installers-workflow.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const projectRoot = fileURLToPath(new URL("..", import.meta.url));
+
+function readProjectFile(path: string) {
+  return readFileSync(join(projectRoot, path), "utf8");
+}
+
+describe("nightly installers workflow", () => {
+  const workflow = readProjectFile(".github/workflows/nightly-installers.yml");
+
+  test("runs on a daily schedule with a force-capable manual dispatch", () => {
+    expect(workflow).toContain("schedule:");
+    expect(workflow).toMatch(/cron: "\d+ \d+ \* \* \*"/);
+    expect(workflow).toContain("workflow_dispatch:");
+    expect(workflow).toContain("force:");
+    // Scheduled runs skip when main has not moved since the last nightly.
+    expect(workflow).toContain('gh api "repos/${GH_REPO}/commits/nightly"');
+    expect(workflow).toContain("should_build=false");
+  });
+
+  test("reuses the installed-app build workflows instead of a bespoke build", () => {
+    expect(workflow).toContain(
+      "uses: ./.github/workflows/reusable-windows-installed-app.yml",
+    );
+    expect(workflow).toContain(
+      "uses: ./.github/workflows/reusable-macos-installed-app-smoke.yml",
+    );
+    expect(workflow).toContain(
+      "uses: ./.github/workflows/reusable-linux-installed-app-smoke.yml",
+    );
+    // Nightly never runs the release build path: release_build stays off, no
+    // signing secrets, and therefore no tauri.release.conf.json overlay.
+    expect(workflow).not.toMatch(/release_build:/);
+    expect(workflow).not.toContain("TAURI_SIGNING");
+    expect(workflow).not.toContain("updater_target");
+    // Clean-install only; the upgrade leg needs a published previous version.
+    expect(workflow).toMatch(/previous_version: none/);
+  });
+
+  test("publishes a rolling prerelease isolated from the updater endpoint", () => {
+    // GitHub resolves releases/latest (the production updater endpoint) only
+    // to non-prerelease releases, so the prerelease flag is load-bearing.
+    expect(workflow).toContain("--prerelease");
+    expect(workflow).toContain("gh release create nightly");
+    expect(workflow).toContain("gh release delete nightly");
+    expect(workflow).toContain("--cleanup-tag");
+    // Updater assets must never ship on the nightly release.
+    expect(workflow).toContain("latest.json");
+    expect(workflow).toMatch(/-name '\*\.sig'/);
+    expect(workflow).toContain('endswith(".sig")');
+    // The publish gate exists for the Windows installer specifically.
+    expect(workflow).toContain("OpenKara_nightly_x64-setup.exe");
+    expect(workflow).toContain("needs.windows.result == 'success'");
+  });
+
+  test("scopes write permissions to the publish job", () => {
+    expect(workflow).toMatch(/^permissions:\n  contents: read$/m);
+    const writeGrants = workflow.match(/contents: write/g) ?? [];
+    expect(writeGrants).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Maintainers currently have no way to put installers from unreleased `main` (e.g. the #361 app-local VC++ CRT fix for #284, and #365) onto real test machines without cutting a release. This PR adds a `nightly-installers` workflow that builds installers from `main` once per day and publishes them as a rolling `nightly` prerelease, plus a small fix to the Release workflow's Nightly-evidence polling deadline.

## Design

### Trigger matrix

| Trigger | Behavior |
| --- | --- |
| `schedule` (05:37 UTC daily) | Builds only when `main` has new commits since the last published nightly (compares the rolling `nightly` tag's commit with HEAD); skips otherwise. |
| `workflow_dispatch` | Same skip logic; `force: true` input overrides it. Guarded to `main` only. |

05:37 UTC is off-peak, off the whole/half hour, and ~50 minutes after the 04:00 UTC Nightly hardening run finishes, so the two matrices do not compete for runners.

### Build reuse (no bespoke build definition)

The four build legs call the existing reusable installed-app workflows — the same ones Release uses — in their fast clean-install shape (`previous_version: none`, all optional Windows gates off):

- Windows x64 NSIS (`reusable-windows-installed-app.yml`) — the hard requirement
- macOS Apple Silicon + Intel DMG (`reusable-macos-installed-app-smoke.yml`)
- Linux x64 AppImage (`reusable-linux-installed-app-smoke.yml`)

Every published installer has passed its platform's clean-install smoke first. `release_build` stays off on every leg: thin-LTO smoke profile, `--no-sign`, no signing secrets passed (they are optional inputs, so missing secrets are a non-issue).

### Publishing

The publish job deletes and recreates the `nightly` release + tag each time (rolling: stale assets from a previous package version can never linger), titles it `nightly-<date>-<shortsha>`, and writes the source commit, subject, build time, per-platform smoke results, and an "unverified build" warning into the notes. Assets get stable names (`OpenKara_nightly_x64-setup.exe`, `OpenKara_nightly_aarch64.dmg`, `OpenKara_nightly_x64.dmg`, `OpenKara_nightly_amd64.AppImage`, `SHA256SUMS`) so maintainers keep a permanent download URL across version bumps.

The Windows leg gates publishing; macOS/Linux are best-effort (a flaky or queued Apple leg cannot block the Windows package — only assets from legs that passed are attached).

### Updater isolation (red line)

Production apps poll `releases/latest/download/latest.json`, and GitHub resolves `releases/latest` only to non-prerelease releases. Enforcement is layered:

1. `release_build` off means the `tauri.release.conf.json` overlay (the only place `createUpdaterArtifacts` is enabled) is never applied — no `.sig`/updater bundles are even built.
2. The stage step fails if any `.sig` or `latest.json` appears in the downloaded artifact set.
3. The release is created with `--prerelease`, and a post-publish verification step fails if the release is not a prerelease, carries `latest.json`/`*.sig`, or is missing the Windows installer.
4. `tests/nightly-installers-workflow.test.ts` pins the prerelease flag, the updater-asset checks, the schedule + force input, and the reuse shape so future edits cannot silently drop them.

Installed nightlies auto-update to the next stable release once it ships (the endpoint only ever serves stable releases).

### Interaction with existing pipelines

- No interaction with `nightly-hardening.yml` (nothing dispatched, no shared artifacts); `release.yml`'s evidence reuse filters on `--workflow nightly-hardening.yml` and is unaffected.
- No changes to release-please, versioning, or CHANGELOG; the nightly reuses the in-tree version for building and never touches `tauri.conf.json`.
- Windows Rust cache: reuses the existing `openkara-windows-installed-smoke` / `thin-lto-o1` shared key from `main`-scoped runs — same trust domain as Nightly hardening, warms the same cache.
- Linux CI package set untouched (`libasound2-dev` intact — no changes to any existing build steps).

### Drive-by fix (separate commit)

`release.yml`'s "Verify Nightly evidence" polls a dispatched Nightly run with a 40-minute inner deadline, but real Nightly runs have taken 43+ minutes and the job's `timeout-minutes` is 45 — a cold release failed on the inner deadline even though the run finished within the job budget. The deadline is now 44 minutes so the job timeout is the effective ceiling.

## Verification

- `python yaml.safe_load` — both changed workflows parse
- `actionlint` — pass (one shellcheck info fixed during development)
- `zizmor --persona=pedantic --min-severity=low` — no findings (same configuration as the CI workflow-lint job)
- `pnpm lint` — pass
- `pnpm test` — 199 files / 2290 tests pass (includes the new contract test and the existing `workflow-security` global scans)
- Post-merge plan: `gh workflow run nightly-installers.yml -f force=true`, watch to completion, verify the `nightly` prerelease exists with the Windows x64 setup.exe attached and no updater assets, then download-test the installer link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scheduled and manually triggered nightly installer builds for Windows, macOS, and Linux.
  * Nightly builds publish as a rolling prerelease with stable download names and checksums.
  * Nightly releases include unsigned installers only and exclude updater packages.
  * Builds are skipped when there are no new changes.
* **Bug Fixes**
  * Improved release automation reliability with extended completion checks.
* **Documentation**
  * Added guidance for the nightly installer process and release behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->