### PR TITLE
fix: resolve 15 open bugs across audio, runtime threads, library registry, and frontend UI

### DIFF
--- a/src-tauri/src/audio/decode.rs
+++ b/src-tauri/src/audio/decode.rs
@@ -44,11 +44,11 @@ pub enum DecodeError {
     #[error("decoded audio contained no PCM samples")]
     NoSamples,
 
-    #[error("audio track is missing sample rate metadata")]
-    MissingSampleRate,
+    #[error("audio track has no usable sample rate: {0}")]
+    MissingSampleRate(String),
 
-    #[error("audio track is missing channel metadata")]
-    MissingChannels,
+    #[error("audio track has no usable channel count: {0}")]
+    MissingChannels(String),
 
     #[error("decoder reset is not supported")]
     ResetNotSupported,
@@ -213,8 +213,14 @@ where
         return Err(DecodeError::NoSamples);
     }
 
-    let sample_rate = sample_rate.ok_or(DecodeError::MissingSampleRate)?;
-    let channels = channels.ok_or(DecodeError::MissingChannels)?;
+    // A zero rate or channel count is as unusable as a missing one; rejecting
+    // it here keeps `sample_rate_hz > 0` a precondition on the audio thread.
+    let sample_rate = sample_rate
+        .filter(|rate| *rate > 0)
+        .ok_or_else(|| DecodeError::MissingSampleRate(source_label.to_owned()))?;
+    let channels = channels
+        .filter(|count| *count > 0)
+        .ok_or_else(|| DecodeError::MissingChannels(source_label.to_owned()))?;
     let frame_count = samples.len() / channels;
     let duration_ms = ((frame_count as f64 / sample_rate as f64) * 1000.0).round() as u64;
 
@@ -288,5 +294,48 @@ mod tests {
         let path = fixture_dir().join("fixture.wav");
         let result = probe_file(&path);
         assert!(result.is_ok(), "valid WAV should probe: {:?}", result.err());
+    }
+
+    fn pcm16_wav_bytes(sample_rate: u32) -> Vec<u8> {
+        let channels: u16 = 2;
+        let bits: u16 = 16;
+        let block_align = channels * bits / 8;
+        let pcm = [0u8; 64]; // 16 silent frames
+        let data_len = pcm.len() as u32;
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"RIFF");
+        bytes.extend_from_slice(&(36 + data_len).to_le_bytes());
+        bytes.extend_from_slice(b"WAVE");
+        bytes.extend_from_slice(b"fmt ");
+        bytes.extend_from_slice(&16u32.to_le_bytes());
+        bytes.extend_from_slice(&1u16.to_le_bytes());
+        bytes.extend_from_slice(&channels.to_le_bytes());
+        bytes.extend_from_slice(&sample_rate.to_le_bytes());
+        bytes.extend_from_slice(&(sample_rate * block_align as u32).to_le_bytes());
+        bytes.extend_from_slice(&block_align.to_le_bytes());
+        bytes.extend_from_slice(&bits.to_le_bytes());
+        bytes.extend_from_slice(b"data");
+        bytes.extend_from_slice(&data_len.to_le_bytes());
+        bytes.extend_from_slice(&pcm);
+        bytes
+    }
+
+    #[test]
+    fn decode_bytes_accepts_crafted_wav_with_valid_rate() {
+        let result = decode_bytes(pcm16_wav_bytes(44_100), "wav");
+        let audio = result.expect("crafted WAV with a valid rate should decode");
+        assert_eq!(audio.sample_rate_hz, 44_100);
+        assert_eq!(audio.channels, 2);
+    }
+
+    /// #378: a zero sample rate must never reach playback; the realtime
+    /// resampler treats `sample_rate_hz > 0` as a precondition.
+    #[test]
+    fn decode_bytes_rejects_zero_sample_rate() {
+        let result = decode_bytes(pcm16_wav_bytes(0), "wav");
+        assert!(
+            result.is_err(),
+            "zero-rate audio must be rejected at the decode boundary, got {result:?}"
+        );
     }
 }

--- a/src-tauri/src/audio/error.rs
+++ b/src-tauri/src/audio/error.rs
@@ -36,8 +36,8 @@ impl From<DecodeError> for PlaybackError {
             | DecodeError::DecodeFailed(msg) => PlaybackError::AudioDecodeFailed(msg),
             DecodeError::NoDefaultTrack
             | DecodeError::NoSamples
-            | DecodeError::MissingSampleRate
-            | DecodeError::MissingChannels
+            | DecodeError::MissingSampleRate(_)
+            | DecodeError::MissingChannels(_)
             | DecodeError::ResetNotSupported => PlaybackError::AudioDecodeFailed(err.to_string()),
             DecodeError::Internal(msg) => PlaybackError::Internal(msg),
         }

--- a/src-tauri/src/audio/output/crossfade_render.rs
+++ b/src-tauri/src/audio/output/crossfade_render.rs
@@ -115,32 +115,48 @@ pub(super) fn render_crossfade_overlap(
             Some(incoming_resampler_cache),
         );
 
-        let mix_frames = (out_rendered.min(inc_rendered)) / device_channels;
-        for frame in 0..mix_frames {
+        let out_frames = out_rendered / device_channels;
+        let inc_frames = inc_rendered / device_channels;
+        // All cursors must advance by the frames actually produced. Advancing
+        // the write cursor by the requested chunk while the mix window and
+        // the overlap clock advance by the produced count leaves unmixed
+        // outgoing frames in the buffer, makes the tail fill overwrite
+        // committed samples, and stalls promotion (#376). A short side
+        // (source exhausted mid-overlap) contributes silence instead.
+        let progress_frames = out_frames.max(inc_frames);
+        for frame in 0..progress_frames {
             let global_overlap_index = overlap_rendered + chunk_start as u64 + frame as u64;
             let (out_gain, inc_gain) = equal_power_gains(global_overlap_index, total_overlap);
 
             let inc_base = frame * device_channels;
             for ch in 0..device_channels {
-                let out_sample = output[(chunk_start + frame) * device_channels + ch];
-                let inc_sample = crossfade_scratch[inc_base + ch];
+                let out_sample = if frame < out_frames {
+                    output[(chunk_start + frame) * device_channels + ch]
+                } else {
+                    0.0
+                };
+                let inc_sample = if frame < inc_frames {
+                    crossfade_scratch[inc_base + ch]
+                } else {
+                    0.0
+                };
                 output[(chunk_start + frame) * device_channels + ch] =
                     out_sample * out_gain + inc_sample * inc_gain;
             }
         }
 
-        rendered_output_frames += mix_frames;
+        rendered_output_frames += progress_frames;
         src_frames_advanced += out_consumed;
         outgoing_frames_consumed += out_consumed;
 
         if let Some(active) = playback.active_crossfade.as_mut() {
-            active.rendered_frames += mix_frames as u64;
+            active.rendered_frames += progress_frames as u64;
             active.incoming_source_frame += inc_consumed;
         }
 
-        chunk_start += chunk_frames;
+        chunk_start += progress_frames;
 
-        if inc_rendered == 0 && mix_frames == 0 {
+        if progress_frames == 0 {
             break;
         }
     }
@@ -1085,6 +1101,79 @@ mod tests {
                 "overlap total must be in device frames (132300), not source frames"
             );
         }
+    }
+
+    /// #376: a rate-converted overlap must keep its cursors in sync when the
+    /// outgoing resampler returns short (source exhausted near the end of the
+    /// overlap). Before the fix the overlap clock stopped advancing on short
+    /// returns, so `rendered_frames` never reached `total_frames` and the
+    /// incoming track was never promoted.
+    #[test]
+    fn crossfade_rate_converted_overlap_promotes_despite_short_resampler_returns() {
+        let device_rate: u32 = 48_000;
+        let outgoing_rate: u32 = 44_100;
+        let device_channels = 2;
+        let outgoing_total = 10 * outgoing_rate as u64;
+        let incoming_total = 20 * device_rate as u64;
+        let duration_ms = 3_000;
+        let effective_device = duration_ms as u64 * device_rate as u64 / 1000; // 144000
+        let remaining_src = effective_device * outgoing_rate as u64 / device_rate as u64;
+        let render_frame = outgoing_total - remaining_src;
+
+        let mut controller = build_crossfade_controller_mismatched_rate(
+            device_rate,
+            device_channels,
+            render_frame,
+            outgoing_total,
+            outgoing_rate,
+            incoming_total,
+            device_rate,
+            duration_ms,
+        );
+
+        let callback_frames = 512usize;
+        let mut rc = ResamplerCache::new();
+        let mut rc_in = ResamplerCache::new();
+        let ring = crate::audio::peaks::PeakRing::new();
+        let mut peak_acc = crate::audio::peaks::PeakAccumulator::new();
+        let mut crossfade_scratch = vec![0.0f32; CROSSFADE_SCRATCH_FRAMES * device_channels];
+
+        // 144000 overlap frames / 512 per callback ≈ 282 callbacks. Allow
+        // slack for resampler priming, but far less than the stall budget.
+        let mut callbacks_until_promotion = None;
+        for callback in 0..400 {
+            let mut output = vec![0.0f32; callback_frames * device_channels];
+            render_output_buffer(
+                &mut controller,
+                &mut output,
+                &mut Vec::new(),
+                &mut Vec::new(),
+                &mut crossfade_scratch,
+                device_rate,
+                device_channels,
+                &mut rc,
+                &mut rc_in,
+                &mut EqProcessor::new(device_rate, device_channels),
+                &mut peak_acc,
+                &ring,
+            );
+            if controller.current_track.as_ref().unwrap().song_id == "song-b" {
+                callbacks_until_promotion = Some(callback + 1);
+                break;
+            }
+        }
+
+        let callbacks = callbacks_until_promotion
+            .expect("rate-converted crossfade must promote the incoming track");
+        assert!(
+            callbacks <= 320,
+            "overlap must complete near its configured duration (~282 callbacks), \
+             not stall on short resampler returns. took {callbacks} callbacks"
+        );
+        assert!(
+            controller.active_crossfade.is_none(),
+            "active crossfade must be cleared after promotion"
+        );
     }
 
     /// Promotion must use `incoming_source_frame` (source frames), not

--- a/src-tauri/src/audio/output/mix_bus.rs
+++ b/src-tauri/src/audio/output/mix_bus.rs
@@ -156,12 +156,20 @@ fn mix_stem_rubato(
     }
 
     let output_frames = output.len() / device_channels;
+    if output_frames == 0 {
+        return (0, 0);
+    }
 
     // Feed exactly input_frames_next(); zero-pad only at end-of-track.
-    let input_needed = resampler_cache
-        .get_or_create_mut(audio.sample_rate_hz, device_sample_rate, 0, output_frames)
-        .resampler
-        .input_frames_next();
+    let Some(entry) = resampler_cache.get_or_create_mut(
+        audio.sample_rate_hz,
+        device_sample_rate,
+        0,
+        output_frames,
+    ) else {
+        return (0, 0);
+    };
+    let input_needed = entry.resampler.input_frames_next();
     let real_available = total_src_frames - src_start_frame;
     let frames_from_source = real_available.min(input_needed);
     let feed_frames = input_needed;
@@ -170,12 +178,14 @@ fn mix_stem_rubato(
 
     // One mono resampler per source channel; planar in, interleaved out.
     for src_ch in 0..src_channels {
-        let entry = resampler_cache.get_or_create_mut(
+        let Some(entry) = resampler_cache.get_or_create_mut(
             audio.sample_rate_hz,
             device_sample_rate,
             src_ch,
             output_frames,
-        );
+        ) else {
+            continue;
+        };
 
         // Explicitly zero the tail: resize leaves stale samples past real frames.
         entry.channel_input.resize(feed_frames, 0.0);
@@ -270,8 +280,11 @@ fn resample_mix_to_output(
     let mut max_out_frames = 0usize;
 
     for src_ch in 0..src_channels {
-        let entry =
-            resampler_cache.get_or_create_mut(src_rate, device_sample_rate, src_ch, output_frames);
+        let Some(entry) =
+            resampler_cache.get_or_create_mut(src_rate, device_sample_rate, src_ch, output_frames)
+        else {
+            continue;
+        };
 
         entry.channel_input.resize(feed_frames, 0.0);
         entry.channel_input[real_frames..].fill(0.0);
@@ -347,10 +360,12 @@ pub(super) fn render_streaming_mix_bus(
     let input_needed = if src_rate == device_sample_rate {
         output_frames
     } else {
-        resampler_cache
-            .get_or_create_mut(src_rate, device_sample_rate, 0, output_frames)
-            .resampler
-            .input_frames_next()
+        let Some(entry) =
+            resampler_cache.get_or_create_mut(src_rate, device_sample_rate, 0, output_frames)
+        else {
+            return (0, 0);
+        };
+        entry.resampler.input_frames_next()
     };
 
     let mut budget = input_needed;
@@ -422,10 +437,12 @@ pub(super) fn render_decoded_mix_bus(
     let input_needed = if src_rate == device_sample_rate {
         output_frames
     } else {
-        resampler_cache
-            .get_or_create_mut(src_rate, device_sample_rate, 0, output_frames)
-            .resampler
-            .input_frames_next()
+        let Some(entry) =
+            resampler_cache.get_or_create_mut(src_rate, device_sample_rate, 0, output_frames)
+        else {
+            return (0, 0);
+        };
+        entry.resampler.input_frames_next()
     };
 
     let src_start = start_frame as usize;

--- a/src-tauri/src/audio/output/mix_bus.rs
+++ b/src-tauri/src/audio/output/mix_bus.rs
@@ -12,10 +12,10 @@ pub(super) fn mix_stem_resampled(
     device_channels: usize,
     resampler_cache: Option<&mut ResamplerCache>,
 ) -> (usize, u64) {
-    if gain == 0.0 {
-        return (0, 0);
-    }
-
+    // Zero gain must still render (silence) and consume source frames:
+    // the consumed count drives the transport clock, and skipping it
+    // freezes playback at exactly zero volume (#379). Same lockstep
+    // invariant as muted stems in the mix buses below (#143).
     if audio.sample_rate_hz == device_sample_rate {
         return mix_stem_same_rate(output, audio, start_frame, gain, device_channels);
     }
@@ -83,10 +83,6 @@ fn mix_stem_linearly_resampled(
     device_sample_rate: u32,
     device_channels: usize,
 ) -> (usize, u64) {
-    if gain == 0.0 {
-        return (0, 0);
-    }
-
     let src_rate = audio.sample_rate_hz as f64;
     let dst_rate = device_sample_rate as f64;
     let src_channels = audio.channels;
@@ -849,6 +845,126 @@ mod tests {
         } else {
             panic!("expected TwoStem streaming track");
         }
+    }
+
+    /// #379: at exactly zero master volume the transport clock must keep
+    /// advancing (rendering silence), so EOF and auto-advance still fire.
+    #[test]
+    fn zero_master_volume_still_advances_transport_clock() {
+        use crate::audio::decode::DecodedAudio;
+        use crate::audio::playback::FadeState;
+
+        let sample_rate: u32 = 44_100;
+        let channels: usize = 2;
+        let frames = sample_rate as usize; // 1 second
+
+        let mut controller = PlaybackController::default();
+        controller.start_track(
+            "song-a".to_owned(),
+            DecodedAudio {
+                sample_rate_hz: sample_rate,
+                channels,
+                duration_ms: 1_000,
+                samples: vec![0.5; frames * channels],
+            },
+            0,
+        );
+        controller.play(0).expect("track should start");
+        controller.fade = FadeState::None;
+        controller.set_volume(0.0).expect("volume should clamp");
+
+        let device_channels = 2;
+        let buffer_frames = 512usize;
+        let mut output = vec![0.0f32; buffer_frames * device_channels];
+        let mut rc = ResamplerCache::new();
+        let mut rc_in = ResamplerCache::new();
+        let mut crossfade_scratch = vec![0.0f32; CROSSFADE_SCRATCH_FRAMES * device_channels];
+        let ring = crate::audio::peaks::PeakRing::new();
+        let mut peak_acc = crate::audio::peaks::PeakAccumulator::new();
+        render_output_buffer(
+            &mut controller,
+            &mut output,
+            &mut Vec::new(),
+            &mut Vec::new(),
+            &mut crossfade_scratch,
+            sample_rate,
+            device_channels,
+            &mut rc,
+            &mut rc_in,
+            &mut EqProcessor::new(sample_rate, device_channels),
+            &mut peak_acc,
+            &ring,
+        );
+
+        assert_eq!(
+            controller.current_render_frame(),
+            buffer_frames as u64,
+            "transport clock must advance at zero volume"
+        );
+        assert!(
+            output.iter().all(|s| *s == 0.0),
+            "zero-volume output must be silence"
+        );
+    }
+
+    /// Rate-converted variant of the zero-volume clock test: the rubato path
+    /// must also consume source frames at zero gain.
+    #[test]
+    fn zero_master_volume_advances_clock_through_resampler() {
+        use crate::audio::decode::DecodedAudio;
+        use crate::audio::playback::FadeState;
+
+        let src_rate: u32 = 44_100;
+        let device_rate: u32 = 48_000;
+        let channels: usize = 2;
+        let frames = src_rate as usize; // 1 second
+
+        let mut controller = PlaybackController::default();
+        controller.start_track(
+            "song-a".to_owned(),
+            DecodedAudio {
+                sample_rate_hz: src_rate,
+                channels,
+                duration_ms: 1_000,
+                samples: vec![0.5; frames * channels],
+            },
+            0,
+        );
+        controller.play(0).expect("track should start");
+        controller.fade = FadeState::None;
+        controller.set_volume(0.0).expect("volume should clamp");
+
+        let device_channels = 2;
+        let buffer_frames = 512usize;
+        let mut output = vec![0.0f32; buffer_frames * device_channels];
+        let mut rc = ResamplerCache::new();
+        let mut rc_in = ResamplerCache::new();
+        let mut crossfade_scratch = vec![0.0f32; CROSSFADE_SCRATCH_FRAMES * device_channels];
+        let ring = crate::audio::peaks::PeakRing::new();
+        let mut peak_acc = crate::audio::peaks::PeakAccumulator::new();
+        render_output_buffer(
+            &mut controller,
+            &mut output,
+            &mut Vec::new(),
+            &mut Vec::new(),
+            &mut crossfade_scratch,
+            device_rate,
+            device_channels,
+            &mut rc,
+            &mut rc_in,
+            &mut EqProcessor::new(device_rate, device_channels),
+            &mut peak_acc,
+            &ring,
+        );
+
+        assert!(
+            controller.current_render_frame() > 0,
+            "transport clock must advance at zero volume through the resampler"
+        );
+        assert!(
+            output.iter().all(|s| *s == 0.0),
+            "zero-volume output must be silence"
+        );
     }
 
     #[test]

--- a/src-tauri/src/audio/output/mod.rs
+++ b/src-tauri/src/audio/output/mod.rs
@@ -196,7 +196,8 @@ pub fn render_output_buffer(
                 }
             }
 
-            if let Some(fade_gain) = playback.take_fade_gain() {
+            let fade_gain = playback.take_fade_gain();
+            if let Some(fade_gain) = fade_gain {
                 if fade_gain < 1.0 {
                     for sample in output[..rendered_samples].iter_mut() {
                         *sample *= fade_gain;
@@ -235,6 +236,15 @@ pub fn render_output_buffer(
                     } else {
                         for sample in remaining[..extra_rendered].iter_mut() {
                             *sample = soft_limit(*sample);
+                        }
+                    }
+                    // Keep this callback's fade gain on post-swap samples
+                    // (EOF resume), mirroring the non-crossfade path below.
+                    if let Some(fade_gain) = fade_gain {
+                        if fade_gain < 1.0 {
+                            for sample in remaining[..extra_rendered].iter_mut() {
+                                *sample *= fade_gain;
+                            }
                         }
                     }
                     peak_accumulator.process(remaining, extra_rendered, device_channels, peak_ring);
@@ -836,6 +846,106 @@ mod tests {
         let track = controller.current_track.as_ref().unwrap();
         assert_eq!(track.song_id, "song-b");
         assert_eq!(track.render_frame, 412);
+    }
+
+    /// #375: when the gapless swap fires inside the crossfade branch, the
+    /// samples rendered after the swap must still receive this callback's
+    /// fade gain — otherwise the level steps from `fade_gain` to full
+    /// amplitude in the middle of one buffer.
+    #[test]
+    fn crossfade_branch_gapless_swap_keeps_fade_gain_on_post_swap_samples() {
+        use crate::audio::decode::DecodedAudio;
+        use crate::audio::output_format::OutputFormatSnapshot;
+        use crate::audio::playback::{
+            ActiveCrossfade, PlaybackController, PreloadRequestGeneration, PreparedTrack,
+        };
+
+        let sample_rate: u32 = 44_100;
+        let channels: usize = 2;
+        let device_channels = 2;
+
+        // Track A (outgoing): already at EOF when the callback starts.
+        let track_a_frames = 1_000usize;
+        let mut controller = PlaybackController::default();
+        controller.start_track(
+            "song-a".to_owned(),
+            DecodedAudio {
+                sample_rate_hz: sample_rate,
+                channels,
+                duration_ms: (track_a_frames * 1_000 / sample_rate as usize) as u64,
+                samples: vec![0.4; track_a_frames * channels],
+            },
+            0,
+        );
+        controller.play(0).unwrap();
+        controller.current_track.as_mut().unwrap().render_frame = track_a_frames as u64;
+
+        let fmt = OutputFormatSnapshot::new(1, sample_rate, channels as u16);
+        let make_prepared = |song_id: &str, frames: usize, amplitude: f32| PreparedTrack {
+            preload_request_generation: PreloadRequestGeneration(0),
+            preload_generation: fmt.generation,
+            song_id: song_id.to_owned(),
+            output_format: fmt,
+            audio: DecodedAudio {
+                sample_rate_hz: sample_rate,
+                channels,
+                duration_ms: (frames * 1_000 / sample_rate as usize) as u64,
+                samples: vec![amplitude; frames * channels],
+            },
+        };
+
+        // A crossfade into song-b is active while a fresh prepared track
+        // (song-c) has already been installed behind it.
+        controller.active_crossfade = Some(ActiveCrossfade {
+            prepared: make_prepared("song-b", 88_200, 0.2),
+            total_frames: 22_050,
+            rendered_frames: 0,
+            incoming_source_frame: 0,
+        });
+        assert!(controller
+            .install_prepared_track(make_prepared("song-c", 44_100, 0.5), fmt)
+            .is_ok());
+
+        // A resume fade is in progress; its gain is ~0 right after start.
+        controller.fade = crate::audio::playback::FadeState::FadingIn {
+            start: std::time::Instant::now(),
+        };
+
+        let mut output = vec![0.0f32; 512 * device_channels];
+        let mut rc = ResamplerCache::new();
+        let mut crossfade_incoming_rc = ResamplerCache::new();
+        let mut crossfade_scratch = vec![0.0f32; CROSSFADE_SCRATCH_FRAMES * device_channels];
+        let ring = crate::audio::peaks::PeakRing::new();
+        let mut peak_acc = crate::audio::peaks::PeakAccumulator::new();
+        render_output_buffer(
+            &mut controller,
+            &mut output,
+            &mut Vec::new(),
+            &mut Vec::new(),
+            &mut crossfade_scratch,
+            sample_rate,
+            device_channels,
+            &mut rc,
+            &mut crossfade_incoming_rc,
+            &mut EqProcessor::new(sample_rate, device_channels),
+            &mut peak_acc,
+            &ring,
+        );
+
+        // The outgoing track was at EOF, so the swap must have fired.
+        assert_eq!(
+            controller.current_track.as_ref().unwrap().song_id,
+            "song-c",
+            "gapless swap must fire for the EOF outgoing track"
+        );
+
+        // Post-swap samples come from song-c (0.5 amplitude) and must be
+        // scaled by the active fade gain instead of jumping to full level.
+        let max_sample = output.iter().fold(0.0f32, |a, &b| a.max(b.abs()));
+        assert!(
+            max_sample < 0.49,
+            "post-swap samples must keep this callback's fade gain, got {max_sample}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/audio/output/mod.rs
+++ b/src-tauri/src/audio/output/mod.rs
@@ -522,6 +522,59 @@ mod tests {
         );
     }
 
+    /// #378: a track that slips through with a zero sample rate must degrade
+    /// to silence on the realtime callback instead of panicking inside the
+    /// rubato resampler construction.
+    #[test]
+    fn zero_sample_rate_track_renders_silence_without_panicking() {
+        use crate::audio::decode::DecodedAudio;
+        use crate::audio::playback::{FadeState, PlaybackController};
+
+        let device_rate: u32 = 48_000;
+        let device_channels: usize = 2;
+
+        let mut controller = PlaybackController::default();
+        controller.start_track(
+            "corrupt-song".to_owned(),
+            DecodedAudio {
+                sample_rate_hz: 0,
+                channels: device_channels,
+                duration_ms: 1_000,
+                samples: vec![0.5; 4_410 * device_channels],
+            },
+            0,
+        );
+        controller.play(0).unwrap();
+        controller.fade = FadeState::None;
+
+        let mut output = vec![0.0f32; 512 * device_channels];
+        let mut rc = ResamplerCache::new();
+        let mut crossfade_incoming_rc = ResamplerCache::new();
+        let mut crossfade_scratch = vec![0.0f32; CROSSFADE_SCRATCH_FRAMES * device_channels];
+        let ring = crate::audio::peaks::PeakRing::new();
+        let mut peak_acc = crate::audio::peaks::PeakAccumulator::new();
+        let rendered = render_output_buffer(
+            &mut controller,
+            &mut output,
+            &mut Vec::new(),
+            &mut Vec::new(),
+            &mut crossfade_scratch,
+            device_rate,
+            device_channels,
+            &mut rc,
+            &mut crossfade_incoming_rc,
+            &mut EqProcessor::new(device_rate, device_channels),
+            &mut peak_acc,
+            &ring,
+        );
+
+        assert_eq!(rendered, 0, "corrupt track must render nothing");
+        assert!(
+            output.iter().all(|sample| *sample == 0.0),
+            "corrupt track must leave the buffer silent"
+        );
+    }
+
     #[test]
     fn streaming_buffering_recovers_after_underrun() {
         use crate::audio::playback::PlaybackController;

--- a/src-tauri/src/audio/output/resampler_cache.rs
+++ b/src-tauri/src/audio/output/resampler_cache.rs
@@ -32,16 +32,29 @@ impl ResamplerCache {
     /// One rubato resampler per (rate pair, channel, output_chunk); shared
     /// filter state across channels phase-blurs. Chunk size is keyed because
     /// `FixedAsync::Output` fixes the output frame count at creation.
+    ///
+    /// Returns `None` for configurations no resampler can serve (zero rate,
+    /// zero chunk — rubato accepts an infinite ratio and would consume zero
+    /// input forever) and when rubato rejects construction. This runs on the
+    /// realtime audio callback, so an invalid track must degrade to silence
+    /// rather than unwind the stream; the decode/install boundaries reject
+    /// such tracks before playback.
     pub(super) fn get_or_create_mut(
         &mut self,
         src_rate: u32,
         dst_rate: u32,
         channel: usize,
         output_chunk: usize,
-    ) -> &mut ResamplerEntry {
-        self.cache
+    ) -> Option<&mut ResamplerEntry> {
+        if src_rate == 0 || dst_rate == 0 || output_chunk == 0 {
+            return None;
+        }
+        match self
+            .cache
             .entry((src_rate, dst_rate, channel, output_chunk))
-            .or_insert_with(|| {
+        {
+            std::collections::hash_map::Entry::Occupied(entry) => Some(entry.into_mut()),
+            std::collections::hash_map::Entry::Vacant(vacant) => {
                 let params = SincInterpolationParameters {
                     sinc_len: 128,
                     f_cutoff: Some(rubato::calculate_cutoff(
@@ -63,19 +76,20 @@ impl ResamplerCache {
                     1,            // channels (mono; we de-interleave per channel)
                     FixedAsync::Output,
                 )
-                .expect("failed to create rubato resampler");
-                ResamplerEntry {
+                .ok()?;
+                Some(vacant.insert(ResamplerEntry {
                     resampler,
                     channel_input: Vec::new(),
                     input_vecs: vec![Vec::new()],
-                }
-            })
+                }))
+            }
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::resample_ratio;
+    use super::{resample_ratio, ResamplerCache};
 
     #[test]
     fn resample_ratio_is_output_rate_over_input_rate() {
@@ -85,5 +99,29 @@ mod tests {
         assert!((downsample - 44_100.0 / 48_000.0).abs() < f64::EPSILON);
         assert!(upsample > 1.0);
         assert!(downsample < 1.0);
+    }
+
+    #[test]
+    fn valid_rates_create_a_cached_entry() {
+        let mut cache = ResamplerCache::new();
+        assert!(cache.get_or_create_mut(44_100, 48_000, 0, 512).is_some());
+        assert_eq!(cache.cache.len(), 1);
+    }
+
+    #[test]
+    fn zero_source_rate_returns_none_instead_of_panicking() {
+        let mut cache = ResamplerCache::new();
+        assert!(cache.get_or_create_mut(0, 48_000, 0, 512).is_none());
+        assert!(
+            cache.cache.is_empty(),
+            "a failed construction must not leave a broken entry behind"
+        );
+    }
+
+    #[test]
+    fn zero_output_chunk_returns_none_instead_of_panicking() {
+        let mut cache = ResamplerCache::new();
+        assert!(cache.get_or_create_mut(44_100, 48_000, 0, 0).is_none());
+        assert!(cache.cache.is_empty());
     }
 }

--- a/src-tauri/src/audio/playback.rs
+++ b/src-tauri/src/audio/playback.rs
@@ -716,6 +716,13 @@ impl PlaybackController {
         prepared: PreparedTrack,
         current_output_format: OutputFormatSnapshot,
     ) -> Result<(), PlaybackError> {
+        if prepared.audio.sample_rate_hz == 0 || prepared.audio.channels == 0 {
+            return Err(PlaybackError::AudioDecodeFailed(format!(
+                "prepared track {} has unusable audio metadata (sample_rate={}, channels={})",
+                prepared.song_id, prepared.audio.sample_rate_hz, prepared.audio.channels,
+            )));
+        }
+
         if prepared.preload_request_generation != self.expected_preload_request_generation {
             return Err(PlaybackError::Internal(format!(
                 "prepared track from stale preload request (prepared gen={}, expected gen={})",
@@ -1395,6 +1402,32 @@ mod tests {
         let fresh = make_prepared("song-new", 1, fmt);
         assert!(controller.install_prepared_track(fresh, fmt).is_ok());
         assert!(controller.prepared_track.is_some());
+    }
+
+    #[test]
+    fn install_prepared_track_rejects_zero_sample_rate_audio() {
+        let mut controller = super::PlaybackController::default();
+        let fmt = super::OutputFormatSnapshot::new(1, 44_100, 2);
+        let mut prepared = make_prepared("song-b", 0, fmt);
+        prepared.audio.sample_rate_hz = 0;
+        assert!(
+            controller.install_prepared_track(prepared, fmt).is_err(),
+            "zero-rate audio must not be installed for playback"
+        );
+        assert!(controller.prepared_track.is_none());
+    }
+
+    #[test]
+    fn install_prepared_track_rejects_zero_channel_audio() {
+        let mut controller = super::PlaybackController::default();
+        let fmt = super::OutputFormatSnapshot::new(1, 44_100, 2);
+        let mut prepared = make_prepared("song-b", 0, fmt);
+        prepared.audio.channels = 0;
+        assert!(
+            controller.install_prepared_track(prepared, fmt).is_err(),
+            "zero-channel audio must not be installed for playback"
+        );
+        assert!(controller.prepared_track.is_none());
     }
 
     #[test]

--- a/src-tauri/src/audio/streaming.rs
+++ b/src-tauri/src/audio/streaming.rs
@@ -511,8 +511,12 @@ pub fn probe_stream_metadata(path: &Path) -> Result<StreamMetadata, DecodeError>
         }
     }
 
-    let sample_rate = sample_rate.ok_or(DecodeError::MissingSampleRate)?;
-    let channels = channels.ok_or(DecodeError::MissingChannels)?;
+    let sample_rate = sample_rate
+        .filter(|rate| *rate > 0)
+        .ok_or_else(|| DecodeError::MissingSampleRate(label.clone()))?;
+    let channels = channels
+        .filter(|count| *count > 0)
+        .ok_or_else(|| DecodeError::MissingChannels(label.clone()))?;
 
     let duration_ms = if let (Some(n_frames), Some(tb)) = (n_frames, time_base) {
         let time = tb.calc_time(Timestamp::new(n_frames as i64));

--- a/src-tauri/src/config/library_registry.rs
+++ b/src-tauri/src/config/library_registry.rs
@@ -248,7 +248,12 @@ impl AppConfig {
             self.library_path = None;
         }
 
-        if self.active_library_id.is_none() {
+        let active_is_registered = self.active_library_id.as_deref().is_some_and(|active_id| {
+            self.libraries
+                .iter()
+                .any(|library| library.id() == active_id)
+        });
+        if !active_is_registered {
             self.active_library_id = self
                 .libraries
                 .first()
@@ -259,13 +264,14 @@ impl AppConfig {
     }
 
     pub fn active_library(&self) -> Option<&RegisteredLibrary> {
-        if let Some(active_id) = self.active_library_id.as_deref() {
-            self.libraries
-                .iter()
-                .find(|library| library.id() == active_id)
-        } else {
-            self.libraries.first()
-        }
+        self.active_library_id
+            .as_deref()
+            .and_then(|active_id| {
+                self.libraries
+                    .iter()
+                    .find(|library| library.id() == active_id)
+            })
+            .or_else(|| self.libraries.first())
     }
 }
 
@@ -338,6 +344,76 @@ mod tests {
         assert!(loaded.library_path.is_none());
         assert_eq!(loaded.libraries.len(), 1);
         assert_eq!(loaded.active_library(), loaded.libraries.first());
+    }
+
+    #[test]
+    fn dangling_active_library_id_is_repointed_on_save() {
+        let library = RegisteredLibrary::local("/Users/test/Music/A".to_owned(), "A".to_owned());
+        let normalized = AppConfig {
+            libraries: vec![library.clone()],
+            active_library_id: Some("library-missing".to_owned()),
+            ..AppConfig::default()
+        }
+        .normalize_for_save();
+
+        assert_eq!(normalized.active_library_id.as_deref(), Some(library.id()));
+    }
+
+    #[test]
+    fn dangling_active_library_id_is_dropped_when_registry_is_empty() {
+        let normalized = AppConfig {
+            active_library_id: Some("library-missing".to_owned()),
+            ..AppConfig::default()
+        }
+        .normalize_for_save();
+
+        assert!(normalized.active_library_id.is_none());
+    }
+
+    #[test]
+    fn registered_active_library_id_is_kept_on_save() {
+        let first = RegisteredLibrary::local("/Users/test/Music/A".to_owned(), "A".to_owned());
+        let second = RegisteredLibrary::local("/Users/test/Music/B".to_owned(), "B".to_owned());
+        let normalized = AppConfig {
+            libraries: vec![first, second.clone()],
+            active_library_id: Some(second.id().to_owned()),
+            ..AppConfig::default()
+        }
+        .normalize_for_save();
+
+        assert_eq!(normalized.active_library_id.as_deref(), Some(second.id()));
+    }
+
+    #[test]
+    fn active_library_falls_back_to_first_when_id_is_dangling() {
+        let library = RegisteredLibrary::local("/Users/test/Music/A".to_owned(), "A".to_owned());
+        let config = AppConfig {
+            libraries: vec![library.clone()],
+            active_library_id: Some("library-missing".to_owned()),
+            ..AppConfig::default()
+        };
+
+        assert_eq!(config.active_library(), Some(&library));
+    }
+
+    #[test]
+    fn dangling_active_library_id_is_repaired_on_load() {
+        let tmp = tempfile::tempdir().unwrap();
+        let raw = r#"{
+          "libraries": [
+            { "kind": "local", "id": "library-1", "display_name": "A", "root_path": "/tmp/a" }
+          ],
+          "active_library_id": "library-gone"
+        }"#;
+        fs::write(tmp.path().join(CONFIG_FILENAME), raw).unwrap();
+
+        let loaded = load_config(tmp.path()).unwrap().unwrap();
+
+        assert_eq!(loaded.active_library_id.as_deref(), Some("library-1"));
+        assert_eq!(
+            loaded.active_library().map(RegisteredLibrary::id),
+            Some("library-1")
+        );
     }
 
     #[test]

--- a/src-tauri/src/config/library_registry.rs
+++ b/src-tauri/src/config/library_registry.rs
@@ -288,19 +288,26 @@ pub fn library_display_name(path: &str) -> String {
         .to_owned()
 }
 
-pub fn migrate_legacy_library_path(config: &mut AppConfig) {
-    if config.libraries.is_empty() {
-        if let Some(path) = config.library_path.clone() {
-            config.libraries.push(RegisteredLibrary::local(
-                path.clone(),
-                library_display_name(&path),
-            ));
-            config.active_library_id = config
-                .libraries
-                .first()
-                .map(|library| library.id().to_owned());
-        }
+/// Registers a pre-registry `library_path` as the first library entry.
+/// `normalize_for_save` then makes it active. The fallback name for a path
+/// with no final component is deliberately "OpenKara Library", not the raw
+/// path that `library_display_name` would produce: this is what the shipped
+/// migration has always written.
+pub(super) fn migrate_legacy_library_path(config: &mut AppConfig) {
+    if !config.libraries.is_empty() {
+        return;
     }
+    let Some(path) = config.library_path.clone() else {
+        return;
+    };
+    let display_name = Path::new(&path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("OpenKara Library")
+        .to_owned();
+    config
+        .libraries
+        .push(RegisteredLibrary::local(path, display_name));
 }
 
 #[cfg(test)]
@@ -343,6 +350,22 @@ mod tests {
 
         assert!(loaded.library_path.is_none());
         assert_eq!(loaded.libraries.len(), 1);
+        assert_eq!(loaded.active_library(), loaded.libraries.first());
+    }
+
+    #[test]
+    fn legacy_library_path_without_final_component_gets_fallback_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join(CONFIG_FILENAME),
+            r#"{ "library_path": "/" }"#,
+        )
+        .unwrap();
+
+        let loaded = load_config(tmp.path()).unwrap().unwrap();
+
+        assert_eq!(loaded.libraries.len(), 1);
+        assert_eq!(loaded.libraries[0].display_name(), "OpenKara Library");
         assert_eq!(loaded.active_library(), loaded.libraries.first());
     }
 

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -8,8 +8,8 @@ pub use execution_provider::{
     restore_directml_timeout_state, ExecutionProviderPreference,
 };
 pub use library_registry::{
-    library_display_name, library_id_for_path, migrate_legacy_library_path, LibraryKind,
-    RegisteredLibrary, RemoteLibraryConnectionConfig, RemoteLibraryProvider,
+    library_display_name, library_id_for_path, LibraryKind, RegisteredLibrary,
+    RemoteLibraryConnectionConfig, RemoteLibraryProvider,
 };
 pub use persistence::{load_config, save_config};
 pub use preferences::{LibrarySortMode, ModelVariant, StemMode, ThemePreference, UpdatePolicy};

--- a/src-tauri/src/config/persistence.rs
+++ b/src-tauri/src/config/persistence.rs
@@ -7,7 +7,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use super::{AppConfig, RegisteredLibrary};
+use super::{library_registry::migrate_legacy_library_path, AppConfig};
 
 pub(super) const CONFIG_FILENAME: &str = "config.json";
 
@@ -41,18 +41,7 @@ pub fn load_config(app_data_dir: &Path) -> Result<Option<AppConfig>> {
         }
     };
 
-    if config.libraries.is_empty() {
-        if let Some(library_path) = config.library_path.clone() {
-            let display_name = Path::new(&library_path)
-                .file_name()
-                .and_then(|name| name.to_str())
-                .unwrap_or("OpenKara Library")
-                .to_owned();
-            config
-                .libraries
-                .push(RegisteredLibrary::local(library_path, display_name));
-        }
-    }
+    migrate_legacy_library_path(&mut config);
 
     Ok(Some(config.normalize_for_save()))
 }
@@ -154,7 +143,7 @@ fn config_path(app_data_dir: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{library_id_for_path, StemMode};
+    use crate::config::{library_id_for_path, RegisteredLibrary, StemMode};
 
     #[test]
     fn load_returns_none_when_missing() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -253,6 +253,11 @@ pub fn run() {
         .on_menu_event(app_menu::handle_menu_event);
 
     builder
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app_handle, event| {
+            if matches!(event, tauri::RunEvent::Exit) {
+                remote::startup::shutdown_durable_operation_executor(app_handle);
+            }
+        });
 }

--- a/src-tauri/src/remote/content.rs
+++ b/src-tauri/src/remote/content.rs
@@ -685,8 +685,12 @@ fn probe_remote_source(
             }
         }
     }
-    let sample_rate = sample_rate.ok_or(decode::DecodeError::MissingSampleRate)?;
-    let channels = channels.ok_or(decode::DecodeError::MissingChannels)?;
+    let sample_rate = sample_rate
+        .filter(|rate| *rate > 0)
+        .ok_or_else(|| decode::DecodeError::MissingSampleRate("remote source".to_owned()))?;
+    let channels = channels
+        .filter(|count| *count > 0)
+        .ok_or_else(|| decode::DecodeError::MissingChannels("remote source".to_owned()))?;
     let duration_ms = n_frames
         .zip(time_base)
         .and_then(|(frames, time_base)| time_base.calc_time(Timestamp::new(frames as i64)))

--- a/src-tauri/src/remote/lifecycle.rs
+++ b/src-tauri/src/remote/lifecycle.rs
@@ -262,6 +262,12 @@ impl<'a> RemoteRepositoryLifecycle<'a> {
             .find(|entry| entry.id() == library_id)
         {
             *existing_entry = updated_library;
+        } else {
+            // The entry can vanish between the two config loads (removed while
+            // recovery was in flight). The recovery just revalidated the remote
+            // location and re-bound its credentials, so re-register the entry
+            // instead of persisting an active id that resolves to nothing.
+            config.libraries.push(updated_library);
         }
         config.active_library_id = Some(library_id);
         persist_app_config(self.app_data_dir, &config)?;
@@ -646,6 +652,72 @@ mod tests {
         assert!(
             fixture.access.opened_locations().is_empty(),
             "a rejected reauthorization must not reach the Remote Provider"
+        );
+    }
+
+    /// Deletes the registry entry while the recovery round-trip is in flight,
+    /// reproducing the race where the repository is removed between the two
+    /// config loads in `recover`.
+    struct EntryRemovingAccess<'a> {
+        inner: &'a ScriptedAccess,
+        app_data_dir: PathBuf,
+    }
+
+    impl RepositoryAccess for EntryRemovingAccess<'_> {
+        fn bind_credentials(
+            &self,
+            session: &ProviderSessionData,
+            app_data_dir: &Path,
+            library_id: &str,
+            context: BindContext,
+        ) -> CommandResult<RemoteLibraryConnectionConfig> {
+            self.inner
+                .bind_credentials(session, app_data_dir, library_id, context)
+        }
+
+        fn open_storage<'b>(
+            &self,
+            app_data_dir: &'b Path,
+            library: &'b RegisteredLibrary,
+        ) -> CommandResult<Box<dyn RepositoryStorage + 'b>> {
+            let mut config = load_app_config(&self.app_data_dir).expect("config");
+            config.libraries.clear();
+            config.active_library_id = None;
+            persist_app_config(&self.app_data_dir, &config).expect("persist removal");
+            self.inner.open_storage(app_data_dir, library)
+        }
+    }
+
+    #[test]
+    fn reauthorize_re_registers_a_repository_removed_while_in_flight() {
+        let fixture = Fixture::new();
+        fixture.access.provider.set_revision("renewed-revision");
+        let access = EntryRemovingAccess {
+            inner: &fixture.access,
+            app_data_dir: fixture.app_data_dir.clone(),
+        };
+        let lifecycle =
+            RemoteRepositoryLifecycle::with_access(&fixture.state, &fixture.app_data_dir, &access);
+
+        let snapshot = lifecycle
+            .reauthorize(
+                LIBRARY_ID.to_owned(),
+                SESSION_ID.to_owned(),
+                ORIGINAL_LOCATION.to_owned(),
+                "Repository".to_owned(),
+            )
+            .expect("reauthorize should succeed");
+
+        assert_eq!(snapshot.active_library_id.as_deref(), Some(LIBRARY_ID));
+        let config = load_app_config(&fixture.app_data_dir).expect("config");
+        assert_eq!(
+            config.active_library().map(RegisteredLibrary::id),
+            Some(LIBRARY_ID),
+            "the recovered repository must be registered and active, not a dangling id"
+        );
+        assert_eq!(
+            fixture.registered().remote_revision(),
+            Some("renewed-revision")
         );
     }
 

--- a/src-tauri/src/remote/startup.rs
+++ b/src-tauri/src/remote/startup.rs
@@ -15,8 +15,10 @@ use crate::state::RemoteState;
 use crate::AppState;
 use rusqlite::Connection;
 use std::path::{Path, PathBuf};
+use std::sync::{mpsc, Mutex};
+use std::thread::JoinHandle;
 use std::time::Duration;
-use tauri::{AppHandle, Runtime};
+use tauri::{AppHandle, Manager, Runtime};
 
 const DURABLE_OPERATION_POLL_INTERVAL: Duration = Duration::from_secs(30);
 
@@ -39,8 +41,10 @@ pub struct StartupReport {
 ///
 /// Call once from app bootstrap, after `RemoteState` exists and before any
 /// caller may reach the control plane. Errors are logged rather than returned:
-/// startup recovery must never abort app start. The executor is a detached
-/// background poller that runs for the rest of the process lifetime.
+/// startup recovery must never abort app start. The executor polls in the
+/// background until the managed [`DurableOperationExecutor`] is told to stop;
+/// the run loop's exit handler does that via
+/// [`shutdown_durable_operation_executor`].
 pub(crate) fn prepare_control_plane<R: Runtime>(
     state: &AppState,
     app_handle: &AppHandle<R>,
@@ -58,7 +62,8 @@ pub(crate) fn prepare_control_plane<R: Runtime>(
         &clock,
     );
 
-    spawn_durable_operation_executor(state.clone(), app_handle.clone());
+    let executor = spawn_durable_operation_executor(state.clone(), app_handle.clone());
+    app_handle.manage(executor);
 
     report
 }
@@ -377,26 +382,68 @@ fn recover_stale_part_files_for_libraries(
     }
 }
 
-fn spawn_durable_operation_executor<R: Runtime>(state: AppState, app_handle: AppHandle<R>) {
-    std::thread::spawn(move || {
-        let publish_changes = crate::remote::PublishChanges::new(&state, &app_handle);
-        if let Err(error) = publish_changes.recover_pending() {
-            tracing::warn!(
-                "durable operation executor initial pass failed: {:?}",
-                error
-            );
-        }
+/// Handle to the durable operation executor thread, kept in managed state so
+/// teardown can stop the poller and wait for an in-flight pass to finish
+/// instead of letting it run against an app that is going away.
+pub(crate) struct DurableOperationExecutor {
+    stop: mpsc::SyncSender<()>,
+    thread: Mutex<Option<JoinHandle<()>>>,
+}
 
-        loop {
-            std::thread::sleep(DURABLE_OPERATION_POLL_INTERVAL);
-            if let Err(error) = publish_changes.recover_pending() {
-                tracing::warn!(
-                    "durable operation executor periodic pass failed: {:?}",
-                    error
-                );
-            }
+impl DurableOperationExecutor {
+    fn shutdown(&self) {
+        let _ = self.stop.try_send(());
+        let thread = self.thread.lock().ok().and_then(|mut slot| slot.take());
+        if let Some(thread) = thread {
+            let _ = thread.join();
         }
+    }
+}
+
+impl Drop for DurableOperationExecutor {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+/// Stop the durable operation executor and wait for it to finish. Called by
+/// the run loop's exit handler; a no-op when the executor was never started.
+pub(crate) fn shutdown_durable_operation_executor<R: Runtime>(app_handle: &AppHandle<R>) {
+    if let Some(executor) = app_handle.try_state::<DurableOperationExecutor>() {
+        executor.shutdown();
+    }
+}
+
+fn spawn_durable_operation_executor<R: Runtime>(
+    state: AppState,
+    app_handle: AppHandle<R>,
+) -> DurableOperationExecutor {
+    let (stop, stop_rx) = mpsc::sync_channel(1);
+    let thread = std::thread::spawn(move || {
+        let publish_changes = crate::remote::PublishChanges::new(&state, &app_handle);
+        run_durable_operation_executor(&stop_rx, DURABLE_OPERATION_POLL_INTERVAL, || {
+            if let Err(error) = publish_changes.recover_pending() {
+                tracing::warn!("durable operation executor pass failed: {:?}", error);
+            }
+        });
     });
+    DurableOperationExecutor {
+        stop,
+        thread: Mutex::new(Some(thread)),
+    }
+}
+
+/// One pass immediately, then one per poll interval, until the stop channel
+/// signals or its sender is dropped.
+fn run_durable_operation_executor(
+    stop: &mpsc::Receiver<()>,
+    poll_interval: Duration,
+    mut pass: impl FnMut(),
+) {
+    pass();
+    while let Err(mpsc::RecvTimeoutError::Timeout) = stop.recv_timeout(poll_interval) {
+        pass();
+    }
 }
 
 #[cfg(test)]
@@ -805,5 +852,66 @@ mod tests {
             &[],
             false
         ));
+    }
+
+    #[test]
+    fn the_executor_loop_stops_when_signalled() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+        use std::time::Instant;
+
+        let (stop, stop_rx) = mpsc::sync_channel(1);
+        let passes = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&passes);
+        let executor = std::thread::spawn(move || {
+            run_durable_operation_executor(&stop_rx, Duration::from_millis(2), move || {
+                counter.fetch_add(1, Ordering::SeqCst);
+            });
+        });
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while passes.load(Ordering::SeqCst) < 3 {
+            assert!(
+                Instant::now() < deadline,
+                "the executor should keep polling"
+            );
+            std::thread::sleep(Duration::from_millis(1));
+        }
+
+        stop.try_send(()).expect("stop signal");
+        executor
+            .join()
+            .expect("the executor thread should stop when signalled");
+    }
+
+    #[test]
+    fn the_executor_loop_stops_when_the_stop_handle_is_dropped() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let (stop, stop_rx) = mpsc::sync_channel::<()>(1);
+        drop(stop);
+
+        let passes = AtomicUsize::new(0);
+        run_durable_operation_executor(&stop_rx, Duration::from_secs(60), || {
+            passes.fetch_add(1, Ordering::SeqCst);
+        });
+
+        assert_eq!(
+            passes.load(Ordering::SeqCst),
+            1,
+            "only the initial pass runs once the handle is gone"
+        );
+    }
+
+    #[test]
+    fn a_spawned_executor_joins_on_shutdown() {
+        let app = tauri::test::mock_app();
+        let executor =
+            spawn_durable_operation_executor(AppState::test_fixture(), app.handle().clone());
+
+        executor.shutdown();
+
+        let thread = executor.thread.lock().expect("thread slot");
+        assert!(thread.is_none(), "shutdown must join the executor thread");
     }
 }

--- a/src-tauri/src/separator/activation.rs
+++ b/src-tauri/src/separator/activation.rs
@@ -28,6 +28,7 @@ use crate::separator::runtime_bootstrap;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::{
+    panic::{catch_unwind, AssertUnwindSafe},
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -378,9 +379,15 @@ impl LoadStrategy {
         let latches = Arc::clone(&self.latches);
         let runtime_path = library_path.to_path_buf();
         thread::spawn(move || {
-            let result = loader
-                .load(&runtime_path)
-                .map_err(|error| format!("{error:#}"));
+            // A panicking load must not unwind past the latch release below:
+            // `in_progress` would stay set for the process lifetime and every
+            // retry would be refused until a restart.
+            let result = catch_unwind(AssertUnwindSafe(|| {
+                loader
+                    .load(&runtime_path)
+                    .map_err(|error| format!("{error:#}"))
+            }))
+            .unwrap_or_else(|payload| Err(load_panic_message(payload.as_ref())));
             latches.in_progress.store(false, Ordering::SeqCst);
             let _ = sender.send(result);
         });
@@ -416,6 +423,15 @@ fn load_timeout_message(timeout: Duration) -> String {
         timeout.as_secs(),
         RUNTIME_POST_DOWNLOAD_TIMEOUT_HINT,
     )
+}
+
+fn load_panic_message(payload: &(dyn std::any::Any + Send)) -> String {
+    let detail = payload
+        .downcast_ref::<&'static str>()
+        .copied()
+        .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+        .unwrap_or("unknown panic");
+    format!("ONNX Runtime loader thread panicked: {detail}")
 }
 
 #[cfg(test)]
@@ -717,6 +733,7 @@ mod tests {
         Succeed,
         Fail(&'static str),
         Stall,
+        Panic,
     }
 
     /// Test adapter at the load-strategy seam: every path succeeds unless
@@ -769,6 +786,7 @@ mod tests {
                     thread::sleep(STALL);
                     Ok(())
                 }
+                Behaviour::Panic => panic!("scripted load panic"),
             }
         }
 
@@ -1006,6 +1024,32 @@ mod tests {
                 .starts_with(RUNTIME_POST_DOWNLOAD_TIMEOUT_MARKER),
             "unexpected message: {error}"
         );
+    }
+
+    #[test]
+    fn a_panicking_load_releases_the_latch_so_a_retry_can_proceed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let flaky = install(tmp.path(), "rt-panics");
+        let loader = ScriptedLoader::new().script(&flaky, Behaviour::Panic);
+        let strategy = strategy(&loader);
+
+        let error =
+            load_with_watchdog_using(&strategy, tmp.path(), &flaky, ActivationTarget::default())
+                .expect_err("a panicking load must surface an error");
+        assert!(
+            error.to_string().contains("panicked"),
+            "unexpected message: {error}"
+        );
+        assert_eq!(
+            failure_phase_of(&error),
+            Some(RuntimeBootstrapFailurePhase::Probe)
+        );
+
+        loader.script(&flaky, Behaviour::Succeed);
+        let loaded =
+            load_with_watchdog_using(&strategy, tmp.path(), &flaky, ActivationTarget::default())
+                .expect("the in-progress latch must be released after a panicking load");
+        assert_eq!(loaded, flaky);
     }
 
     #[test]

--- a/src-tauri/src/separator/activation.rs
+++ b/src-tauri/src/separator/activation.rs
@@ -1036,8 +1036,9 @@ mod tests {
         let error =
             load_with_watchdog_using(&strategy, tmp.path(), &flaky, ActivationTarget::default())
                 .expect_err("a panicking load must surface an error");
+        let message = error.to_string();
         assert!(
-            error.to_string().contains("panicked"),
+            message.contains("panicked") && message.contains("scripted load panic"),
             "unexpected message: {error}"
         );
         assert_eq!(

--- a/src-tauri/src/services/track_load/streaming.rs
+++ b/src-tauri/src/services/track_load/streaming.rs
@@ -26,7 +26,7 @@ use crate::{
     remote::cache_catalog::CachePinGuard,
     services::playback::PlaybackErrorEvent,
 };
-use std::{sync::mpsc, sync::Arc, time::Duration};
+use std::{ops::ControlFlow, sync::mpsc, sync::Arc, time::Duration};
 use tauri::{AppHandle, Emitter, Runtime};
 
 pub(super) const INITIAL_FETCH: &str = "remote fetch";
@@ -35,6 +35,12 @@ const RECONNECTED_FETCH: &str = "remote fetch (reconnect)";
 /// Drains the fetch-event channel for the lifetime of one streaming source
 /// and owns its cache pin. `label` distinguishes the source installed by the
 /// initial load from one installed by a reconnect in the logs.
+///
+/// The listener stops as soon as its source stops being the installed one —
+/// a successful reconnect hands the new receiver to a fresh listener, the
+/// full-file fallback replaces streaming entirely, and a superseded request
+/// never reinstalls this source. Exiting drops the cache pin and the
+/// receiver, so exactly one listener is live per installed source.
 pub(super) fn spawn_fetch_event_listener<R: Runtime>(
     ctx: LoadContext<R>,
     cache_pin_guard: Option<CachePinGuard>,
@@ -45,10 +51,10 @@ pub(super) fn spawn_fetch_event_listener<R: Runtime>(
         let _pin = cache_pin_guard;
         let song_id = ctx.song_id.clone();
         for event in fetch_event_rx {
-            match event {
+            let flow = match event {
                 FetchEvent::ConsecutiveFailures { count } => {
                     eprintln!("{label}: {count} consecutive failures for {song_id}");
-                    attempt_reconnect(&ctx, ReconnectError::Transient);
+                    attempt_reconnect(&ctx, ReconnectError::Transient)
                 }
                 FetchEvent::RangeNotSupported => {
                     eprintln!(
@@ -58,13 +64,17 @@ pub(super) fn spawn_fetch_event_listener<R: Runtime>(
                         eprintln!("{label} fallback failed for {song_id}: {error:#}");
                         ctx.fail(error);
                     }
+                    ControlFlow::Break(())
                 }
                 FetchEvent::UrlExpired => {
                     eprintln!(
                         "{label}: download URL expired for {song_id}, attempting reconnect with credential refresh"
                     );
-                    attempt_reconnect(&ctx, ReconnectError::CredentialExpired);
+                    attempt_reconnect(&ctx, ReconnectError::CredentialExpired)
                 }
+            };
+            if flow.is_break() {
+                break;
             }
         }
     });
@@ -83,22 +93,32 @@ fn fallback_to_full_file<R: Runtime>(ctx: &LoadContext<R>) -> Result<(), Playbac
 /// Mid-song reconnect after a transient or URL-expired fetch failure.
 /// Re-resolve plus an atomic source swap; `refresh_credentials` is a no-op
 /// (ProviderFetcher single-flights 401 refresh; re-resolve refreshes provider).
-fn attempt_reconnect<R: Runtime>(ctx: &LoadContext<R>, failure: ReconnectError) {
+///
+/// Returns `Break` when the calling listener's source is out of service — the
+/// swap installed a new source (whose listener was spawned here) or the
+/// request is stale — and `Continue` when the old source stays installed.
+fn attempt_reconnect<R: Runtime>(ctx: &LoadContext<R>, failure: ReconnectError) -> ControlFlow<()> {
     let song_id = ctx.song_id.clone();
     eprintln!("remote playback reconnect triggered for {song_id} (cause: {failure:?})");
 
     let position_ms = {
         let Ok(playback) = ctx.state.playback.playback.lock() else {
-            return;
+            return ControlFlow::Continue(());
         };
         playback_position_for_reconnect(&playback, &song_id)
     };
     let Some(position_ms) = position_ms else {
-        return;
+        // No matching active track. A current request may still be installing
+        // this source; a superseded one never will, so its listener stops.
+        return if ctx.guard().is_current() {
+            ControlFlow::Continue(())
+        } else {
+            ControlFlow::Break(())
+        };
     };
 
     let Ok(cache_catalog) = ctx.state.remote.remote_chunk_cache() else {
-        return;
+        return ControlFlow::Continue(());
     };
     let cache = Arc::clone(cache_catalog);
 
@@ -178,8 +198,9 @@ fn attempt_reconnect<R: Runtime>(ctx: &LoadContext<R>, failure: ReconnectError) 
                 position_ms,
                 new_source: Box::new(success.source),
             });
+            ControlFlow::Break(())
         }
-        Err(ReconnectError::Stale) => {}
+        Err(ReconnectError::Stale) => ControlFlow::Break(()),
         Err(error) => {
             eprintln!("remote playback reconnect failed for {song_id}: {error:?}");
             let _ = ctx.app_handle.emit(
@@ -194,6 +215,7 @@ fn attempt_reconnect<R: Runtime>(ctx: &LoadContext<R>, failure: ReconnectError) 
                     ),
                 },
             );
+            ControlFlow::Continue(())
         }
     }
 }

--- a/src-tauri/src/services/track_load/tests.rs
+++ b/src-tauri/src/services/track_load/tests.rs
@@ -3,6 +3,7 @@ use crate::{
     audio::{
         coordinator::{spawn_coordinator, CoordinatorRuntime},
         decode::DecodedAudio,
+        remote_source::FetchEvent,
     },
     cache::stems::StemCacheEntry,
     state::AppState,
@@ -471,6 +472,40 @@ fn stem_attachment_for_the_current_request_attaches() {
         .expect("attach_stems thread should not panic")
         .expect("attach_stems should return a snapshot");
     assert!(snapshot.has_stems);
+}
+
+#[test]
+fn a_fetch_event_listener_for_a_superseded_request_stops_draining() {
+    let fixture = Fixture::new();
+    let request = PlaybackRequest::begin(&fixture.state.playback).expect("request");
+    let ctx = LoadContext {
+        state: fixture.state.clone(),
+        app_handle: fixture.app.handle().clone(),
+        app_data_dir: fixture.state.shell.app_data_dir.clone(),
+        library_root: fixture.library.clone(),
+        song_id: "song-superseded".to_owned(),
+        request,
+    };
+    let _current = PlaybackRequest::begin(&fixture.state.playback).expect("newer request");
+
+    let (fetch_event_tx, fetch_event_rx) = mpsc::channel();
+    streaming::spawn_fetch_event_listener(ctx, None, fetch_event_rx, "test fetch");
+
+    fetch_event_tx
+        .send(FetchEvent::ConsecutiveFailures { count: 5 })
+        .expect("the listener should be draining before it sees the event");
+
+    let deadline = Instant::now() + COMMAND_TIMEOUT;
+    while fetch_event_tx
+        .send(FetchEvent::ConsecutiveFailures { count: 5 })
+        .is_ok()
+    {
+        assert!(
+            Instant::now() < deadline,
+            "the listener must drop its receiver once its request is superseded"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
 }
 
 #[test]

--- a/src/components/Lyrics/LyricsPanel.remote-page.test.tsx
+++ b/src/components/Lyrics/LyricsPanel.remote-page.test.tsx
@@ -76,7 +76,6 @@ const { mockLyricsSession } = vi.hoisted(() => ({
     toAdjustedMs: (positionMs: number) => positionMs - mockLyricsState.offsetMs,
     syncActiveLine: vi.fn(),
     syncActiveWord: vi.fn(),
-    resetActiveIndexLatches: vi.fn(),
   },
 }));
 

--- a/src/components/Lyrics/LyricsPanel.test.tsx
+++ b/src/components/Lyrics/LyricsPanel.test.tsx
@@ -114,7 +114,6 @@ const { mockLyricsSession } = vi.hoisted(() => ({
     toAdjustedMs: (positionMs: number) => positionMs - mockLyricsState.offsetMs,
     syncActiveLine: vi.fn(),
     syncActiveWord: vi.fn(),
-    resetActiveIndexLatches: vi.fn(),
   },
 }));
 

--- a/src/components/Settings/InputDialog.tsx
+++ b/src/components/Settings/InputDialog.tsx
@@ -9,6 +9,13 @@ interface InputDialogProps {
   placeholder?: string;
   initialValue?: string;
   confirmLabel?: string;
+  /**
+   * When set, confirming stays disabled until the trimmed input matches this
+   * value exactly; a non-matching input shows `mismatchHint` next to the
+   * field.
+   */
+  expectedValue?: string;
+  mismatchHint?: string;
   onConfirm: (value: string) => void;
   onCancel: () => void;
 }
@@ -18,6 +25,8 @@ export function InputDialog({
   placeholder,
   initialValue = "",
   confirmLabel,
+  expectedValue,
+  mismatchHint,
   onConfirm,
   onCancel,
 }: InputDialogProps) {
@@ -33,6 +42,13 @@ export function InputDialog({
   });
 
   const label = confirmLabel || t("common.save");
+  const trimmedValue = value.trim();
+  const matchesExpected =
+    expectedValue === undefined || trimmedValue === expectedValue;
+  const canConfirm = trimmedValue.length > 0 && matchesExpected;
+  const showMismatchHint =
+    !matchesExpected && trimmedValue.length > 0 && mismatchHint !== undefined;
+  const mismatchHintId = "input-dialog-mismatch-hint";
 
   const dialogContent = (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
@@ -63,15 +79,27 @@ export function InputDialog({
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={(event) => {
-            if (event.key === "Enter" && value.trim()) {
+            if (event.key === "Enter" && canConfirm) {
               event.preventDefault();
-              onConfirm(value.trim());
+              onConfirm(trimmedValue);
             }
           }}
           placeholder={placeholder}
           aria-label={title}
+          aria-invalid={showMismatchHint || undefined}
+          aria-describedby={showMismatchHint ? mismatchHintId : undefined}
           className="mt-3 w-full rounded-md border border-[var(--color-border-light)] bg-[var(--color-surface)] px-3 py-2 text-[13px] text-[var(--color-text)] placeholder-[var(--color-text-dimmer)] outline-none transition-colors focus:border-[var(--color-accent)] focus:ring-1 focus:ring-[var(--color-accent)]/30"
         />
+
+        {showMismatchHint && (
+          <p
+            id={mismatchHintId}
+            role="alert"
+            className="mt-2 break-words text-[12px] text-[var(--color-destructive)]"
+          >
+            {mismatchHint}
+          </p>
+        )}
 
         <div className="mt-5 flex justify-end gap-2">
           <button
@@ -81,8 +109,8 @@ export function InputDialog({
             {t("common.cancel")}
           </button>
           <button
-            onClick={() => value.trim() && onConfirm(value.trim())}
-            disabled={!value.trim()}
+            onClick={() => canConfirm && onConfirm(trimmedValue)}
+            disabled={!canConfirm}
             className="rounded-md bg-[var(--color-control-primary)] px-4 py-2 text-[13px] text-[var(--color-control-primary-foreground)] transition-colors hover:bg-[color-mix(in_srgb,var(--color-control-primary)_88%,white)] focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] disabled:opacity-50"
           >
             {label}

--- a/src/components/Settings/RemoteLibraryWizard.test.tsx
+++ b/src/components/Settings/RemoteLibraryWizard.test.tsx
@@ -602,6 +602,185 @@ describe("RemoteLibraryWizard", () => {
     container.remove();
   });
 
+  test("does not report success or close when activation fails after registration", async () => {
+    mockBeginRemoteAuth.mockResolvedValue({
+      session_id: "session-1",
+      provider: "google_drive",
+      authorization_url: null,
+      expires_at_ms: null,
+    });
+    mockCreateRemoteLibrary.mockResolvedValue({
+      provider: "google_drive",
+      remote_root_locator: "root-1",
+      remote_path_display: "Google Drive / OpenKara",
+      display_name: "Drive",
+      account_id: "account-1",
+    });
+    mockRegisterRemoteLibrary.mockResolvedValue({
+      active_library_id: "remote:new",
+      libraries: [],
+    });
+
+    const onClose = vi.fn();
+    const harness = await createInitializedSettingsHarness();
+    harness.librarySession.failOn(
+      "switchLibrary",
+      new Error("endpoint unreachable"),
+    );
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <SettingsControllerContext value={harness.controller}>
+          <RemoteLibraryWizard onClose={onClose} />
+        </SettingsControllerContext>,
+      );
+    });
+
+    const openRemoteButtons = [...container.querySelectorAll("button")].filter(
+      (button) =>
+        button.textContent?.includes(
+          "settings.library.connectRemoteGoogleDrive",
+        ),
+    );
+    const connectButton = openRemoteButtons[openRemoteButtons.length - 1];
+
+    await act(async () => {
+      connectButton?.click();
+    });
+    await flushEffects();
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("endpoint unreachable");
+    expect(container.textContent).not.toContain(
+      "settings.library.remoteLibraryConnected",
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  test("keeps the wizard open and shows the error when activating an existing library fails", async () => {
+    const onClose = vi.fn();
+    const harness = await createInitializedSettingsHarness({
+      activeLibraryId: "local:/karaoke",
+      libraries: [
+        {
+          id: "local:/karaoke",
+          kind: "local",
+          display_name: "Main Library",
+          root_path: "/karaoke",
+        },
+        {
+          id: "remote:drive-1",
+          kind: "remote",
+          display_name: "Drive",
+          provider: "google_drive",
+          account_id: "account-1",
+          remote_root_locator: "root-1",
+          remote_path_display: "Google Drive / OpenKara",
+          connection_config: null,
+          cached_db_path: null,
+          remote_revision: "rev-1",
+        },
+      ],
+    });
+    harness.librarySession.failOn(
+      "switchLibrary",
+      new Error("endpoint unreachable"),
+    );
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <SettingsControllerContext value={harness.controller}>
+          <RemoteLibraryWizard onClose={onClose} />
+        </SettingsControllerContext>,
+      );
+    });
+
+    const existingLibraryButton = [...container.querySelectorAll("button p")]
+      .find((paragraph) => paragraph.textContent === "Drive")
+      ?.closest("button");
+    expect(existingLibraryButton).toBeTruthy();
+
+    await act(async () => {
+      existingLibraryButton?.click();
+    });
+    await flushEffects();
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("endpoint unreachable");
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  test("closes the wizard when activating an existing library succeeds", async () => {
+    const onClose = vi.fn();
+    const harness = await createInitializedSettingsHarness({
+      activeLibraryId: "local:/karaoke",
+      libraries: [
+        {
+          id: "local:/karaoke",
+          kind: "local",
+          display_name: "Main Library",
+          root_path: "/karaoke",
+        },
+        {
+          id: "remote:drive-1",
+          kind: "remote",
+          display_name: "Drive",
+          provider: "google_drive",
+          account_id: "account-1",
+          remote_root_locator: "root-1",
+          remote_path_display: "Google Drive / OpenKara",
+          connection_config: null,
+          cached_db_path: null,
+          remote_revision: "rev-1",
+        },
+      ],
+    });
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <SettingsControllerContext value={harness.controller}>
+          <RemoteLibraryWizard onClose={onClose} />
+        </SettingsControllerContext>,
+      );
+    });
+
+    const existingLibraryButton = [...container.querySelectorAll("button p")]
+      .find((paragraph) => paragraph.textContent === "Drive")
+      ?.closest("button");
+
+    await act(async () => {
+      existingLibraryButton?.click();
+    });
+    await flushEffects();
+
+    expect(harness.librarySession.calls).toEqual([
+      { entry: "switchLibrary", libraryId: "remote:drive-1" },
+    ]);
+    expect(onClose).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
   test("cancels auth if opening the external browser fails", async () => {
     mockBeginRemoteAuth.mockResolvedValue({
       session_id: "session-1",

--- a/src/components/Settings/RemoteLibraryWizard.tsx
+++ b/src/components/Settings/RemoteLibraryWizard.tsx
@@ -201,26 +201,31 @@ export function RemoteLibraryWizard({
         throw new Error(t("settings.library.remoteLibraryMissingId"));
       }
 
-      if (
-        !isRecoveryFlow &&
-        mode === "mirror_active_local" &&
-        activeLocalLibrary
-      ) {
+      const mirrorSource =
+        !isRecoveryFlow && mode === "mirror_active_local"
+          ? activeLocalLibrary
+          : null;
+
+      if (mirrorSource) {
         await remoteRepository.mirrorLocalLibraryToRemote(
-          activeLocalLibrary.id,
+          mirrorSource.id,
           remoteLibraryId,
         );
-        await library.activate(remoteLibraryId);
-        setMessage(
-          t("settings.library.remoteLibraryCreatedAndMirroring", {
-            displayName: activeLocalLibrary.display_name,
-          }),
-        );
-      } else {
-        await library.activate(remoteLibraryId);
-        setMessage(t("settings.library.remoteLibraryConnected"));
       }
 
+      const activation = await library.activate(remoteLibraryId);
+      if (!activation.ok) {
+        setError(activation.error);
+        return;
+      }
+
+      setMessage(
+        mirrorSource
+          ? t("settings.library.remoteLibraryCreatedAndMirroring", {
+              displayName: mirrorSource.display_name,
+            })
+          : t("settings.library.remoteLibraryConnected"),
+      );
       onClose();
     } catch (err: unknown) {
       if (getErrorMessage(err) !== REMOTE_AUTH_CANCELLED) {
@@ -231,6 +236,16 @@ export function RemoteLibraryWizard({
         setLoading(false);
       }
     }
+  };
+
+  const activateExistingLibrary = async (candidateId: string) => {
+    setError(null);
+    const activation = await library.activate(candidateId);
+    if (!activation.ok) {
+      setError(activation.error);
+      return;
+    }
+    onClose();
   };
 
   const remoteLibraries = view.library.libraries.filter(
@@ -506,9 +521,7 @@ export function RemoteLibraryWizard({
                 <button
                   key={candidate.id}
                   type="button"
-                  onClick={() =>
-                    void library.activate(candidate.id).then(() => onClose())
-                  }
+                  onClick={() => void activateExistingLibrary(candidate.id)}
                   disabled={loading}
                   className="rounded-md border border-[var(--color-border-light)] px-3 py-2"
                 >

--- a/src/components/Settings/SettingsLibrarySection.interaction.test.tsx
+++ b/src/components/Settings/SettingsLibrarySection.interaction.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 
+import { fireEvent } from "@testing-library/react";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
@@ -71,6 +72,7 @@ describe("SettingsLibrarySection interactions", () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    vi.restoreAllMocks();
   });
 
   function renderSection(controller: SettingsController) {
@@ -131,6 +133,72 @@ describe("SettingsLibrarySection interactions", () => {
     renderSection(harness.controller);
 
     expect(container.textContent).toContain("settings.integrity.reportTitle");
+  });
+
+  async function openDeleteConfirmDialog(): Promise<HTMLInputElement> {
+    const deleteButton = container.querySelector(
+      'button[title="settings.library.deleteLibrary"]',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      deleteButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    return document.body.querySelector(
+      'input[aria-label^="settings.library.typeToConfirmDelete"]',
+    ) as HTMLInputElement;
+  }
+
+  function dialogConfirmButton(): HTMLButtonElement {
+    const confirm = [...document.body.querySelectorAll("button")].find(
+      (button) => button.textContent === "common.confirm",
+    );
+    if (!confirm) {
+      throw new Error("delete confirmation button not found");
+    }
+    return confirm;
+  }
+
+  test("a mismatched delete confirmation name disables confirm and hints inline", async () => {
+    const harness = await activeLocalLibraryHarness();
+    renderSection(harness.controller);
+
+    const input = await openDeleteConfirmDialog();
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "Wrong Library" } });
+    });
+
+    expect(dialogConfirmButton().disabled).toBe(true);
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    expect(
+      document.getElementById("input-dialog-mismatch-hint")?.textContent,
+    ).toBe("settings.library.confirmNameMismatch{displayName=Main Library}");
+  });
+
+  test("the exact delete confirmation name enables confirm and deletes", async () => {
+    const deleteLibrary = vi.fn(async () => ({
+      active_library_id: null,
+      libraries: [],
+    }));
+    const harness = await activeLocalLibraryHarness({
+      overrides: { librarySetup: { deleteLibrary } },
+    });
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    renderSection(harness.controller);
+
+    const input = await openDeleteConfirmDialog();
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "Main Library" } });
+    });
+
+    expect(document.getElementById("input-dialog-mismatch-hint")).toBeNull();
+    const confirmButton = dialogConfirmButton();
+    expect(confirmButton.disabled).toBe(false);
+
+    await act(async () => {
+      confirmButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(deleteLibrary).toHaveBeenCalledWith(localLibrary.id);
   });
 
   test("disables the integrity check while a cleanup is in progress", async () => {

--- a/src/components/Settings/SettingsLibrarySection.tsx
+++ b/src/components/Settings/SettingsLibrarySection.tsx
@@ -342,6 +342,10 @@ export function SettingsLibrarySection() {
             displayName: deleteConfirmDialog.displayName,
           })}
           confirmLabel={t("common.confirm")}
+          expectedValue={deleteConfirmDialog.displayName}
+          mismatchHint={t("settings.library.confirmNameMismatch", {
+            displayName: deleteConfirmDialog.displayName,
+          })}
           onConfirm={handleDeleteConfirm}
           onCancel={() => setDeleteConfirmDialog(null)}
         />

--- a/src/components/Settings/SettingsModelVariantSection.test.tsx
+++ b/src/components/Settings/SettingsModelVariantSection.test.tsx
@@ -65,6 +65,7 @@ const downloadedStatus = (variant: string): ModelStatusSnapshot => ({
 async function render(options: {
   status?: RuntimeBootstrapStatusSnapshot;
   statuses?: Partial<Record<ModelVariant, ModelStatusSnapshot>>;
+  statusesError?: string;
   update?: ModelUpdateReport;
   updateError?: string;
 }) {
@@ -73,8 +74,15 @@ async function render(options: {
     overrides: {
       settings: {
         getRuntimeBootstrapStatus: async () => status,
-        getModelStatus: async (variant) =>
-          options.statuses?.[variant as ModelVariant] ?? missingStatus(variant),
+        getModelStatus: async (variant) => {
+          if (options.statusesError) {
+            throw new Error(options.statusesError);
+          }
+          return (
+            options.statuses?.[variant as ModelVariant] ??
+            missingStatus(variant)
+          );
+        },
         checkModelUpdates: async () => {
           if (options.updateError) {
             throw new Error(options.updateError);
@@ -269,5 +277,16 @@ describe("SettingsModelVariantSection", () => {
     expect(html).toContain("settings.modelUpdate.checkFailed");
     expect(html).toContain("update check failed: offline");
     expect(html).toContain("settings.modelVariant.htdemucs");
+  });
+
+  test("shows the status-read failure instead of stale model statuses", async () => {
+    const html = await render({
+      statusesError: "model directory unreadable",
+    });
+
+    expect(html).toContain("settings.modelVariant.statusUnavailable");
+    expect(html).toContain("settings.modelVariant.statusReadFailed");
+    expect(html).toContain("model directory unreadable");
+    expect(html).not.toContain("settings.modelVariant.notDownloaded");
   });
 });

--- a/src/components/Settings/SettingsModelVariantSection.tsx
+++ b/src/components/Settings/SettingsModelVariantSection.tsx
@@ -62,6 +62,10 @@ export function SettingsModelVariantSection() {
       return t("settings.modelVariant.downloading");
     }
 
+    if (models.statusesError != null) {
+      return t("settings.modelVariant.statusUnavailable");
+    }
+
     const status = models.statuses[variant];
 
     if (status?.legacy_install_present && !status.downloaded) {
@@ -139,6 +143,13 @@ export function SettingsModelVariantSection() {
           onClick={() => void preferences.selectModelVariant("htdemucs_ft")}
         />
       </div>
+
+      {models.statusesError != null ? (
+        <p className="mt-2 text-[11px] text-[var(--color-danger,#e5484d)] opacity-90">
+          {t("settings.modelVariant.statusReadFailed")}
+          {` ${models.statusesError}`}
+        </p>
+      ) : null}
 
       <div className="mt-3 flex flex-col gap-2 border-t border-[var(--color-border-light)] pt-3">
         <div className="flex items-center gap-2">

--- a/src/components/Settings/SettingsRuntimeSection.test.tsx
+++ b/src/components/Settings/SettingsRuntimeSection.test.tsx
@@ -50,6 +50,7 @@ async function render(options: {
   status: RuntimeBootstrapStatusSnapshot;
   update?: RuntimeUpdateReport;
   updateError?: string;
+  statusReadError?: string;
 }) {
   const harness = createSettingsHarness({
     runtimeStatus: options.status,
@@ -64,11 +65,19 @@ async function render(options: {
           }
           return options.update;
         },
-        getRuntimeBootstrapStatus: async () => options.status,
+        getRuntimeBootstrapStatus: async () => {
+          if (options.statusReadError) {
+            throw new Error(options.statusReadError);
+          }
+          return options.status;
+        },
       },
     },
   });
 
+  if (options.statusReadError) {
+    await harness.controller.initialize();
+  }
   if (options.update || options.updateError) {
     await harness.controller.maintenance.checkRuntimeUpdates();
   }
@@ -278,5 +287,16 @@ describe("SettingsRuntimeSection", () => {
     expect(html).not.toContain("settings.runtime.upToDate");
     expect(html).toContain("settings.runtime.statusMissing");
     expect(html).toContain("settings.runtime.installButton");
+  });
+
+  test("replaces the status line when the runtime status cannot be read", async () => {
+    const html = await render({
+      status: runtimeStatus(),
+      statusReadError: "ipc channel closed",
+    });
+
+    expect(html).toContain("settings.runtime.statusReadFailed");
+    expect(html).toContain("ipc channel closed");
+    expect(html).not.toContain("settings.runtime.statusReady");
   });
 });

--- a/src/components/Settings/SettingsRuntimeSection.test.tsx
+++ b/src/components/Settings/SettingsRuntimeSection.test.tsx
@@ -47,7 +47,7 @@ function failedWith(message: string): CommandError {
 }
 
 async function render(options: {
-  status: RuntimeBootstrapStatusSnapshot;
+  status?: RuntimeBootstrapStatusSnapshot;
   update?: RuntimeUpdateReport;
   updateError?: string;
   statusReadError?: string;
@@ -68,6 +68,9 @@ async function render(options: {
         getRuntimeBootstrapStatus: async () => {
           if (options.statusReadError) {
             throw new Error(options.statusReadError);
+          }
+          if (!options.status) {
+            throw new Error("no runtime status");
           }
           return options.status;
         },
@@ -298,5 +301,30 @@ describe("SettingsRuntimeSection", () => {
     expect(html).toContain("settings.runtime.statusReadFailed");
     expect(html).toContain("ipc channel closed");
     expect(html).not.toContain("settings.runtime.statusReady");
+    expect(html).not.toContain("settings.runtime.version:");
+  });
+
+  test("hides status-derived actions while the runtime status is unreadable", async () => {
+    const html = await render({
+      status: runtimeStatus({
+        state: "candidate_ready_restart_required",
+        candidate_version: "v1.28.0",
+        restart_required: true,
+      }),
+      statusReadError: "ipc channel closed",
+    });
+
+    expect(html).toContain("settings.runtime.statusReadFailed");
+    expect(html).not.toContain("settings.runtime.restartButton");
+    expect(html).not.toContain("settings.runtime.version:");
+  });
+
+  test("does not claim the runtime is missing when the first status read fails", async () => {
+    const html = await render({ statusReadError: "ipc channel closed" });
+
+    expect(html).toContain("settings.runtime.statusReadFailed");
+    expect(html).not.toContain('data-testid="runtime-install-button"');
+    expect(html).not.toContain("settings.runtime.installRequired");
+    expect(html).not.toContain("settings.runtime.statusMissing");
   });
 });

--- a/src/components/Settings/SettingsRuntimeSection.tsx
+++ b/src/components/Settings/SettingsRuntimeSection.tsx
@@ -35,9 +35,6 @@ export function SettingsRuntimeSection() {
   const update = view.runtime.update;
   const runtimeState = runtime?.state;
 
-  // A failed status read leaves `runtime` null or stale, so the actual state
-  // is unknown — not `missing`. Treat status-derived data and actions as
-  // unavailable instead of offering install/restart against a guess.
   const statusReadError = view.runtime.statusError;
   const statusUnavailable = statusReadError != null;
 

--- a/src/components/Settings/SettingsRuntimeSection.tsx
+++ b/src/components/Settings/SettingsRuntimeSection.tsx
@@ -40,7 +40,12 @@ export function SettingsRuntimeSection() {
     runtime?.restart_required === true ||
     runtimeState === "candidate_ready_restart_required";
 
+  const statusReadError = view.runtime.statusError;
+
   const statusLine = (() => {
+    if (statusReadError != null) {
+      return t("settings.runtime.statusReadFailed");
+    }
     switch (runtimeState) {
       case "candidate_ready_restart_required":
         return t("settings.runtime.candidateReadyRestartRequired", {
@@ -104,6 +109,11 @@ export function SettingsRuntimeSection() {
     >
       <div className="flex flex-col gap-1">
         <p className="text-[12px] text-[var(--color-text)]">{statusLine}</p>
+        {statusReadError != null ? (
+          <p className="text-[11px] text-[var(--color-danger,#e5484d)] opacity-90">
+            {statusReadError}
+          </p>
+        ) : null}
         {versionLine ? (
           <p className="text-[11px] text-[var(--color-text-dim)]">
             {versionLine}

--- a/src/components/Settings/SettingsRuntimeSection.tsx
+++ b/src/components/Settings/SettingsRuntimeSection.tsx
@@ -35,12 +35,18 @@ export function SettingsRuntimeSection() {
   const update = view.runtime.update;
   const runtimeState = runtime?.state;
 
-  const isMissing = !runtime || runtimeState === "missing";
-  const restartRequired =
-    runtime?.restart_required === true ||
-    runtimeState === "candidate_ready_restart_required";
-
+  // A failed status read leaves `runtime` null or stale, so the actual state
+  // is unknown — not `missing`. Treat status-derived data and actions as
+  // unavailable instead of offering install/restart against a guess.
   const statusReadError = view.runtime.statusError;
+  const statusUnavailable = statusReadError != null;
+
+  const isMissing =
+    !statusUnavailable && (!runtime || runtimeState === "missing");
+  const restartRequired =
+    !statusUnavailable &&
+    (runtime?.restart_required === true ||
+      runtimeState === "candidate_ready_restart_required");
 
   const statusLine = (() => {
     if (statusReadError != null) {
@@ -75,7 +81,7 @@ export function SettingsRuntimeSection() {
   })();
 
   const versionLine =
-    runtime && !isMissing
+    !statusUnavailable && runtime && !isMissing
       ? `${t("settings.runtime.version", {
           version: runtime.version,
         })} · ${runtime.target_triple}`
@@ -86,11 +92,13 @@ export function SettingsRuntimeSection() {
     (report?.state === "update_available" ||
       report?.state === "installed_without_identity") &&
     !restartRequired;
-  const downloadingCandidate = runtimeState === "downloading_candidate";
-  const isDownloading = runtimeState === "downloading";
+  const downloadingCandidate =
+    !statusUnavailable && runtimeState === "downloading_candidate";
+  const isDownloading = !statusUnavailable && runtimeState === "downloading";
 
   const needsInstall =
-    isMissing || runtimeState === "corrupt" || runtimeState === "failed";
+    !statusUnavailable &&
+    (isMissing || runtimeState === "corrupt" || runtimeState === "failed");
   const installLabel =
     runtimeState === "corrupt" || runtimeState === "failed"
       ? t("settings.runtime.retryButton")

--- a/src/hooks/use-lyrics-engine.ts
+++ b/src/hooks/use-lyrics-engine.ts
@@ -92,8 +92,7 @@ export function useLyricsEngine(input: {
 
   useEffect(() => {
     lineRuntime.clear();
-    session.resetActiveIndexLatches();
-  }, [lineRuntime, session, songId]);
+  }, [lineRuntime, songId]);
 
   useEffect(() => {
     if (isPlainText || !songId || !viewportActive) {

--- a/src/lib/lyrics-session/lyrics-session.test.ts
+++ b/src/lib/lyrics-session/lyrics-session.test.ts
@@ -541,6 +541,31 @@ describe("LyricsSession active line derivation", () => {
     expect(harness.session.getState().activeWordIndex).toBe(-1);
   });
 
+  test("highlights the first word after a line change onto the previous line's word index", async () => {
+    await load(
+      harness,
+      payload({
+        lines: [
+          line(1000, "solo", [{ text: "solo", time_ms: 1000, end_ms: 1900 }]),
+          line(2000, "next word", [
+            { text: "next", time_ms: 2000, end_ms: 2400 },
+            { text: "word", time_ms: 2400, end_ms: 2900 },
+          ]),
+        ],
+      }),
+    );
+
+    harness.session.syncActiveLine(1200);
+    harness.session.syncActiveWord(1200);
+    expect(harness.session.getState().activeWordIndex).toBe(0);
+
+    harness.session.syncActiveLine(2100);
+    harness.session.syncActiveWord(2100);
+
+    expect(harness.session.getState().activeLineIndex).toBe(1);
+    expect(harness.session.getState().activeWordIndex).toBe(0);
+  });
+
   test("re-derives the same index for a new song instead of holding the latch", async () => {
     await load(harness, payload({ songId: "song-A", lines: TIMED_LINES }));
     harness.session.syncActiveLine(2000);

--- a/src/lib/lyrics-session/lyrics-session.ts
+++ b/src/lib/lyrics-session/lyrics-session.ts
@@ -102,8 +102,6 @@ export class LyricsSession {
   readonly scroll = new LyricsScrollControl();
 
   private fetchGeneration = 0;
-  private syncedLineIndex = -1;
-  private syncedWordIndex = -1;
 
   constructor(private readonly deps: LyricsSessionDependencies) {
     this.store = create<LyricsState>(() => ({
@@ -130,7 +128,6 @@ export class LyricsSession {
 
   async load(songId: string): Promise<void> {
     const generation = ++this.fetchGeneration;
-    this.resetActiveIndexLatches();
     this.set({
       isLoading: true,
       lines: [],
@@ -170,7 +167,6 @@ export class LyricsSession {
   }
 
   clear(): void {
-    this.resetActiveIndexLatches();
     this.set({
       songId: null,
       lines: [],
@@ -241,34 +237,16 @@ export class LyricsSession {
     const { lines } = this.getState();
     if (lines.length === 0) return;
 
-    const index = findActiveLyricLineIndex(lines, adjustedMs);
-    if (index === this.syncedLineIndex) return;
-
-    this.syncedLineIndex = index;
-    this.setActiveLineIndex(index);
+    this.setActiveLineIndex(findActiveLyricLineIndex(lines, adjustedMs));
   }
 
   syncActiveWord(adjustedMs: number): void {
     const { lines, activeLineIndex } = this.getState();
     const words = lines[activeLineIndex]?.words;
 
-    if (words && words.length > 0) {
-      const index = findActiveWordIndex(words, adjustedMs);
-      if (index === this.syncedWordIndex) return;
-      this.syncedWordIndex = index;
-      this.setActiveWordIndex(index);
-      return;
-    }
-
-    if (this.syncedWordIndex === -1) return;
-    this.syncedWordIndex = -1;
-    this.setActiveWordIndex(-1);
-  }
-
-  /** Forgets what was on screen, so the next frame re-derives from scratch. */
-  resetActiveIndexLatches(): void {
-    this.syncedLineIndex = -1;
-    this.syncedWordIndex = -1;
+    this.setActiveWordIndex(
+      words && words.length > 0 ? findActiveWordIndex(words, adjustedMs) : -1,
+    );
   }
 
   toggleRomanized(): void {

--- a/src/lib/settings-controller/index.ts
+++ b/src/lib/settings-controller/index.ts
@@ -4,6 +4,7 @@ export {
 } from "./settings-controller";
 export { createZustandSettingsStores } from "./zustand-stores";
 export type {
+  LibraryCommandResult,
   ModelStatusView,
   ModelUpdateView,
   RuntimeStatusView,

--- a/src/lib/settings-controller/settings-controller.test.ts
+++ b/src/lib/settings-controller/settings-controller.test.ts
@@ -544,7 +544,7 @@ describe("library commands", () => {
     expect(deleteLibrary).toHaveBeenCalledWith(driveRepository.id);
   });
 
-  test("Delete Repository stops when the typed name does not match", async () => {
+  test("a mismatched name stops the delete before the native prompt", async () => {
     const deleteLibrary = vi.fn(async () => registryOf(null, []));
     const harness = createSettingsHarness({
       overrides: {
@@ -556,10 +556,11 @@ describe("library commands", () => {
       },
     });
     await harness.controller.initialize();
-    vi.spyOn(window, "confirm").mockReturnValue(true);
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
 
     await harness.controller.library.delete(driveRepository.id, "Wrong");
 
+    expect(confirm).not.toHaveBeenCalled();
     expect(deleteLibrary).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/settings-controller/settings-controller.test.ts
+++ b/src/lib/settings-controller/settings-controller.test.ts
@@ -352,6 +352,32 @@ describe("library commands", () => {
     expect(switchLibrary).not.toHaveBeenCalled();
   });
 
+  test("a successful activation reports ok to its caller", async () => {
+    const harness = createSettingsHarness();
+
+    const result = await harness.controller.library.activate(
+      driveRepository.id,
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(harness.view().library.error).toBeNull();
+  });
+
+  test("a failed activation reports its error to the caller", async () => {
+    const harness = createSettingsHarness();
+    harness.librarySession.failOn(
+      "switchLibrary",
+      new Error("endpoint unreachable"),
+    );
+
+    const result = await harness.controller.library.activate(
+      driveRepository.id,
+    );
+
+    expect(result).toEqual({ ok: false, error: "endpoint unreachable" });
+    expect(harness.view().library.error).toBe("endpoint unreachable");
+  });
+
   test("refreshing an active Remote Repository refreshes in place", async () => {
     const harness = createSettingsHarness({
       overrides: {

--- a/src/lib/settings-controller/settings-controller.test.ts
+++ b/src/lib/settings-controller/settings-controller.test.ts
@@ -376,6 +376,19 @@ describe("library commands", () => {
     expect(harness.view().library.error).toBe("disk full");
   });
 
+  test("a rejecting directory picker reports the error instead of rejecting", async () => {
+    const harness = createSettingsHarness();
+    harness.selectDirectory.mockRejectedValue(new Error("picker crashed"));
+
+    const created = await harness.controller.library.create("Create library");
+    const opened = await harness.controller.library.open("Open library");
+
+    expect(created).toEqual({ ok: false, error: "picker crashed" });
+    expect(opened).toEqual({ ok: false, error: "picker crashed" });
+    expect(harness.view().library.error).toBe("picker crashed");
+    expect(harness.librarySession.calls).toEqual([]);
+  });
+
   test("the session's registry view refreshes the library slice", async () => {
     const harness = createSettingsHarness({
       overrides: {

--- a/src/lib/settings-controller/settings-controller.test.ts
+++ b/src/lib/settings-controller/settings-controller.test.ts
@@ -270,6 +270,68 @@ describe("initialize", () => {
     expect(harness.notifyError).toHaveBeenCalledTimes(2);
     expect(harness.view().isInitializing).toBe(false);
   });
+
+  test("records a failed model status read in the view instead of swallowing it", async () => {
+    let failing = true;
+    const harness = createSettingsHarness({
+      runtimeStatus: runtimeStatus(),
+      overrides: {
+        settings: {
+          getRuntimeBootstrapStatus: async () => runtimeStatus(),
+          getModelStatus: async (variant) => {
+            if (failing) {
+              throw new Error("model directory unreadable");
+            }
+            return modelStatus({ variant, downloaded: true });
+          },
+        },
+      },
+    });
+
+    await harness.controller.initialize();
+
+    expect(harness.view().models.statusesError).toBe(
+      "model directory unreadable",
+    );
+    expect(harness.view().models.statuses).toEqual({});
+    expect(harness.notifyError).not.toHaveBeenCalled();
+
+    failing = false;
+    await harness.controller.initialize();
+
+    expect(harness.view().models.statusesError).toBeNull();
+    expect(harness.view().models.statuses.htdemucs?.downloaded).toBe(true);
+  });
+
+  test("records a failed runtime status read in the view instead of swallowing it", async () => {
+    let failing = true;
+    const harness = createSettingsHarness({
+      runtimeStatus: runtimeStatus(),
+      overrides: {
+        settings: {
+          getModelStatus: async (variant) => modelStatus({ variant }),
+          getRuntimeBootstrapStatus: async () => {
+            if (failing) {
+              throw new Error("runtime probe crashed");
+            }
+            return runtimeStatus({ state: "missing" });
+          },
+        },
+      },
+    });
+
+    await harness.controller.initialize();
+
+    expect(harness.view().runtime.statusError).toBe("runtime probe crashed");
+    expect(harness.view().runtime.status?.state).toBe("ready");
+    expect(harness.notifyError).not.toHaveBeenCalled();
+
+    failing = false;
+    await harness.controller.maintenance.checkRuntimeUpdates();
+
+    expect(harness.view().runtime.statusError).toBeNull();
+    expect(harness.view().runtime.status?.state).toBe("missing");
+  });
 });
 
 describe("library commands", () => {

--- a/src/lib/settings-controller/settings-controller.test.ts
+++ b/src/lib/settings-controller/settings-controller.test.ts
@@ -1487,6 +1487,28 @@ describe("library integrity", () => {
     expect(harness.view().integrity.skippedCount).toBe(2);
   });
 
+  test("cleanup without a report still prunes the selection and records skips", async () => {
+    const harness = createSettingsHarness({
+      overrides: {
+        library: {
+          removeMissingLibraryEntries: async () => ({
+            deleted_song_hashes: ["hash-a"],
+            skipped_song_hashes: ["hash-b"],
+          }),
+        },
+      },
+    });
+    harness.controller.library.toggleIntegrityEntry("hash-a");
+    harness.controller.library.toggleIntegrityEntry("hash-b");
+
+    await harness.controller.library.cleanUpIntegrity();
+
+    const integrity = harness.view().integrity;
+    expect(integrity.report).toBeNull();
+    expect([...integrity.selection]).toEqual(["hash-b"]);
+    expect(integrity.skippedCount).toBe(1);
+  });
+
   test("cleanup with an empty selection just closes the dialog", async () => {
     const removeMissingLibraryEntries = vi.fn();
     const harness = createSettingsHarness({

--- a/src/lib/settings-controller/settings-controller.ts
+++ b/src/lib/settings-controller/settings-controller.ts
@@ -11,6 +11,7 @@ import type {
   RuntimeBootstrapStatusSnapshot,
 } from "@/types/ipc";
 import type {
+  LibraryCommandResult,
   ModelStatusView,
   SettingsController,
   SettingsControllerDependencies,
@@ -282,13 +283,18 @@ export function createSettingsController({
     refreshModelStatuses,
   });
 
-  const runLibraryWork = async (work: () => Promise<void>) => {
+  const runLibraryWork = async (
+    work: () => Promise<void>,
+  ): Promise<LibraryCommandResult> => {
     patchLibrary({ error: null });
 
     try {
       await work();
+      return { ok: true };
     } catch (error: unknown) {
-      patchLibrary({ error: getErrorMessage(error) });
+      const message = getErrorMessage(error);
+      patchLibrary({ error: message });
+      return { ok: false, error: message };
     }
   };
 
@@ -661,18 +667,18 @@ export function createSettingsController({
     library: {
       create: async (dialogTitle) => {
         const directory = await selectDirectory(dialogTitle);
-        if (!directory) return;
+        if (!directory) return { ok: true };
 
-        await runLibraryWork(() =>
+        return runLibraryWork(() =>
           librarySession.createLocalLibrary(directory),
         );
       },
 
       open: async (dialogTitle) => {
         const directory = await selectDirectory(dialogTitle);
-        if (!directory) return;
+        if (!directory) return { ok: true };
 
-        await runLibraryWork(() => librarySession.openLocalLibrary(directory));
+        return runLibraryWork(() => librarySession.openLocalLibrary(directory));
       },
 
       activate: (libraryId) =>

--- a/src/lib/settings-controller/settings-controller.ts
+++ b/src/lib/settings-controller/settings-controller.ts
@@ -548,6 +548,14 @@ export function createSettingsController({
       await stores.library.loadLibrary();
       await stores.player.loadState();
 
+      patchIntegrity({
+        selection: new Set(selectedHashes.filter((hash) => !deleted.has(hash))),
+        skippedCount:
+          result.skipped_song_hashes.length > 0
+            ? result.skipped_song_hashes.length
+            : null,
+      });
+
       if (report) {
         const keep = (issue: { song_hash: string }) =>
           !deleted.has(issue.song_hash);
@@ -561,13 +569,6 @@ export function createSettingsController({
               report.missing_optional_assets.filter(keep),
             empty_optional_assets: report.empty_optional_assets.filter(keep),
           },
-          selection: new Set(
-            selectedHashes.filter((hash) => !deleted.has(hash)),
-          ),
-          skippedCount:
-            result.skipped_song_hashes.length > 0
-              ? result.skipped_song_hashes.length
-              : null,
         });
       }
     } catch (error: unknown) {

--- a/src/lib/settings-controller/settings-controller.ts
+++ b/src/lib/settings-controller/settings-controller.ts
@@ -148,9 +148,15 @@ export function createSettingsController({
       error: null,
     },
     preferences: toPreferencesView(stores.preferences.getSnapshot()),
-    models: { statuses: {}, downloading: null, update: null },
+    models: {
+      statuses: {},
+      statusesError: null,
+      downloading: null,
+      update: null,
+    },
     runtime: {
       status: toRuntimeStatusView(stores.runtimeStatus.getStatus()),
+      statusError: null,
       update: null,
     },
     integrity: {
@@ -264,8 +270,11 @@ export function createSettingsController({
           htdemucs: toModelStatusView(standard),
           htdemucs_ft: toModelStatusView(fineTuned),
         },
+        statusesError: null,
       });
-    } catch {}
+    } catch (error) {
+      patchModels({ statusesError: getErrorMessage(error) });
+    }
   };
 
   const refreshRuntimeStatus = async () => {
@@ -273,8 +282,11 @@ export function createSettingsController({
       stores.runtimeStatus.updateStatus(
         await backend.settings.getRuntimeBootstrapStatus(),
       );
+      patchRuntime({ statusError: null });
       syncStores();
-    } catch {}
+    } catch (error) {
+      patchRuntime({ statusError: getErrorMessage(error) });
+    }
   };
 
   const librarySession = createLibrarySession({

--- a/src/lib/settings-controller/settings-controller.ts
+++ b/src/lib/settings-controller/settings-controller.ts
@@ -753,7 +753,7 @@ export function createSettingsController({
                   appName: i18next.t("app.name"),
                 });
 
-          if (!window.confirm(message) || confirmationName !== displayName) {
+          if (confirmationName !== displayName || !window.confirm(message)) {
             return;
           }
 

--- a/src/lib/settings-controller/settings-controller.ts
+++ b/src/lib/settings-controller/settings-controller.ts
@@ -678,21 +678,21 @@ export function createSettingsController({
     },
 
     library: {
-      create: async (dialogTitle) => {
-        const directory = await selectDirectory(dialogTitle);
-        if (!directory) return { ok: true };
+      create: (dialogTitle) =>
+        runLibraryWork(async () => {
+          const directory = await selectDirectory(dialogTitle);
+          if (directory) {
+            await librarySession.createLocalLibrary(directory);
+          }
+        }),
 
-        return runLibraryWork(() =>
-          librarySession.createLocalLibrary(directory),
-        );
-      },
-
-      open: async (dialogTitle) => {
-        const directory = await selectDirectory(dialogTitle);
-        if (!directory) return { ok: true };
-
-        return runLibraryWork(() => librarySession.openLocalLibrary(directory));
-      },
+      open: (dialogTitle) =>
+        runLibraryWork(async () => {
+          const directory = await selectDirectory(dialogTitle);
+          if (directory) {
+            await librarySession.openLocalLibrary(directory);
+          }
+        }),
 
       activate: (libraryId) =>
         runLibraryWork(() => librarySession.switchLibrary(libraryId)),

--- a/src/lib/settings-controller/types.ts
+++ b/src/lib/settings-controller/types.ts
@@ -85,12 +85,16 @@ export interface SettingsLibraryView {
 
 export interface SettingsModelsView {
   statuses: Partial<Record<ModelVariant, ModelStatusView>>;
+  /** Why the last model status read failed, or null after a successful read. */
+  statusesError: string | null;
   downloading: ModelVariant | null;
   update: ModelUpdateView | null;
 }
 
 export interface SettingsRuntimeView {
   status: RuntimeStatusView | null;
+  /** Why the last runtime status read failed, or null after a successful read. */
+  statusError: string | null;
   update: RuntimeUpdateView | null;
 }
 
@@ -200,7 +204,8 @@ export interface SettingsMaintenanceCommands {
 /**
  * Owns everything the Settings surfaces read and every mutation they can
  * start. Commands never reject: a failure lands either in `view.library.error`
- * (library work), in the matching `update` slice (update checks), or on the
+ * (library work), in the matching `update` slice (update checks), in
+ * `models.statusesError` or `runtime.statusError` (status reads), or on the
  * error reporter. The view is replaced, never mutated, so consumers can
  * compare identities.
  */

--- a/src/lib/settings-controller/types.ts
+++ b/src/lib/settings-controller/types.ts
@@ -140,26 +140,36 @@ export interface WritablePreferences {
 
 export type SettingsPreferencePatch = Partial<WritablePreferences>;
 
+/**
+ * How a library command settled. Commands still never reject; `ok: false`
+ * carries the message recorded in `view.library.error`, so a caller can gate
+ * follow-up UI (such as closing a wizard) on success.
+ */
+export type LibraryCommandResult = { ok: true } | { ok: false; error: string };
+
 export interface SettingsLibraryCommands {
   /** Creates a Local Working Copy under a directory the user picks. */
-  create(dialogTitle: string): Promise<void>;
+  create(dialogTitle: string): Promise<LibraryCommandResult>;
   /** Registers an existing Local Working Copy the user picks. */
-  open(dialogTitle: string): Promise<void>;
+  open(dialogTitle: string): Promise<LibraryCommandResult>;
   /** Makes `libraryId` the active library. */
-  activate(libraryId: string): Promise<void>;
+  activate(libraryId: string): Promise<LibraryCommandResult>;
   /**
    * Refresh Repository for a Remote Repository, activating it first when it is
    * not already active. Ignores libraries that are not remote.
    */
-  refresh(libraryId: string): Promise<void>;
-  rename(libraryId: string, displayName: string): Promise<void>;
+  refresh(libraryId: string): Promise<LibraryCommandResult>;
+  rename(libraryId: string, displayName: string): Promise<LibraryCommandResult>;
   /** Disconnect Repository after a confirmation prompt. */
-  disconnect(libraryId: string): Promise<void>;
+  disconnect(libraryId: string): Promise<LibraryCommandResult>;
   /**
    * Delete Repository. Runs only when the prompt is accepted and
    * `confirmationName` matches the library's display name exactly.
    */
-  delete(libraryId: string, confirmationName: string): Promise<void>;
+  delete(
+    libraryId: string,
+    confirmationName: string,
+  ): Promise<LibraryCommandResult>;
   checkIntegrity(): Promise<void>;
   toggleIntegrityEntry(songHash: string): void;
   /** Removes the selected integrity entries, then re-reads the song list. */
@@ -201,8 +211,9 @@ export interface SettingsMaintenanceCommands {
  * Owns everything the Settings surfaces read and every mutation they can
  * start. Commands never reject: a failure lands either in `view.library.error`
  * (library work), in the matching `update` slice (update checks), or on the
- * error reporter. The view is replaced, never mutated, so consumers can
- * compare identities.
+ * error reporter. Library commands also report that outcome as a
+ * `LibraryCommandResult` so callers can react to a failure. The view is
+ * replaced, never mutated, so consumers can compare identities.
  */
 export interface SettingsController {
   getView(): SettingsView;

--- a/src/lib/task-progress.test.ts
+++ b/src/lib/task-progress.test.ts
@@ -508,7 +508,7 @@ describe("createModelDownloadFlash", () => {
     expect(emit).not.toHaveBeenCalled();
   });
 
-  test("cancels a pending settle when the model state changes again", () => {
+  test("hides a visible flash as soon as the model state changes again", () => {
     vi.useFakeTimers();
     const emit = vi.fn();
     const flash = createModelDownloadFlash(emit);
@@ -517,9 +517,36 @@ describe("createModelDownloadFlash", () => {
     flash.observe("ready");
     vi.advanceTimersByTime(0);
     flash.observe("failed");
+
+    expect(emit.mock.calls).toEqual([[true], [false]]);
+  });
+
+  test("does not resurface the flash when the state returns to ready without a new download", () => {
+    vi.useFakeTimers();
+    const emit = vi.fn();
+    const flash = createModelDownloadFlash(emit);
+
+    flash.observe("downloading");
+    flash.observe("ready");
+    vi.advanceTimersByTime(0);
+    flash.observe("failed");
+    flash.observe("ready");
     vi.advanceTimersByTime(MODEL_DOWNLOAD_FLASH_MS * 2);
 
-    expect(emit.mock.calls).toEqual([[true]]);
+    expect(emit.mock.calls).toEqual([[true], [false]]);
+  });
+
+  test("cancels a scheduled flash that has not shown yet without emitting", () => {
+    vi.useFakeTimers();
+    const emit = vi.fn();
+    const flash = createModelDownloadFlash(emit);
+
+    flash.observe("downloading");
+    flash.observe("ready");
+    flash.observe("downloading");
+    vi.advanceTimersByTime(MODEL_DOWNLOAD_FLASH_MS * 2);
+
+    expect(emit).not.toHaveBeenCalled();
   });
 
   test("stops a scheduled flash when disposed", () => {

--- a/src/lib/task-progress.ts
+++ b/src/lib/task-progress.ts
@@ -225,11 +225,18 @@ export function createModelDownloadFlash(
   flashMs: number = MODEL_DOWNLOAD_FLASH_MS,
 ): ModelDownloadFlash {
   let previous: ModelBootstrapState | undefined;
+  let shown = false;
   let timers: ReturnType<typeof setTimeout>[] = [];
 
   const clearTimers = () => {
     timers.forEach((timer) => globalThis.clearTimeout(timer));
     timers = [];
+  };
+
+  const hide = () => {
+    if (!shown) return;
+    shown = false;
+    emit(false);
   };
 
   return {
@@ -239,12 +246,14 @@ export function createModelDownloadFlash(
       const downloadSettled = previous === "downloading" && state === "ready";
       previous = state;
       clearTimers();
+      hide();
       if (!downloadSettled) return;
 
       timers.push(
         globalThis.setTimeout(() => {
+          shown = true;
           emit(true);
-          timers.push(globalThis.setTimeout(() => emit(false), flashMs));
+          timers.push(globalThis.setTimeout(hide, flashMs));
         }, 0),
       );
     },

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -347,6 +347,7 @@
       "removeLibrary": "Repository trennen",
       "deleteLibrary": "Repository löschen",
       "typeToConfirmDelete": "Geben Sie „{{displayName}}“ ein, um die dauerhafte Löschung zu bestätigen.",
+      "confirmNameMismatch": "Der eingegebene Name stimmt nicht mit „{{displayName}}“ überein.",
       "confirmDisconnectRemote": "„{{displayName}}“ von {{appName}} trennen? Der Inhalt des Remote-Repositorys bleibt in {{provider}}.",
       "confirmDisconnectLocal": "Diese Bibliothek von {{appName}} trennen? Die Bibliotheksdaten bleiben auf dem Datenträger.",
       "confirmDeleteRemote": "„{{displayName}}“ löschen? Dadurch werden der Inhalt des Remote-Repositorys aus {{provider}} unter {{path}} und die lokale Arbeitskopie gelöscht.",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -412,6 +412,8 @@
       "downloaded": "Heruntergeladen",
       "legacyOnDisk": "Alte Version auf der Festplatte — in der Gefahrenzone löschen, dann erneut herunterladen",
       "notDownloaded": "Nicht heruntergeladen",
+      "statusUnavailable": "Status nicht verfügbar",
+      "statusReadFailed": "Modellstatus konnte nicht gelesen werden.",
       "runtimeRequired": "ONNX Runtime erforderlich",
       "delete": "Löschen",
       "download": "Herunterladen"
@@ -429,6 +431,7 @@
       "retryButton": "ONNX Runtime neu installieren",
       "statusReady": "Installiert und bereit.",
       "statusMissing": "Nicht installiert.",
+      "statusReadFailed": "Runtime-Status konnte nicht gelesen werden.",
       "version": "Version {{version}}",
       "checkButton": "Nach Updates suchen",
       "checking": "Nach Updates wird gesucht…",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -347,6 +347,7 @@
       "removeLibrary": "Disconnect repository",
       "deleteLibrary": "Delete repository",
       "typeToConfirmDelete": "Type \"{{displayName}}\" to confirm permanent deletion.",
+      "confirmNameMismatch": "The name does not match \"{{displayName}}\".",
       "confirmDisconnectRemote": "Disconnect \"{{displayName}}\" from {{appName}}? The remote repository contents will stay in {{provider}}.",
       "confirmDisconnectLocal": "Disconnect this library from {{appName}}? The library data will stay on disk.",
       "confirmDeleteRemote": "Delete \"{{displayName}}\"? This will delete the remote repository contents from {{provider}} at {{path}} and remove the local working copy.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -412,6 +412,8 @@
       "downloaded": "Downloaded",
       "legacyOnDisk": "Old version on disk — delete in Danger Zone, then download again",
       "notDownloaded": "Not downloaded",
+      "statusUnavailable": "Status unavailable",
+      "statusReadFailed": "Couldn't read model status.",
       "runtimeRequired": "ONNX Runtime required",
       "delete": "Delete",
       "download": "Download"
@@ -429,6 +431,7 @@
       "retryButton": "Reinstall ONNX Runtime",
       "statusReady": "Installed and ready.",
       "statusMissing": "Not installed.",
+      "statusReadFailed": "Couldn't read runtime status.",
       "version": "Version {{version}}",
       "checkButton": "Check for updates",
       "checking": "Checking for updates...",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -413,6 +413,8 @@
       "downloaded": "Descargado",
       "legacyOnDisk": "Versión antigua en disco: elimínala en la Zona de peligro y vuelve a descargarla",
       "notDownloaded": "No descargado",
+      "statusUnavailable": "Estado no disponible",
+      "statusReadFailed": "No se pudo leer el estado de los modelos.",
       "runtimeRequired": "Se requiere ONNX Runtime",
       "delete": "Eliminar",
       "download": "Descargar"
@@ -430,6 +432,7 @@
       "retryButton": "Reinstalar ONNX Runtime",
       "statusReady": "Instalado y listo.",
       "statusMissing": "No instalado.",
+      "statusReadFailed": "No se pudo leer el estado del runtime.",
       "version": "Versión {{version}}",
       "checkButton": "Buscar actualizaciones",
       "checking": "Buscando actualizaciones...",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -348,6 +348,7 @@
       "removeLibrary": "Desconectar repositorio",
       "deleteLibrary": "Eliminar repositorio",
       "typeToConfirmDelete": "Escribe «{{displayName}}» para confirmar la eliminación permanente.",
+      "confirmNameMismatch": "El nombre escrito no coincide con «{{displayName}}».",
       "confirmDisconnectRemote": "¿Desconectar «{{displayName}}» de {{appName}}? El contenido del repositorio remoto permanecerá en {{provider}}.",
       "confirmDisconnectLocal": "¿Desconectar esta biblioteca de {{appName}}? Los datos de la biblioteca permanecerán en el disco.",
       "confirmDeleteRemote": "¿Eliminar «{{displayName}}»? Se eliminará el contenido del repositorio remoto de {{provider}} en {{path}} y la copia de trabajo local.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -413,6 +413,8 @@
       "downloaded": "Téléchargé",
       "legacyOnDisk": "Ancienne version sur le disque — supprimez-la dans la Zone de danger, puis téléchargez à nouveau",
       "notDownloaded": "Non téléchargé",
+      "statusUnavailable": "Statut indisponible",
+      "statusReadFailed": "Impossible de lire l'état des modèles.",
       "runtimeRequired": "ONNX Runtime requis",
       "delete": "Supprimer",
       "download": "Télécharger"
@@ -430,6 +432,7 @@
       "retryButton": "Réinstaller ONNX Runtime",
       "statusReady": "Installé et prêt.",
       "statusMissing": "Non installé.",
+      "statusReadFailed": "Impossible de lire l'état du runtime.",
       "version": "Version {{version}}",
       "checkButton": "Rechercher des mises à jour",
       "checking": "Recherche de mises à jour...",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -348,6 +348,7 @@
       "removeLibrary": "Déconnecter le dépôt",
       "deleteLibrary": "Supprimer le dépôt",
       "typeToConfirmDelete": "Saisissez « {{displayName}} » pour confirmer la suppression définitive.",
+      "confirmNameMismatch": "Le nom saisi ne correspond pas à « {{displayName}} ».",
       "confirmDisconnectRemote": "Déconnecter « {{displayName}} » de {{appName}} ? Le contenu du dépôt distant restera dans {{provider}}.",
       "confirmDisconnectLocal": "Déconnecter cette bibliothèque de {{appName}} ? Les données de la bibliothèque resteront sur le disque.",
       "confirmDeleteRemote": "Supprimer « {{displayName}} » ? Le contenu du dépôt distant de {{provider}} à l’emplacement {{path}} et la copie de travail locale seront supprimés.",

--- a/src/locales/id.json
+++ b/src/locales/id.json
@@ -346,6 +346,7 @@
       "removeLibrary": "Putuskan repositori",
       "deleteLibrary": "Hapus repositori",
       "typeToConfirmDelete": "Ketik \"{{displayName}}\" untuk mengonfirmasi penghapusan permanen.",
+      "confirmNameMismatch": "Nama yang diketik tidak cocok dengan \"{{displayName}}\".",
       "confirmDisconnectRemote": "Putuskan \"{{displayName}}\" dari {{appName}}? Isi repositori jarak jauh akan tetap di {{provider}}.",
       "confirmDisconnectLocal": "Putuskan pustaka ini dari {{appName}}? Data pustaka akan tetap di disk.",
       "confirmDeleteRemote": "Hapus \"{{displayName}}\"? Isi repositori jarak jauh di {{provider}} pada {{path}} dan salinan kerja lokal akan dihapus.",

--- a/src/locales/id.json
+++ b/src/locales/id.json
@@ -411,6 +411,8 @@
       "downloaded": "Terunduh",
       "legacyOnDisk": "Versi lama di disk — hapus di Zona Bahaya, lalu unduh lagi",
       "notDownloaded": "Belum diunduh",
+      "statusUnavailable": "Status tidak tersedia",
+      "statusReadFailed": "Tidak dapat membaca status model.",
       "runtimeRequired": "ONNX Runtime diperlukan",
       "delete": "Hapus",
       "download": "Unduh"
@@ -428,6 +430,7 @@
       "retryButton": "Instal Ulang ONNX Runtime",
       "statusReady": "Terinstal dan siap.",
       "statusMissing": "Belum terinstal.",
+      "statusReadFailed": "Tidak dapat membaca status runtime.",
       "version": "Versi {{version}}",
       "checkButton": "Periksa pembaruan",
       "checking": "Memeriksa pembaruan...",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -413,6 +413,8 @@
       "downloaded": "Scaricato",
       "legacyOnDisk": "Vecchia versione su disco — eliminala nella Zona pericolo, poi scaricala di nuovo",
       "notDownloaded": "Non scaricato",
+      "statusUnavailable": "Stato non disponibile",
+      "statusReadFailed": "Impossibile leggere lo stato dei modelli.",
       "runtimeRequired": "ONNX Runtime richiesto",
       "delete": "Elimina",
       "download": "Scarica"
@@ -430,6 +432,7 @@
       "retryButton": "Reinstalla ONNX Runtime",
       "statusReady": "Installato e pronto.",
       "statusMissing": "Non installato.",
+      "statusReadFailed": "Impossibile leggere lo stato del runtime.",
       "version": "Versione {{version}}",
       "checkButton": "Controlla aggiornamenti",
       "checking": "Controllo aggiornamenti...",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -348,6 +348,7 @@
       "removeLibrary": "Disconnetti repository",
       "deleteLibrary": "Elimina repository",
       "typeToConfirmDelete": "Digita \"{{displayName}}\" per confermare l'eliminazione permanente.",
+      "confirmNameMismatch": "Il nome digitato non corrisponde a \"{{displayName}}\".",
       "confirmDisconnectRemote": "Disconnettere \"{{displayName}}\" da {{appName}}? Il contenuto del repository remoto resterà in {{provider}}.",
       "confirmDisconnectLocal": "Disconnettere questa libreria da {{appName}}? I dati della libreria resteranno sul disco.",
       "confirmDeleteRemote": "Eliminare \"{{displayName}}\"? Verranno eliminati il contenuto del repository remoto in {{provider}} al percorso {{path}} e la copia di lavoro locale.",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -346,6 +346,7 @@
       "removeLibrary": "リポジトリを切断",
       "deleteLibrary": "リポジトリを削除",
       "typeToConfirmDelete": "完全に削除するには「{{displayName}}」と入力してください。",
+      "confirmNameMismatch": "入力された名前が「{{displayName}}」と一致しません。",
       "confirmDisconnectRemote": "{{appName}} から「{{displayName}}」を切断しますか？リモートリポジトリの内容は {{provider}} に残ります。",
       "confirmDisconnectLocal": "{{appName}} からこのライブラリを切断しますか？ライブラリのデータはディスクに残ります。",
       "confirmDeleteRemote": "「{{displayName}}」を削除しますか？{{provider}} の {{path}} にあるリモートリポジトリの内容とローカル作業コピーを削除します。",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -411,6 +411,8 @@
       "downloaded": "ダウンロード済み",
       "legacyOnDisk": "古いバージョンがディスク上にあります — デンジャーゾーンで削除してから再ダウンロードしてください",
       "notDownloaded": "未ダウンロード",
+      "statusUnavailable": "状態不明",
+      "statusReadFailed": "モデルの状態を読み取れませんでした。",
       "runtimeRequired": "ONNX Runtime が必要です",
       "delete": "削除",
       "download": "ダウンロード"
@@ -428,6 +430,7 @@
       "retryButton": "ONNX Runtime を再インストール",
       "statusReady": "インストール済みで使用可能です。",
       "statusMissing": "インストールされていません。",
+      "statusReadFailed": "ランタイムの状態を読み取れませんでした。",
       "version": "バージョン {{version}}",
       "checkButton": "更新を確認",
       "checking": "更新を確認中...",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -346,6 +346,7 @@
       "removeLibrary": "저장소 연결 해제",
       "deleteLibrary": "저장소 삭제",
       "typeToConfirmDelete": "영구 삭제를 확인하려면 \"{{displayName}}\"을(를) 입력하세요.",
+      "confirmNameMismatch": "입력한 이름이 \"{{displayName}}\"과(와) 일치하지 않습니다.",
       "confirmDisconnectRemote": "{{appName}}에서 \"{{displayName}}\"의 연결을 끊을까요? 원격 저장소의 내용은 {{provider}}에 남아요.",
       "confirmDisconnectLocal": "{{appName}}에서 이 라이브러리의 연결을 끊을까요? 라이브러리 데이터는 디스크에 남아요.",
       "confirmDeleteRemote": "\"{{displayName}}\"을(를) 삭제할까요? {{provider}}의 {{path}}에 있는 원격 저장소 내용과 로컬 작업 복사본을 삭제해요.",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -411,6 +411,8 @@
       "downloaded": "다운로드됨",
       "legacyOnDisk": "디스크에 이전 버전이 있어요 — 위험 구역에서 삭제한 뒤 다시 다운로드하세요",
       "notDownloaded": "다운로드 안 됨",
+      "statusUnavailable": "상태 확인 불가",
+      "statusReadFailed": "모델 상태를 읽지 못했어요.",
       "runtimeRequired": "ONNX Runtime 필요",
       "delete": "삭제",
       "download": "다운로드"
@@ -428,6 +430,7 @@
       "retryButton": "ONNX Runtime 다시 설치",
       "statusReady": "설치되어 준비됐어요.",
       "statusMissing": "설치되지 않았어요.",
+      "statusReadFailed": "런타임 상태를 읽지 못했어요.",
       "version": "버전 {{version}}",
       "checkButton": "업데이트 확인",
       "checking": "업데이트 확인 중...",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -347,6 +347,7 @@
       "removeLibrary": "Opslag loskoppelen",
       "deleteLibrary": "Opslag verwijderen",
       "typeToConfirmDelete": "Typ \"{{displayName}}\" om definitieve verwijdering te bevestigen.",
+      "confirmNameMismatch": "De getypte naam komt niet overeen met \"{{displayName}}\".",
       "confirmDisconnectRemote": "\"{{displayName}}\" loskoppelen van {{appName}}? De inhoud van de externe opslag blijft in {{provider}}.",
       "confirmDisconnectLocal": "Deze bibliotheek loskoppelen van {{appName}}? De bibliotheekgegevens blijven op schijf staan.",
       "confirmDeleteRemote": "\"{{displayName}}\" verwijderen? De inhoud van de externe opslag in {{provider}} op {{path}} en de lokale werkkopie worden verwijderd.",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -412,6 +412,8 @@
       "downloaded": "Gedownload",
       "legacyOnDisk": "Oude versie op schijf — verwijder in de gevarenzone en download opnieuw",
       "notDownloaded": "Niet gedownload",
+      "statusUnavailable": "Status niet beschikbaar",
+      "statusReadFailed": "Kan de modelstatus niet lezen.",
       "runtimeRequired": "ONNX Runtime vereist",
       "delete": "Verwijderen",
       "download": "Downloaden"
@@ -429,6 +431,7 @@
       "retryButton": "ONNX Runtime opnieuw installeren",
       "statusReady": "Geïnstalleerd en klaar.",
       "statusMissing": "Niet geïnstalleerd.",
+      "statusReadFailed": "Kan de status van de runtime niet lezen.",
       "version": "Versie {{version}}",
       "checkButton": "Controleren op updates",
       "checking": "Controleren op updates...",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -414,6 +414,8 @@
       "downloaded": "Pobrano",
       "legacyOnDisk": "Stara wersja na dysku — usuń w Strefie zagrożenia, a następnie pobierz ponownie",
       "notDownloaded": "Nie pobrano",
+      "statusUnavailable": "Stan niedostępny",
+      "statusReadFailed": "Nie udało się odczytać stanu modeli.",
       "runtimeRequired": "Wymagane ONNX Runtime",
       "delete": "Usuń",
       "download": "Pobierz"
@@ -431,6 +433,7 @@
       "retryButton": "Zainstaluj ONNX Runtime ponownie",
       "statusReady": "Zainstalowane i gotowe.",
       "statusMissing": "Nie zainstalowano.",
+      "statusReadFailed": "Nie udało się odczytać stanu środowiska uruchomieniowego.",
       "version": "Wersja {{version}}",
       "checkButton": "Sprawdź aktualizacje",
       "checking": "Sprawdzanie aktualizacji...",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -349,6 +349,7 @@
       "removeLibrary": "Odłącz repozytorium",
       "deleteLibrary": "Usuń repozytorium",
       "typeToConfirmDelete": "Wpisz „{{displayName}}”, aby potwierdzić trwałe usunięcie.",
+      "confirmNameMismatch": "Wpisana nazwa nie zgadza się z „{{displayName}}”.",
       "confirmDisconnectRemote": "Odłączyć „{{displayName}}” od {{appName}}? Zawartość zdalnego repozytorium pozostanie w {{provider}}.",
       "confirmDisconnectLocal": "Odłączyć tę bibliotekę od {{appName}}? Dane biblioteki pozostaną na dysku.",
       "confirmDeleteRemote": "Usunąć „{{displayName}}”? Zawartość zdalnego repozytorium w {{provider}} pod adresem {{path}} oraz lokalna kopia robocza zostaną usunięte.",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -348,6 +348,7 @@
       "removeLibrary": "Desconectar repositório",
       "deleteLibrary": "Excluir repositório",
       "typeToConfirmDelete": "Digite \"{{displayName}}\" para confirmar a exclusão permanente.",
+      "confirmNameMismatch": "O nome digitado não corresponde a \"{{displayName}}\".",
       "confirmDisconnectRemote": "Desconectar \"{{displayName}}\" do {{appName}}? O conteúdo do repositório remoto continuará em {{provider}}.",
       "confirmDisconnectLocal": "Desconectar esta biblioteca do {{appName}}? Os dados da biblioteca continuarão no disco.",
       "confirmDeleteRemote": "Excluir \"{{displayName}}\"? O conteúdo do repositório remoto em {{provider}}, no caminho {{path}}, e a cópia de trabalho local serão excluídos.",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -413,6 +413,8 @@
       "downloaded": "Baixado",
       "legacyOnDisk": "Versão antiga no disco — exclua na Zona de perigo e baixe novamente",
       "notDownloaded": "Não baixado",
+      "statusUnavailable": "Status indisponível",
+      "statusReadFailed": "Não foi possível ler o status dos modelos.",
       "runtimeRequired": "ONNX Runtime necessário",
       "delete": "Excluir",
       "download": "Baixar"
@@ -430,6 +432,7 @@
       "retryButton": "Reinstalar o ONNX Runtime",
       "statusReady": "Instalado e pronto.",
       "statusMissing": "Não instalado.",
+      "statusReadFailed": "Não foi possível ler o status do runtime.",
       "version": "Versão {{version}}",
       "checkButton": "Verificar atualizações",
       "checking": "Verificando atualizações...",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -349,6 +349,7 @@
       "removeLibrary": "Отключить репозиторий",
       "deleteLibrary": "Удалить репозиторий",
       "typeToConfirmDelete": "Введите «{{displayName}}», чтобы подтвердить безвозвратное удаление.",
+      "confirmNameMismatch": "Введённое имя не совпадает с «{{displayName}}».",
       "confirmDisconnectRemote": "Отключить «{{displayName}}» от {{appName}}? Содержимое удалённого репозитория останется в {{provider}}.",
       "confirmDisconnectLocal": "Отключить эту библиотеку от {{appName}}? Данные библиотеки останутся на диске.",
       "confirmDeleteRemote": "Удалить «{{displayName}}»? Содержимое удалённого репозитория в {{provider}} по адресу {{path}} и локальная рабочая копия будут удалены.",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -414,6 +414,8 @@
       "downloaded": "Загружено",
       "legacyOnDisk": "На диске старая версия — удалите в «Опасной зоне», затем загрузите снова",
       "notDownloaded": "Не загружено",
+      "statusUnavailable": "Статус недоступен",
+      "statusReadFailed": "Не удалось получить статус моделей.",
       "runtimeRequired": "Требуется ONNX Runtime",
       "delete": "Удалить",
       "download": "Загрузить"
@@ -431,6 +433,7 @@
       "retryButton": "Переустановить ONNX Runtime",
       "statusReady": "Установлено и готово.",
       "statusMissing": "Не установлено.",
+      "statusReadFailed": "Не удалось получить статус среды выполнения.",
       "version": "Версия {{version}}",
       "checkButton": "Проверить обновления",
       "checking": "Проверка обновлений...",

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -411,6 +411,8 @@
       "downloaded": "ดาวน์โหลดแล้ว",
       "legacyOnDisk": "เวอร์ชันเก่าอยู่ในดิสก์ — ลบในโซนอันตราย แล้วดาวน์โหลดใหม่อีกครั้ง",
       "notDownloaded": "ยังไม่ได้ดาวน์โหลด",
+      "statusUnavailable": "ไม่ทราบสถานะ",
+      "statusReadFailed": "ไม่สามารถอ่านสถานะโมเดลได้",
       "runtimeRequired": "ต้องมี ONNX Runtime",
       "delete": "ลบ",
       "download": "ดาวน์โหลด"
@@ -428,6 +430,7 @@
       "retryButton": "ติดตั้ง ONNX Runtime ใหม่",
       "statusReady": "ติดตั้งแล้วและพร้อมใช้งาน",
       "statusMissing": "ยังไม่ได้ติดตั้ง",
+      "statusReadFailed": "ไม่สามารถอ่านสถานะรันไทม์ได้",
       "version": "เวอร์ชัน {{version}}",
       "checkButton": "ตรวจหาการอัปเดต",
       "checking": "กำลังตรวจหาการอัปเดต...",

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -346,6 +346,7 @@
       "removeLibrary": "ตัดการเชื่อมต่อที่เก็บ",
       "deleteLibrary": "ลบที่เก็บ",
       "typeToConfirmDelete": "พิมพ์ \"{{displayName}}\" เพื่อยืนยันการลบถาวร",
+      "confirmNameMismatch": "ชื่อที่พิมพ์ไม่ตรงกับ \"{{displayName}}\"",
       "confirmDisconnectRemote": "ตัดการเชื่อมต่อ \"{{displayName}}\" จาก {{appName}} หรือไม่ เนื้อหาในที่เก็บระยะไกลจะยังคงอยู่ใน {{provider}}",
       "confirmDisconnectLocal": "ตัดการเชื่อมต่อคลังเพลงนี้จาก {{appName}} หรือไม่ ข้อมูลคลังเพลงจะยังคงอยู่ในดิสก์",
       "confirmDeleteRemote": "ลบ \"{{displayName}}\" หรือไม่ เนื้อหาในที่เก็บระยะไกลของ {{provider}} ที่ {{path}} และสำเนาการทำงานในเครื่องจะถูกลบ",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -347,6 +347,7 @@
       "removeLibrary": "Depo bağlantısını kes",
       "deleteLibrary": "Depoyu sil",
       "typeToConfirmDelete": "Kalıcı silmeyi onaylamak için \"{{displayName}}\" yazın.",
+      "confirmNameMismatch": "Yazılan ad \"{{displayName}}\" ile eşleşmiyor.",
       "confirmDisconnectRemote": "\"{{displayName}}\" bağlantısı {{appName}} üzerinden kesilsin mi? Uzak depo içeriği {{provider}} içinde kalır.",
       "confirmDisconnectLocal": "Bu kitaplığın {{appName}} ile bağlantısı kesilsin mi? Kitaplık verileri diskte kalır.",
       "confirmDeleteRemote": "\"{{displayName}}\" silinsin mi? {{provider}} konumundaki {{path}} uzak depo içeriği ve yerel çalışma kopyası silinir.",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -412,6 +412,8 @@
       "downloaded": "İndirildi",
       "legacyOnDisk": "Diskte eski sürüm var — Tehlikeli Bölge'den silin, sonra yeniden indirin",
       "notDownloaded": "İndirilmedi",
+      "statusUnavailable": "Durum bilinmiyor",
+      "statusReadFailed": "Model durumu okunamadı.",
       "runtimeRequired": "ONNX Runtime gerekli",
       "delete": "Sil",
       "download": "İndir"
@@ -429,6 +431,7 @@
       "retryButton": "ONNX Runtime'ı Yeniden Kur",
       "statusReady": "Kuruldu ve hazır.",
       "statusMissing": "Kurulu değil.",
+      "statusReadFailed": "Çalışma zamanı durumu okunamadı.",
       "version": "Sürüm {{version}}",
       "checkButton": "Güncellemeleri denetle",
       "checking": "Güncellemeler denetleniyor...",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -346,6 +346,7 @@
       "removeLibrary": "Ngắt kết nối kho lưu trữ",
       "deleteLibrary": "Xóa kho lưu trữ",
       "typeToConfirmDelete": "Nhập \"{{displayName}}\" để xác nhận xóa vĩnh viễn.",
+      "confirmNameMismatch": "Tên đã nhập không khớp với \"{{displayName}}\".",
       "confirmDisconnectRemote": "Ngắt kết nối \"{{displayName}}\" khỏi {{appName}}? Nội dung kho lưu trữ từ xa sẽ vẫn ở {{provider}}.",
       "confirmDisconnectLocal": "Ngắt kết nối thư viện này khỏi {{appName}}? Dữ liệu thư viện sẽ vẫn trên đĩa.",
       "confirmDeleteRemote": "Xóa \"{{displayName}}\"? Nội dung kho lưu trữ từ xa tại {{provider}} ở {{path}} và bản sao làm việc cục bộ sẽ bị xóa.",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -411,6 +411,8 @@
       "downloaded": "Đã tải xuống",
       "legacyOnDisk": "Phiên bản cũ trên đĩa — hãy xóa trong Vùng nguy hiểm, rồi tải lại",
       "notDownloaded": "Chưa tải xuống",
+      "statusUnavailable": "Không rõ trạng thái",
+      "statusReadFailed": "Không thể đọc trạng thái mô hình.",
       "runtimeRequired": "Cần ONNX Runtime",
       "delete": "Xóa",
       "download": "Tải xuống"
@@ -428,6 +430,7 @@
       "retryButton": "Cài lại ONNX Runtime",
       "statusReady": "Đã cài đặt và sẵn sàng.",
       "statusMissing": "Chưa cài đặt.",
+      "statusReadFailed": "Không thể đọc trạng thái runtime.",
       "version": "Phiên bản {{version}}",
       "checkButton": "Kiểm tra cập nhật",
       "checking": "Đang kiểm tra cập nhật...",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -412,6 +412,8 @@
       "downloaded": "已下载",
       "legacyOnDisk": "磁盘上为旧版本 — 请在「危险区」删除后重新下载",
       "notDownloaded": "未下载",
+      "statusUnavailable": "状态不可用",
+      "statusReadFailed": "无法读取模型状态。",
       "runtimeRequired": "需要 ONNX 运行时",
       "delete": "删除",
       "download": "下载"
@@ -429,6 +431,7 @@
       "retryButton": "重新安装 ONNX 运行时",
       "statusReady": "已安装并就绪。",
       "statusMissing": "尚未安装。",
+      "statusReadFailed": "无法读取运行时状态。",
       "version": "版本 {{version}}",
       "checkButton": "检查更新",
       "checking": "正在检查更新...",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -347,6 +347,7 @@
       "removeLibrary": "断开资料库",
       "deleteLibrary": "删除资料库",
       "typeToConfirmDelete": "输入“{{displayName}}”以确认永久删除。",
+      "confirmNameMismatch": "输入的名称与“{{displayName}}”不一致。",
       "confirmDisconnectRemote": "断开“{{displayName}}”与 {{appName}} 的连接？远程资料库内容将保留在 {{provider}} 中。",
       "confirmDisconnectLocal": "断开此曲库与 {{appName}} 的连接？曲库数据会保留在磁盘上。",
       "confirmDeleteRemote": "删除“{{displayName}}”？这将从 {{provider}} 的 {{path}} 中删除远程资料库内容，并移除本地工作副本。",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -411,6 +411,8 @@
       "downloaded": "已下載",
       "legacyOnDisk": "磁碟上是舊版本——請在危險區刪除後再重新下載",
       "notDownloaded": "尚未下載",
+      "statusUnavailable": "無法取得狀態",
+      "statusReadFailed": "無法讀取模型狀態。",
       "runtimeRequired": "需要 ONNX Runtime",
       "delete": "刪除",
       "download": "下載"
@@ -428,6 +430,7 @@
       "retryButton": "重新安裝 ONNX Runtime",
       "statusReady": "已安裝並就緒。",
       "statusMissing": "尚未安裝。",
+      "statusReadFailed": "無法讀取執行環境狀態。",
       "version": "版本 {{version}}",
       "checkButton": "檢查更新",
       "checking": "正在檢查更新...",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -346,6 +346,7 @@
       "removeLibrary": "中斷儲存庫連線",
       "deleteLibrary": "刪除儲存庫",
       "typeToConfirmDelete": "請輸入「{{displayName}}」以確認永久刪除。",
+      "confirmNameMismatch": "輸入的名稱與「{{displayName}}」不相符。",
       "confirmDisconnectRemote": "中斷「{{displayName}}」與 {{appName}} 的連線？遠端資料庫內容會保留在 {{provider}} 中。",
       "confirmDisconnectLocal": "中斷此曲庫與 {{appName}} 的連線？曲庫資料會保留在磁碟上。",
       "confirmDeleteRemote": "刪除「{{displayName}}」？這會從 {{provider}} 的 {{path}} 刪除遠端資料庫內容，並移除本機工作副本。",


### PR DESCRIPTION
## What changed

Batch integration of 15 bug fixes, one commit per issue, developed on five topic branches and merged here with `--no-ff`.

**Audio engine (Rust)**
- Fixes #378 — resampler cache no longer panics on the realtime callback; zero sample-rate/channel sources are rejected at decode entry points
- Fixes #375 — crossfade gapless handoff applies this callback's fade gain on both sides of the swap
- Fixes #376 — crossfade overlap cursors advance by produced frames; short resampler output no longer desyncs mixing or deadlocks promotion (investigated: not a duplicate of #375)
- Fixes #379 — transport clock keeps advancing at exactly zero volume

**Background thread lifecycle (Rust)**
- Fixes #377 — ONNX runtime load latch is released when the loader thread panics
- Fixes #382 — stale fetch-event listener thread exits when its source is replaced
- Fixes #383 — durable operation executor gets a shutdown signal and is joined on exit

**Library registry (Rust)**
- Fixes #381 — `active_library_id` is validated on save and load; dangling ids fall back to the first registry entry
- Fixes #380 — single legacy `library_path` migration implementation remains; dead copy removed

**Library UI (frontend)**
- Fixes #385 — remote-library wizard closes only after successful activation; library commands report outcomes as `LibraryCommandResult`
- Fixes #387 — delete-confirmation dialog validates the typed name inline (disabled confirm + hint) instead of silently no-oping
- Fixes #389 — integrity cleanup resets selection and skipped count regardless of report presence

**Playback & status UI (frontend)**
- Fixes #384 — karaoke word highlight survives line changes with matching word indices (shadow latch fields removed)
- Fixes #386 — "download complete" flash cannot reappear without a new download
- Fixes #388 — model/runtime status refresh failures surface as view state instead of being swallowed by empty catch blocks

Every fix ships with a regression test verified to fail against the previous implementation. No public IPC command/payload/event changes; `docs/references/contracts/` unchanged.

## Verification

- [x] `pnpm lint` — PASS (oxlint, --deny-warnings)
- [x] `pnpm build` — PASS (tsc + vite)
- [x] `pnpm test` — PASS (196 files / 2251 tests)
- [x] `pnpm check:i18n` — PASS (17 locales)
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy --all-targets -- -D warnings` — PASS
- [x] `cargo test` — PASS (all 46 suites, incl. phase3_inference)
- [x] `pnpm test:a11y` — PASS (110 passed / 2 conditional skips, chromium + webkit)
- [ ] `pnpm tauri build` — SKIPPED (no IPC/packaging/contract changes)

Merges were cross-checked with patch-id comparison to confirm both parents' change sets coexist intact.

## Product standards evidence

- **Interaction & accessibility**: jsx-a11y via lint; axe WCAG 2.2 A/AA suite green (above). #387's dialog validation uses `role="alert"`, `aria-invalid`, `aria-describedby`; keyboard paths covered by interaction tests.
- **Language, terminology & data**: locale key structure and placeholder tests green across all 17 locales. Outstanding: the 4 new locale strings need a named human copy review.
- **Lifecycle, quality & testing**: per-issue regression tests, linked from each commit.

## Residual risk

- New locale copy pending human review (above).
- #376 carries a `kilo-duplicate` label that this investigation disproved; the label should be removed.
- #363 (Windows static CRT) is intentionally not in this PR: the /MT fix lives in `openkara-models` (merged upstream, unreleased); the OpenKara side is a catalog bump gated on that release.

---
Merge note: use a merge commit (not squash) so the 15 conventional commits reach `main` for release-please changelog generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer status reporting when model or runtime information cannot be read.
  - Added exact-name validation when deleting a library.
  - Improved remote library activation feedback and recovery of missing library registrations.
  - Improved application shutdown and background operation cleanup.

- **Bug Fixes**
  - Improved audio handling for invalid metadata, silence, crossfades, and sample-rate conversion.
  - Fixed lyric highlighting and stale playback requests.
  - Improved cleanup of model-download completion messages.

- **Localization**
  - Added translations for new settings and error messages across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->