### PR TITLE
feat(catalog): advance embedded snapshot to generation 13 (static-CRT Windows runtimes)

### DIFF
--- a/src-tauri/catalog/release-manifest.json
+++ b/src-tauri/catalog/release-manifest.json
@@ -57,28 +57,28 @@
             "kind": "license-file",
             "sha256": "02d7a40913647c7755c74e307b822bba33b5c238191658dfbca7c4fc30947d78",
             "size": 1061,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/LICENSE"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/LICENSE"
           },
           "notice": {
             "digest_algorithm": "sha256",
             "kind": "notice-file",
-            "sha256": "ac0d4643ca30dae2f3fe4e3b987a0b97ce23015df092a14ac404743adf83b536",
-            "size": 456,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/NOTICE"
+            "sha256": "7fc27d2c3dbdc265676afbda4a482c39dbc52400cdccf84d3e958f895148748b",
+            "size": 439,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/NOTICE"
           },
           "provenance": {
             "digest_algorithm": "sha256",
             "kind": "commit-provenance",
-            "sha256": "538aec1894c5986844464a9d1723b09fe23361e91ea31bbea45bb83e871b1e89",
-            "size": 6838,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/provenance.json"
+            "sha256": "5dfe7486517454d42ca92aa71cd7e2840355b6d53c1825a9f2b7b8d9ab157497",
+            "size": 6821,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/provenance.json"
           },
           "sbom": {
             "digest_algorithm": "sha256",
             "kind": "spdx-json",
-            "sha256": "555870b516518b6369c1a811d9028f407cb6d1c7278473b8ffb3620c52413e5b",
+            "sha256": "3928436718b0cb285bd82d38674d13e701965ce98c8cedd157319b415426a15b",
             "size": 13026,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/sbom.spdx.json"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/sbom.spdx.json"
           }
         },
         "target_triple": null,
@@ -143,28 +143,28 @@
             "kind": "license-file",
             "sha256": "02d7a40913647c7755c74e307b822bba33b5c238191658dfbca7c4fc30947d78",
             "size": 1061,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/LICENSE"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/LICENSE"
           },
           "notice": {
             "digest_algorithm": "sha256",
             "kind": "notice-file",
-            "sha256": "ac0d4643ca30dae2f3fe4e3b987a0b97ce23015df092a14ac404743adf83b536",
-            "size": 456,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/NOTICE"
+            "sha256": "7fc27d2c3dbdc265676afbda4a482c39dbc52400cdccf84d3e958f895148748b",
+            "size": 439,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/NOTICE"
           },
           "provenance": {
             "digest_algorithm": "sha256",
             "kind": "commit-provenance",
-            "sha256": "538aec1894c5986844464a9d1723b09fe23361e91ea31bbea45bb83e871b1e89",
-            "size": 6838,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/provenance.json"
+            "sha256": "5dfe7486517454d42ca92aa71cd7e2840355b6d53c1825a9f2b7b8d9ab157497",
+            "size": 6821,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/provenance.json"
           },
           "sbom": {
             "digest_algorithm": "sha256",
             "kind": "spdx-json",
-            "sha256": "555870b516518b6369c1a811d9028f407cb6d1c7278473b8ffb3620c52413e5b",
+            "sha256": "3928436718b0cb285bd82d38674d13e701965ce98c8cedd157319b415426a15b",
             "size": 13026,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/sbom.spdx.json"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/sbom.spdx.json"
           }
         },
         "target_triple": null,
@@ -229,28 +229,28 @@
             "kind": "license-file",
             "sha256": "02d7a40913647c7755c74e307b822bba33b5c238191658dfbca7c4fc30947d78",
             "size": 1061,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/LICENSE"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/LICENSE"
           },
           "notice": {
             "digest_algorithm": "sha256",
             "kind": "notice-file",
-            "sha256": "ac0d4643ca30dae2f3fe4e3b987a0b97ce23015df092a14ac404743adf83b536",
-            "size": 456,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/NOTICE"
+            "sha256": "7fc27d2c3dbdc265676afbda4a482c39dbc52400cdccf84d3e958f895148748b",
+            "size": 439,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/NOTICE"
           },
           "provenance": {
             "digest_algorithm": "sha256",
             "kind": "commit-provenance",
-            "sha256": "538aec1894c5986844464a9d1723b09fe23361e91ea31bbea45bb83e871b1e89",
-            "size": 6838,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/provenance.json"
+            "sha256": "5dfe7486517454d42ca92aa71cd7e2840355b6d53c1825a9f2b7b8d9ab157497",
+            "size": 6821,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/provenance.json"
           },
           "sbom": {
             "digest_algorithm": "sha256",
             "kind": "spdx-json",
-            "sha256": "555870b516518b6369c1a811d9028f407cb6d1c7278473b8ffb3620c52413e5b",
+            "sha256": "3928436718b0cb285bd82d38674d13e701965ce98c8cedd157319b415426a15b",
             "size": 13026,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/sbom.spdx.json"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/sbom.spdx.json"
           }
         },
         "target_triple": null,
@@ -315,28 +315,28 @@
             "kind": "license-file",
             "sha256": "02d7a40913647c7755c74e307b822bba33b5c238191658dfbca7c4fc30947d78",
             "size": 1061,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/LICENSE"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/LICENSE"
           },
           "notice": {
             "digest_algorithm": "sha256",
             "kind": "notice-file",
-            "sha256": "ac0d4643ca30dae2f3fe4e3b987a0b97ce23015df092a14ac404743adf83b536",
-            "size": 456,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/NOTICE"
+            "sha256": "7fc27d2c3dbdc265676afbda4a482c39dbc52400cdccf84d3e958f895148748b",
+            "size": 439,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/NOTICE"
           },
           "provenance": {
             "digest_algorithm": "sha256",
             "kind": "commit-provenance",
-            "sha256": "538aec1894c5986844464a9d1723b09fe23361e91ea31bbea45bb83e871b1e89",
-            "size": 6838,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/provenance.json"
+            "sha256": "5dfe7486517454d42ca92aa71cd7e2840355b6d53c1825a9f2b7b8d9ab157497",
+            "size": 6821,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/provenance.json"
           },
           "sbom": {
             "digest_algorithm": "sha256",
             "kind": "spdx-json",
-            "sha256": "555870b516518b6369c1a811d9028f407cb6d1c7278473b8ffb3620c52413e5b",
+            "sha256": "3928436718b0cb285bd82d38674d13e701965ce98c8cedd157319b415426a15b",
             "size": 13026,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/sbom.spdx.json"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/sbom.spdx.json"
           }
         },
         "target_triple": null,
@@ -401,28 +401,28 @@
             "kind": "license-file",
             "sha256": "02d7a40913647c7755c74e307b822bba33b5c238191658dfbca7c4fc30947d78",
             "size": 1061,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/LICENSE"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/LICENSE"
           },
           "notice": {
             "digest_algorithm": "sha256",
             "kind": "notice-file",
-            "sha256": "ac0d4643ca30dae2f3fe4e3b987a0b97ce23015df092a14ac404743adf83b536",
-            "size": 456,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/NOTICE"
+            "sha256": "7fc27d2c3dbdc265676afbda4a482c39dbc52400cdccf84d3e958f895148748b",
+            "size": 439,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/NOTICE"
           },
           "provenance": {
             "digest_algorithm": "sha256",
             "kind": "commit-provenance",
-            "sha256": "538aec1894c5986844464a9d1723b09fe23361e91ea31bbea45bb83e871b1e89",
-            "size": 6838,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/provenance.json"
+            "sha256": "5dfe7486517454d42ca92aa71cd7e2840355b6d53c1825a9f2b7b8d9ab157497",
+            "size": 6821,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/provenance.json"
           },
           "sbom": {
             "digest_algorithm": "sha256",
             "kind": "spdx-json",
-            "sha256": "555870b516518b6369c1a811d9028f407cb6d1c7278473b8ffb3620c52413e5b",
+            "sha256": "3928436718b0cb285bd82d38674d13e701965ce98c8cedd157319b415426a15b",
             "size": 13026,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/sbom.spdx.json"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/sbom.spdx.json"
           }
         },
         "target_triple": null,
@@ -492,28 +492,28 @@
             "kind": "license-file",
             "sha256": "02d7a40913647c7755c74e307b822bba33b5c238191658dfbca7c4fc30947d78",
             "size": 1061,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/LICENSE"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/LICENSE"
           },
           "notice": {
             "digest_algorithm": "sha256",
             "kind": "notice-file",
-            "sha256": "ac0d4643ca30dae2f3fe4e3b987a0b97ce23015df092a14ac404743adf83b536",
-            "size": 456,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/NOTICE"
+            "sha256": "7fc27d2c3dbdc265676afbda4a482c39dbc52400cdccf84d3e958f895148748b",
+            "size": 439,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/NOTICE"
           },
           "provenance": {
             "digest_algorithm": "sha256",
             "kind": "commit-provenance",
-            "sha256": "538aec1894c5986844464a9d1723b09fe23361e91ea31bbea45bb83e871b1e89",
-            "size": 6838,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/provenance.json"
+            "sha256": "5dfe7486517454d42ca92aa71cd7e2840355b6d53c1825a9f2b7b8d9ab157497",
+            "size": 6821,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/provenance.json"
           },
           "sbom": {
             "digest_algorithm": "sha256",
             "kind": "spdx-json",
-            "sha256": "555870b516518b6369c1a811d9028f407cb6d1c7278473b8ffb3620c52413e5b",
+            "sha256": "3928436718b0cb285bd82d38674d13e701965ce98c8cedd157319b415426a15b",
             "size": 13026,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/sbom.spdx.json"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/sbom.spdx.json"
           }
         },
         "target_triple": null,
@@ -583,28 +583,28 @@
             "kind": "license-file",
             "sha256": "02d7a40913647c7755c74e307b822bba33b5c238191658dfbca7c4fc30947d78",
             "size": 1061,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/LICENSE"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/LICENSE"
           },
           "notice": {
             "digest_algorithm": "sha256",
             "kind": "notice-file",
-            "sha256": "ac0d4643ca30dae2f3fe4e3b987a0b97ce23015df092a14ac404743adf83b536",
-            "size": 456,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/NOTICE"
+            "sha256": "7fc27d2c3dbdc265676afbda4a482c39dbc52400cdccf84d3e958f895148748b",
+            "size": 439,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/NOTICE"
           },
           "provenance": {
             "digest_algorithm": "sha256",
             "kind": "commit-provenance",
-            "sha256": "538aec1894c5986844464a9d1723b09fe23361e91ea31bbea45bb83e871b1e89",
-            "size": 6838,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/provenance.json"
+            "sha256": "5dfe7486517454d42ca92aa71cd7e2840355b6d53c1825a9f2b7b8d9ab157497",
+            "size": 6821,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/provenance.json"
           },
           "sbom": {
             "digest_algorithm": "sha256",
             "kind": "spdx-json",
-            "sha256": "555870b516518b6369c1a811d9028f407cb6d1c7278473b8ffb3620c52413e5b",
+            "sha256": "3928436718b0cb285bd82d38674d13e701965ce98c8cedd157319b415426a15b",
             "size": 13026,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/sbom.spdx.json"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/sbom.spdx.json"
           }
         },
         "target_triple": null,
@@ -682,28 +682,28 @@
             "kind": "license-file",
             "sha256": "02d7a40913647c7755c74e307b822bba33b5c238191658dfbca7c4fc30947d78",
             "size": 1061,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/LICENSE"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/LICENSE"
           },
           "notice": {
             "digest_algorithm": "sha256",
             "kind": "notice-file",
-            "sha256": "ac0d4643ca30dae2f3fe4e3b987a0b97ce23015df092a14ac404743adf83b536",
-            "size": 456,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/NOTICE"
+            "sha256": "7fc27d2c3dbdc265676afbda4a482c39dbc52400cdccf84d3e958f895148748b",
+            "size": 439,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/NOTICE"
           },
           "provenance": {
             "digest_algorithm": "sha256",
             "kind": "commit-provenance",
-            "sha256": "538aec1894c5986844464a9d1723b09fe23361e91ea31bbea45bb83e871b1e89",
-            "size": 6838,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/provenance.json"
+            "sha256": "5dfe7486517454d42ca92aa71cd7e2840355b6d53c1825a9f2b7b8d9ab157497",
+            "size": 6821,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/provenance.json"
           },
           "sbom": {
             "digest_algorithm": "sha256",
             "kind": "spdx-json",
-            "sha256": "555870b516518b6369c1a811d9028f407cb6d1c7278473b8ffb3620c52413e5b",
+            "sha256": "3928436718b0cb285bd82d38674d13e701965ce98c8cedd157319b415426a15b",
             "size": 13026,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/sbom.spdx.json"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/sbom.spdx.json"
           }
         },
         "target_triple": "aarch64-apple-darwin",
@@ -806,28 +806,28 @@
             "kind": "license-file",
             "sha256": "02d7a40913647c7755c74e307b822bba33b5c238191658dfbca7c4fc30947d78",
             "size": 1061,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/LICENSE"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/LICENSE"
           },
           "notice": {
             "digest_algorithm": "sha256",
             "kind": "notice-file",
-            "sha256": "ac0d4643ca30dae2f3fe4e3b987a0b97ce23015df092a14ac404743adf83b536",
-            "size": 456,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/NOTICE"
+            "sha256": "7fc27d2c3dbdc265676afbda4a482c39dbc52400cdccf84d3e958f895148748b",
+            "size": 439,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/NOTICE"
           },
           "provenance": {
             "digest_algorithm": "sha256",
             "kind": "commit-provenance",
-            "sha256": "538aec1894c5986844464a9d1723b09fe23361e91ea31bbea45bb83e871b1e89",
-            "size": 6838,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/provenance.json"
+            "sha256": "5dfe7486517454d42ca92aa71cd7e2840355b6d53c1825a9f2b7b8d9ab157497",
+            "size": 6821,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/provenance.json"
           },
           "sbom": {
             "digest_algorithm": "sha256",
             "kind": "spdx-json",
-            "sha256": "555870b516518b6369c1a811d9028f407cb6d1c7278473b8ffb3620c52413e5b",
+            "sha256": "3928436718b0cb285bd82d38674d13e701965ce98c8cedd157319b415426a15b",
             "size": 13026,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/sbom.spdx.json"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/sbom.spdx.json"
           }
         },
         "target_triple": "aarch64-unknown-linux-gnu",
@@ -928,28 +928,28 @@
             "kind": "license-file",
             "sha256": "02d7a40913647c7755c74e307b822bba33b5c238191658dfbca7c4fc30947d78",
             "size": 1061,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/LICENSE"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/LICENSE"
           },
           "notice": {
             "digest_algorithm": "sha256",
             "kind": "notice-file",
-            "sha256": "ac0d4643ca30dae2f3fe4e3b987a0b97ce23015df092a14ac404743adf83b536",
-            "size": 456,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/NOTICE"
+            "sha256": "7fc27d2c3dbdc265676afbda4a482c39dbc52400cdccf84d3e958f895148748b",
+            "size": 439,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/NOTICE"
           },
           "provenance": {
             "digest_algorithm": "sha256",
             "kind": "commit-provenance",
-            "sha256": "538aec1894c5986844464a9d1723b09fe23361e91ea31bbea45bb83e871b1e89",
-            "size": 6838,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/provenance.json"
+            "sha256": "5dfe7486517454d42ca92aa71cd7e2840355b6d53c1825a9f2b7b8d9ab157497",
+            "size": 6821,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/provenance.json"
           },
           "sbom": {
             "digest_algorithm": "sha256",
             "kind": "spdx-json",
-            "sha256": "555870b516518b6369c1a811d9028f407cb6d1c7278473b8ffb3620c52413e5b",
+            "sha256": "3928436718b0cb285bd82d38674d13e701965ce98c8cedd157319b415426a15b",
             "size": 13026,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/sbom.spdx.json"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/sbom.spdx.json"
           }
         },
         "target_triple": "x86_64-apple-darwin",
@@ -1052,28 +1052,28 @@
             "kind": "license-file",
             "sha256": "02d7a40913647c7755c74e307b822bba33b5c238191658dfbca7c4fc30947d78",
             "size": 1061,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/LICENSE"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/LICENSE"
           },
           "notice": {
             "digest_algorithm": "sha256",
             "kind": "notice-file",
-            "sha256": "ac0d4643ca30dae2f3fe4e3b987a0b97ce23015df092a14ac404743adf83b536",
-            "size": 456,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/NOTICE"
+            "sha256": "7fc27d2c3dbdc265676afbda4a482c39dbc52400cdccf84d3e958f895148748b",
+            "size": 439,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/NOTICE"
           },
           "provenance": {
             "digest_algorithm": "sha256",
             "kind": "commit-provenance",
-            "sha256": "538aec1894c5986844464a9d1723b09fe23361e91ea31bbea45bb83e871b1e89",
-            "size": 6838,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/provenance.json"
+            "sha256": "5dfe7486517454d42ca92aa71cd7e2840355b6d53c1825a9f2b7b8d9ab157497",
+            "size": 6821,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/provenance.json"
           },
           "sbom": {
             "digest_algorithm": "sha256",
             "kind": "spdx-json",
-            "sha256": "555870b516518b6369c1a811d9028f407cb6d1c7278473b8ffb3620c52413e5b",
+            "sha256": "3928436718b0cb285bd82d38674d13e701965ce98c8cedd157319b415426a15b",
             "size": 13026,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/sbom.spdx.json"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/sbom.spdx.json"
           }
         },
         "target_triple": "x86_64-unknown-linux-gnu",
@@ -1180,28 +1180,28 @@
             "kind": "license-file",
             "sha256": "02d7a40913647c7755c74e307b822bba33b5c238191658dfbca7c4fc30947d78",
             "size": 1061,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/LICENSE"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/LICENSE"
           },
           "notice": {
             "digest_algorithm": "sha256",
             "kind": "notice-file",
-            "sha256": "ac0d4643ca30dae2f3fe4e3b987a0b97ce23015df092a14ac404743adf83b536",
-            "size": 456,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/NOTICE"
+            "sha256": "7fc27d2c3dbdc265676afbda4a482c39dbc52400cdccf84d3e958f895148748b",
+            "size": 439,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/NOTICE"
           },
           "provenance": {
             "digest_algorithm": "sha256",
             "kind": "commit-provenance",
-            "sha256": "538aec1894c5986844464a9d1723b09fe23361e91ea31bbea45bb83e871b1e89",
-            "size": 6838,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/provenance.json"
+            "sha256": "5dfe7486517454d42ca92aa71cd7e2840355b6d53c1825a9f2b7b8d9ab157497",
+            "size": 6821,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/provenance.json"
           },
           "sbom": {
             "digest_algorithm": "sha256",
             "kind": "spdx-json",
-            "sha256": "555870b516518b6369c1a811d9028f407cb6d1c7278473b8ffb3620c52413e5b",
+            "sha256": "3928436718b0cb285bd82d38674d13e701965ce98c8cedd157319b415426a15b",
             "size": 13026,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/sbom.spdx.json"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/sbom.spdx.json"
           }
         },
         "target_triple": "x86_64-pc-windows-msvc",
@@ -1249,7 +1249,7 @@
           "replacement_artifact_id": null,
           "sunset_generation": null
         },
-        "download_url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-001/onnxruntime-1.27.1-openkara-aarch64-apple-darwin-reduced.tar.gz",
+        "download_url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/onnxruntime-1.27.1-openkara-aarch64-apple-darwin-reduced.tar.gz",
         "extracted_file_digests": {
           "LICENSE.onnxruntime": {
             "sha256": "2f07c72751aed99790b8a4869cf2311df85a860b22ded05fa22803587a48922c",
@@ -1299,28 +1299,28 @@
             "kind": "license-file",
             "sha256": "02d7a40913647c7755c74e307b822bba33b5c238191658dfbca7c4fc30947d78",
             "size": 1061,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/LICENSE"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/LICENSE"
           },
           "notice": {
             "digest_algorithm": "sha256",
             "kind": "notice-file",
-            "sha256": "ac0d4643ca30dae2f3fe4e3b987a0b97ce23015df092a14ac404743adf83b536",
-            "size": 456,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/NOTICE"
+            "sha256": "7fc27d2c3dbdc265676afbda4a482c39dbc52400cdccf84d3e958f895148748b",
+            "size": 439,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/NOTICE"
           },
           "provenance": {
             "digest_algorithm": "sha256",
             "kind": "commit-provenance",
-            "sha256": "538aec1894c5986844464a9d1723b09fe23361e91ea31bbea45bb83e871b1e89",
-            "size": 6838,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/provenance.json"
+            "sha256": "5dfe7486517454d42ca92aa71cd7e2840355b6d53c1825a9f2b7b8d9ab157497",
+            "size": 6821,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/provenance.json"
           },
           "sbom": {
             "digest_algorithm": "sha256",
             "kind": "spdx-json",
-            "sha256": "555870b516518b6369c1a811d9028f407cb6d1c7278473b8ffb3620c52413e5b",
+            "sha256": "3928436718b0cb285bd82d38674d13e701965ce98c8cedd157319b415426a15b",
             "size": 13026,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/sbom.spdx.json"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/sbom.spdx.json"
           }
         },
         "target_triple": "aarch64-apple-darwin",
@@ -1360,15 +1360,15 @@
       },
       {
         "arch": "aarch64",
-        "archive_digest": "7115205ce9e537323ba4bdfd959604cd238351b2e0f04574fb726bc365b00e7c",
+        "archive_digest": "fa5c87a357ade6360ef39d9bfdac941af6664cb058202a4aa2b9cfc9e171008e",
         "artifact_id": "onnxruntime-1.27.1-openkara-aarch64-unknown-linux-gnu-reduced",
-        "byte_size": 9034217,
+        "byte_size": 9034213,
         "deprecation": {
           "deprecated": false,
           "replacement_artifact_id": null,
           "sunset_generation": null
         },
-        "download_url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-001/onnxruntime-1.27.1-openkara-aarch64-unknown-linux-gnu-reduced.tar.gz",
+        "download_url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/onnxruntime-1.27.1-openkara-aarch64-unknown-linux-gnu-reduced.tar.gz",
         "extracted_file_digests": {
           "LICENSE.onnxruntime": {
             "sha256": "2f07c72751aed99790b8a4869cf2311df85a860b22ded05fa22803587a48922c",
@@ -1379,7 +1379,7 @@
             "size": 325054
           },
           "build-manifest.json": {
-            "sha256": "d5b57b54cf46359e95beb818859f27bdd102cafdd49dccfa39aa701ea7c30ed4",
+            "sha256": "8023a5b43ae50766844104a10dafd65862f03c887089d5ecdbf8827c656bcb63",
             "size": 3111
           },
           "libonnxruntime.so": {
@@ -1387,11 +1387,11 @@
             "size": 25884920
           },
           "provenance.json": {
-            "sha256": "fd9f5ee9c8d74997a4643c48abe45102276d42ca98aad5babcc065979da8fc4e",
+            "sha256": "7b9fd3b99fd81875aa3f82391fdc0d8c2b2140968e730196e1be7a5e589f5531",
             "size": 2223
           },
           "sbom.spdx.json": {
-            "sha256": "d2c86ac759f9a84da244d5eb18fdca4720daf99893aeb952e478085f08dcb2b1",
+            "sha256": "babb888f878d96c15aa527c4d98f2ce95b0973a41b2bafcd0186fbc3b3b7ba5c",
             "size": 6746
           }
         },
@@ -1418,28 +1418,28 @@
             "kind": "license-file",
             "sha256": "02d7a40913647c7755c74e307b822bba33b5c238191658dfbca7c4fc30947d78",
             "size": 1061,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/LICENSE"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/LICENSE"
           },
           "notice": {
             "digest_algorithm": "sha256",
             "kind": "notice-file",
-            "sha256": "ac0d4643ca30dae2f3fe4e3b987a0b97ce23015df092a14ac404743adf83b536",
-            "size": 456,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/NOTICE"
+            "sha256": "7fc27d2c3dbdc265676afbda4a482c39dbc52400cdccf84d3e958f895148748b",
+            "size": 439,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/NOTICE"
           },
           "provenance": {
             "digest_algorithm": "sha256",
             "kind": "commit-provenance",
-            "sha256": "538aec1894c5986844464a9d1723b09fe23361e91ea31bbea45bb83e871b1e89",
-            "size": 6838,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/provenance.json"
+            "sha256": "5dfe7486517454d42ca92aa71cd7e2840355b6d53c1825a9f2b7b8d9ab157497",
+            "size": 6821,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/provenance.json"
           },
           "sbom": {
             "digest_algorithm": "sha256",
             "kind": "spdx-json",
-            "sha256": "555870b516518b6369c1a811d9028f407cb6d1c7278473b8ffb3620c52413e5b",
+            "sha256": "3928436718b0cb285bd82d38674d13e701965ce98c8cedd157319b415426a15b",
             "size": 13026,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/sbom.spdx.json"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/sbom.spdx.json"
           }
         },
         "target_triple": "aarch64-unknown-linux-gnu",
@@ -1486,7 +1486,7 @@
           "replacement_artifact_id": null,
           "sunset_generation": null
         },
-        "download_url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-001/onnxruntime-1.27.1-openkara-x86_64-apple-darwin-reduced.tar.gz",
+        "download_url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/onnxruntime-1.27.1-openkara-x86_64-apple-darwin-reduced.tar.gz",
         "extracted_file_digests": {
           "LICENSE.onnxruntime": {
             "sha256": "2f07c72751aed99790b8a4869cf2311df85a860b22ded05fa22803587a48922c",
@@ -1536,28 +1536,28 @@
             "kind": "license-file",
             "sha256": "02d7a40913647c7755c74e307b822bba33b5c238191658dfbca7c4fc30947d78",
             "size": 1061,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/LICENSE"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/LICENSE"
           },
           "notice": {
             "digest_algorithm": "sha256",
             "kind": "notice-file",
-            "sha256": "ac0d4643ca30dae2f3fe4e3b987a0b97ce23015df092a14ac404743adf83b536",
-            "size": 456,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/NOTICE"
+            "sha256": "7fc27d2c3dbdc265676afbda4a482c39dbc52400cdccf84d3e958f895148748b",
+            "size": 439,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/NOTICE"
           },
           "provenance": {
             "digest_algorithm": "sha256",
             "kind": "commit-provenance",
-            "sha256": "538aec1894c5986844464a9d1723b09fe23361e91ea31bbea45bb83e871b1e89",
-            "size": 6838,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/provenance.json"
+            "sha256": "5dfe7486517454d42ca92aa71cd7e2840355b6d53c1825a9f2b7b8d9ab157497",
+            "size": 6821,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/provenance.json"
           },
           "sbom": {
             "digest_algorithm": "sha256",
             "kind": "spdx-json",
-            "sha256": "555870b516518b6369c1a811d9028f407cb6d1c7278473b8ffb3620c52413e5b",
+            "sha256": "3928436718b0cb285bd82d38674d13e701965ce98c8cedd157319b415426a15b",
             "size": 13026,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/sbom.spdx.json"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/sbom.spdx.json"
           }
         },
         "target_triple": "x86_64-apple-darwin",
@@ -1605,7 +1605,7 @@
           "replacement_artifact_id": null,
           "sunset_generation": null
         },
-        "download_url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-001/onnxruntime-1.27.1-openkara-x86_64-unknown-linux-gnu-reduced.tar.gz",
+        "download_url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/onnxruntime-1.27.1-openkara-x86_64-unknown-linux-gnu-reduced.tar.gz",
         "extracted_file_digests": {
           "LICENSE.onnxruntime": {
             "sha256": "2f07c72751aed99790b8a4869cf2311df85a860b22ded05fa22803587a48922c",
@@ -1655,28 +1655,28 @@
             "kind": "license-file",
             "sha256": "02d7a40913647c7755c74e307b822bba33b5c238191658dfbca7c4fc30947d78",
             "size": 1061,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/LICENSE"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/LICENSE"
           },
           "notice": {
             "digest_algorithm": "sha256",
             "kind": "notice-file",
-            "sha256": "ac0d4643ca30dae2f3fe4e3b987a0b97ce23015df092a14ac404743adf83b536",
-            "size": 456,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/NOTICE"
+            "sha256": "7fc27d2c3dbdc265676afbda4a482c39dbc52400cdccf84d3e958f895148748b",
+            "size": 439,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/NOTICE"
           },
           "provenance": {
             "digest_algorithm": "sha256",
             "kind": "commit-provenance",
-            "sha256": "538aec1894c5986844464a9d1723b09fe23361e91ea31bbea45bb83e871b1e89",
-            "size": 6838,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/provenance.json"
+            "sha256": "5dfe7486517454d42ca92aa71cd7e2840355b6d53c1825a9f2b7b8d9ab157497",
+            "size": 6821,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/provenance.json"
           },
           "sbom": {
             "digest_algorithm": "sha256",
             "kind": "spdx-json",
-            "sha256": "555870b516518b6369c1a811d9028f407cb6d1c7278473b8ffb3620c52413e5b",
+            "sha256": "3928436718b0cb285bd82d38674d13e701965ce98c8cedd157319b415426a15b",
             "size": 13026,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/sbom.spdx.json"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/sbom.spdx.json"
           }
         },
         "target_triple": "x86_64-unknown-linux-gnu",
@@ -1715,15 +1715,15 @@
       },
       {
         "arch": "x86_64",
-        "archive_digest": "f127d8aa28a5905c04755d374ef8afca8176cd00b52bbb7d4e05c7176262d01a",
+        "archive_digest": "3146e4fdb42ccb8f1e19d44570dd1daec8613bf8238936f58e473c700a1f0f4a",
         "artifact_id": "onnxruntime-1.27.1-openkara-x86_64-pc-windows-msvc-cpu-reduced",
-        "byte_size": 5467736,
+        "byte_size": 5759229,
         "deprecation": {
           "deprecated": false,
           "replacement_artifact_id": null,
           "sunset_generation": null
         },
-        "download_url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-001/onnxruntime-1.27.1-openkara-x86_64-pc-windows-msvc-cpu-reduced.zip",
+        "download_url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/onnxruntime-1.27.1-openkara-x86_64-pc-windows-msvc-cpu-reduced.zip",
         "extracted_file_digests": {
           "LICENSE.onnxruntime": {
             "sha256": "c250d6278f0b47a6439fb7592b08b58a55eb9f535aa49a1db63211c3f982b674",
@@ -1734,19 +1734,19 @@
             "size": 331175
           },
           "build-manifest.json": {
-            "sha256": "b06e473a417b5a759b372db4903bdd8779d14d7f63c0cce82db7d5259332322f",
-            "size": 3127
+            "sha256": "02e46c6edf0625e8de3be956c919983d4d2916b885a9693de5542d4e526e3d66",
+            "size": 3165
           },
           "onnxruntime.dll": {
-            "sha256": "a709dc313d6f68c58dc4a0f59a10676967670a2b9f5e6ef3f09f34d1bf8e32dc",
-            "size": 14565888
+            "sha256": "019092f2e03d4c278ae92bf573aa189610a5c800a8eacbf02dbb175e0eaeda52",
+            "size": 15182336
           },
           "provenance.json": {
-            "sha256": "742d84e7b2f325f208158d4d3cb266d2648e3d1d3234c6d3e124e4c6ddd680e0",
-            "size": 2238
+            "sha256": "60f65c8f0edc8f3f042c529efbc9bc7778a9ca2a54234d122c7ed0ec123f9cf4",
+            "size": 2276
           },
           "sbom.spdx.json": {
-            "sha256": "7de79126723564a0388d671776bbb70abc32aae16e8930ead4ced2bec36ce5e7",
+            "sha256": "62ec4e8151ca52423a66fb40d4b1e140ca8c50679f1ff222cf6d74cc75413ca6",
             "size": 6750
           }
         },
@@ -1772,28 +1772,28 @@
             "kind": "license-file",
             "sha256": "02d7a40913647c7755c74e307b822bba33b5c238191658dfbca7c4fc30947d78",
             "size": 1061,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/LICENSE"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/LICENSE"
           },
           "notice": {
             "digest_algorithm": "sha256",
             "kind": "notice-file",
-            "sha256": "ac0d4643ca30dae2f3fe4e3b987a0b97ce23015df092a14ac404743adf83b536",
-            "size": 456,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/NOTICE"
+            "sha256": "7fc27d2c3dbdc265676afbda4a482c39dbc52400cdccf84d3e958f895148748b",
+            "size": 439,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/NOTICE"
           },
           "provenance": {
             "digest_algorithm": "sha256",
             "kind": "commit-provenance",
-            "sha256": "538aec1894c5986844464a9d1723b09fe23361e91ea31bbea45bb83e871b1e89",
-            "size": 6838,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/provenance.json"
+            "sha256": "5dfe7486517454d42ca92aa71cd7e2840355b6d53c1825a9f2b7b8d9ab157497",
+            "size": 6821,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/provenance.json"
           },
           "sbom": {
             "digest_algorithm": "sha256",
             "kind": "spdx-json",
-            "sha256": "555870b516518b6369c1a811d9028f407cb6d1c7278473b8ffb3620c52413e5b",
+            "sha256": "3928436718b0cb285bd82d38674d13e701965ce98c8cedd157319b415426a15b",
             "size": 13026,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/sbom.spdx.json"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/sbom.spdx.json"
           }
         },
         "target_triple": "x86_64-pc-windows-msvc",
@@ -1810,9 +1810,10 @@
             "-DCMAKE_BUILD_TYPE=Release",
             "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
             "-DCMAKE_SKIP_INSTALL_RULES=ON",
-            "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL",
-            "-Dprotobuf_MSVC_STATIC_RUNTIME=OFF",
-            "-Dabsl_MSVC_STATIC_RUNTIME=OFF",
+            "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded",
+            "-DONNX_USE_MSVC_STATIC_RUNTIME=ON",
+            "-Dprotobuf_MSVC_STATIC_RUNTIME=ON",
+            "-DABSL_MSVC_STATIC_RUNTIME=ON",
             "-Donnxruntime_DISABLE_ML_OPS=ON"
           ],
           "compiler": "MSVC (VS 2022)",
@@ -1833,15 +1834,15 @@
       },
       {
         "arch": "x86_64",
-        "archive_digest": "458e144a5dea1119b8ee97b808206f89db34bbc19eea4a2af584305920cd455e",
+        "archive_digest": "984ecbea4555079dbfe5ff5b996e93fc50fa454a351b570feb49d28db1fe039b",
         "artifact_id": "onnxruntime-1.27.1-openkara-x86_64-pc-windows-msvc-reduced",
-        "byte_size": 15770619,
+        "byte_size": 16065512,
         "deprecation": {
           "deprecated": false,
           "replacement_artifact_id": null,
           "sunset_generation": null
         },
-        "download_url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-001/onnxruntime-1.27.1-openkara-x86_64-pc-windows-msvc-reduced.zip",
+        "download_url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/onnxruntime-1.27.1-openkara-x86_64-pc-windows-msvc-reduced.zip",
         "extracted_file_digests": {
           "DirectML.dll": {
             "sha256": "9c9e6d822561c6c41b90e6994b3e8857cf1d66dbfb1e0c4c799c7c89b4e92da1",
@@ -1856,19 +1857,19 @@
             "size": 331175
           },
           "build-manifest.json": {
-            "sha256": "74a726c9d2876fb0799d3fb06fde1334edb15f35ddd519925a989dc4d0846c27",
-            "size": 3289
+            "sha256": "fe1b0547bb1a755475bfb32f216f1ba455a7b62ce5954a0be71946c41353d038",
+            "size": 3327
           },
           "onnxruntime.dll": {
-            "sha256": "5ee34605acd7aafa86c04592b3fa801a4e4c45aa0150bafc339ba7461d65268d",
-            "size": 19783680
+            "sha256": "048f9b80ff54d25fda7f9ff90fe89296b940c205085886d1cc9303626fddf660",
+            "size": 20403200
           },
           "provenance.json": {
-            "sha256": "3eb9e6f0c303d427fdfd3c75f5e94399084f718fe5649658ae7eeacafb1f7241",
-            "size": 2265
+            "sha256": "10a252955c32744deaac6dd8253a3950c6068028e617287f4fbf04665797c172",
+            "size": 2303
           },
           "sbom.spdx.json": {
-            "sha256": "26e982ab5cd178d5eccb66773f99918221d516a00ba091fb23084428f1d252c0",
+            "sha256": "7dbca1b58acc29231ba79f9bcd96f8a116468ac215b962dd14750e61bf71f8c6",
             "size": 6735
           }
         },
@@ -1897,28 +1898,28 @@
             "kind": "license-file",
             "sha256": "02d7a40913647c7755c74e307b822bba33b5c238191658dfbca7c4fc30947d78",
             "size": 1061,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/LICENSE"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/LICENSE"
           },
           "notice": {
             "digest_algorithm": "sha256",
             "kind": "notice-file",
-            "sha256": "ac0d4643ca30dae2f3fe4e3b987a0b97ce23015df092a14ac404743adf83b536",
-            "size": 456,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/NOTICE"
+            "sha256": "7fc27d2c3dbdc265676afbda4a482c39dbc52400cdccf84d3e958f895148748b",
+            "size": 439,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/NOTICE"
           },
           "provenance": {
             "digest_algorithm": "sha256",
             "kind": "commit-provenance",
-            "sha256": "538aec1894c5986844464a9d1723b09fe23361e91ea31bbea45bb83e871b1e89",
-            "size": 6838,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/provenance.json"
+            "sha256": "5dfe7486517454d42ca92aa71cd7e2840355b6d53c1825a9f2b7b8d9ab157497",
+            "size": 6821,
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/provenance.json"
           },
           "sbom": {
             "digest_algorithm": "sha256",
             "kind": "spdx-json",
-            "sha256": "555870b516518b6369c1a811d9028f407cb6d1c7278473b8ffb3620c52413e5b",
+            "sha256": "3928436718b0cb285bd82d38674d13e701965ce98c8cedd157319b415426a15b",
             "size": 13026,
-            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/sbom.spdx.json"
+            "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/sbom.spdx.json"
           }
         },
         "target_triple": "x86_64-pc-windows-msvc",
@@ -1936,9 +1937,10 @@
             "-DCMAKE_BUILD_TYPE=Release",
             "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
             "-DCMAKE_SKIP_INSTALL_RULES=ON",
-            "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL",
-            "-Dprotobuf_MSVC_STATIC_RUNTIME=OFF",
-            "-Dabsl_MSVC_STATIC_RUNTIME=OFF",
+            "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded",
+            "-DONNX_USE_MSVC_STATIC_RUNTIME=ON",
+            "-Dprotobuf_MSVC_STATIC_RUNTIME=ON",
+            "-DABSL_MSVC_STATIC_RUNTIME=ON",
             "-Donnxruntime_DISABLE_ML_OPS=ON"
           ],
           "compiler": "MSVC (VS 2022)",
@@ -2605,17 +2607,17 @@
       "target_triple": "x86_64-unknown-linux-gnu"
     }
   ],
-  "created_at": "2026-08-07T19:30:00Z",
-  "generation": 12,
+  "created_at": "2026-08-13T06:30:00Z",
+  "generation": 13,
   "minimum_consumer_schema": "openkara.catalog/release-v1",
-  "notes": "Generation 12 corrects the CPU-only Windows runtime target_triple. Generation 11 introduced x86_64-pc-windows-msvc-cpu as the catalog target_triple, but OpenKara resolves runtimes by exact host-triple match (x86_64-pc-windows-msvc), so the CPU runtime was unreachable and the DirectML load-timeout fallback could not select it (OpenKara/OpenKara#284). This release sets the CPU runtime target_triple to x86_64-pc-windows-msvc so both Windows runtimes share a triple and resolve_runtime disambiguates them by execution provider. The build matrix target stays x86_64-pc-windows-msvc-cpu; only the catalog target_triple changes. Runtime and model bytes are identical to generation 11.",
+  "notes": "Generation 13 rebuilds the six reduced runtimes with the static MSVC CRT (/MT) on both Windows targets (CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded plus matching ONNX_USE_MSVC_STATIC_RUNTIME/protobuf_MSVC_STATIC_RUNTIME/ABSL_MSVC_STATIC_RUNTIME), so onnxruntime.dll no longer imports the VC++ Redistributable DLLs (VCRUNTIME140*, MSVCP140*) and loads on clean Windows images without the redistributable installed (OpenKara/OpenKara#284, OpenKara/OpenKara#363, PR #90). All six archives are rebuilt under infra-2026-08-12-001 from the same upstream tag v1.27.1; the four non-Windows targets rebuild with unchanged flags. The five full (non-reduced) builds remain deprecated. Models are unchanged. The CPU-only Windows runtime keeps the generation-12 catalog target_triple x86_64-pc-windows-msvc so resolve_runtime disambiguates the two Windows runtimes by execution provider.",
   "producer": {
-    "commit_sha": "a8e8acab56d85a0121132ce8fe512d640bff1041",
+    "commit_sha": "98a1aeb245894337f48b67a907951d2770e22405",
     "repo": "thedavidweng/openkara-models",
-    "run_id": "manual",
-    "workflow": "fix/catalog-cpu-windows-target-triple"
+    "run_id": "31670494161",
+    "workflow": "ort-publish.yml"
   },
-  "release_id": "2026-08-07-002",
+  "release_id": "2026-08-12-001",
   "schema_version": "openkara.catalog/release-v1",
   "supply_chain": {
     "license": {
@@ -2623,28 +2625,28 @@
       "kind": "license-file",
       "sha256": "02d7a40913647c7755c74e307b822bba33b5c238191658dfbca7c4fc30947d78",
       "size": 1061,
-      "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/LICENSE"
+      "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/LICENSE"
     },
     "notice": {
       "digest_algorithm": "sha256",
       "kind": "notice-file",
-      "sha256": "ac0d4643ca30dae2f3fe4e3b987a0b97ce23015df092a14ac404743adf83b536",
-      "size": 456,
-      "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/NOTICE"
+      "sha256": "7fc27d2c3dbdc265676afbda4a482c39dbc52400cdccf84d3e958f895148748b",
+      "size": 439,
+      "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/NOTICE"
     },
     "provenance": {
       "digest_algorithm": "sha256",
       "kind": "commit-provenance",
-      "sha256": "538aec1894c5986844464a9d1723b09fe23361e91ea31bbea45bb83e871b1e89",
-      "size": 6838,
-      "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/provenance.json"
+      "sha256": "5dfe7486517454d42ca92aa71cd7e2840355b6d53c1825a9f2b7b8d9ab157497",
+      "size": 6821,
+      "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/provenance.json"
     },
     "sbom": {
       "digest_algorithm": "sha256",
       "kind": "spdx-json",
-      "sha256": "555870b516518b6369c1a811d9028f407cb6d1c7278473b8ffb3620c52413e5b",
+      "sha256": "3928436718b0cb285bd82d38674d13e701965ce98c8cedd157319b415426a15b",
       "size": 13026,
-      "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/sbom.spdx.json"
+      "url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/sbom.spdx.json"
     }
   }
 }

--- a/src-tauri/catalog/stable-pointer.json
+++ b/src-tauri/catalog/stable-pointer.json
@@ -1,11 +1,11 @@
 {
   "channel": "stable",
-  "generation": 12,
-  "previous_release_id": "2026-08-07-001",
-  "release_id": "2026-08-07-002",
-  "release_manifest_sha256": "08f6cf47cea944a61f75416880fb0221241fd614b8112e93671536e0a50133ee",
-  "release_manifest_size": 113221,
-  "release_manifest_url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-07-002/release-manifest.json",
+  "generation": 13,
+  "previous_release_id": "2026-08-07-002",
+  "release_id": "2026-08-12-001",
+  "release_manifest_sha256": "de0248138f7d1de0eaa50e5eaa6afd52c961066c95c69126e827c3fd29b5182d",
+  "release_manifest_size": 113482,
+  "release_manifest_url": "https://github.com/thedavidweng/openkara-models/releases/download/infra-2026-08-12-001/release-manifest.json",
   "schema_version": "openkara.catalog/channel-v1",
-  "updated_at": "2026-08-07T19:30:00Z"
+  "updated_at": "2026-08-13T06:30:00Z"
 }


### PR DESCRIPTION
## What changed

Advances the embedded openkara-models catalog snapshot from generation 12 (`2026-08-07-002`) to generation 13 (`2026-08-12-001`, upstream release `infra-2026-08-12-001`):

- `src-tauri/catalog/release-manifest.json` — new upstream release manifest with the OpenKara-side model annotations (`capability_limit` / `evaluation_fixture` / `known_user_effect`) re-applied unchanged.
- `src-tauri/catalog/stable-pointer.json` — `release_id` / `generation` / digest / size / URL advanced to the new embedded manifest.

Generation 13 rebuilds all six reduced runtimes; the two Windows runtimes are now linked with the **static MSVC CRT (/MT)** (`CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded` plus `ONNX_USE_MSVC_STATIC_RUNTIME` / `protobuf_MSVC_STATIC_RUNTIME` / `ABSL_MSVC_STATIC_RUNTIME`), so `onnxruntime.dll` no longer imports `VCRUNTIME140*` / `MSVCP140*` and loads on clean Windows installs without the VC++ Redistributable. Refs #363, #284; upstream thedavidweng/openkara-models#90 (build flags) and #91 (generation 13 catalog). Models and the four non-Windows runtimes are functionally unchanged: same upstream v1.27.1, unchanged build flags, fresh archives/digests from upstream publish run 31670494161.

The CPU Windows runtime keeps catalog `target_triple` `x86_64-pc-windows-msvc` (generation-12 convention) so `resolve_runtime` still disambiguates the two Windows runtimes by execution provider.

This PR only advances the snapshot. Removing the #361 app-local CRT mitigation is the follow-up step on #363's checklist once this generation is live on main.

## Verification

- [x] `pnpm format:write` — no further diff (manifest bytes stable; `stable-pointer.json` digest matches embedded file: sha256 `de0248138f7d1de0eaa50e5eaa6afd52c961066c95c69126e827c3fd29b5182d`, 113482 bytes)
- [x] `pnpm lint` — PASS
- [x] `pnpm test` — PASS (2236 tests / 196 files, via pre-push hook with coverage + patch-coverage)
- [x] `cargo test --lib separator::catalog` — PASS (27 tests, includes embedded snapshot/pointer self-consistency)
- [x] `node scripts/prepare-onnx-runtime.mjs` fresh-staged from the new release (download + size + archive digest + per-file digests) for 3 targets:
  - `--target x86_64-pc-windows-msvc --provider directml` — PASS
  - `--target x86_64-pc-windows-msvc --provider cpu` — PASS
  - host `aarch64-apple-darwin` (default) — PASS
- [x] Upstream: PE import tables of both Windows `onnxruntime.dll` variants verified clean of `VCRUNTIME140*` / `MSVCP140*` (remaining `api-ms-win-crt-*` imports are the UCRT, which ships with Windows 10+)

## Gaps

- Windows installed-app behavior is only provable in Windows CI, and `src-tauri/catalog/**` is not in the Branch Windows installed-app gate's `pull_request` path filter — so I dispatched it manually on this branch (suite=full): https://github.com/thedavidweng/OpenKara/actions/runs/31674410572. The #361 app-local CRT DLLs remain bundled by this PR, so that workflow's CRT assertions still hold here.
- `pnpm tauri build` not run locally (covered by CI).
- The three remaining runtime archives (linux x64/arm64, macOS x64) were not re-downloaded locally; their digests were verified by the upstream publish pipeline's verify step.

## Residual risk

Low. Models are byte-identical to generation 12; non-Windows runtimes rebuilt with unchanged flags from the same pinned source; existing installs pick up generation 13 via catalog auto-discovery without an app release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the stable release catalog to generation 13 (`2026-08-12-001`).
  * Refreshed runtime artifact downloads, checksums, sizes, and extracted-file metadata.
  * Rebuilt reduced Windows CPU and DirectML runtime packages with static runtime support.
  * Updated release metadata and publication timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->