### PR TITLE
fix(separator): make the runtime install/update path digest-aware and probe-gated

### DIFF
--- a/src-tauri/src/automation_smoke.rs
+++ b/src-tauri/src/automation_smoke.rs
@@ -163,6 +163,7 @@ pub fn run_phase(config: &AutomationSmokeConfig) -> Result<InstalledAppSmokeRepo
     let model_path = separation::ensure_runtime_and_managed_model_blocking(
         &config.app_data_dir,
         &runtime_status,
+        &Arc::new(Mutex::new(None)),
         &model_status,
         &mut |event, snapshot| {
             runtime_events.push(BootstrapEvent {

--- a/src-tauri/src/commands/runtime_bootstrap.rs
+++ b/src-tauri/src/commands/runtime_bootstrap.rs
@@ -347,7 +347,11 @@ pub(crate) fn ensure_runtime_loaded_with_watchdog(path: &Path) -> anyhow::Result
     activation::commit_with_watchdog(path)
 }
 
-fn download_runtime_source(
+/// The catalog an install should use right now: the cached verified catalog
+/// when its generation is newer than the embedded snapshot, the embedded
+/// snapshot otherwise. Every install path resolves through this so a
+/// refreshed catalog is never silently ignored (#393).
+pub(crate) fn refreshed_or_embedded_catalog(
     catalog_cache: &Arc<Mutex<Option<VerifiedCatalog>>>,
 ) -> CommandResult<VerifiedCatalog> {
     let embedded = catalog::embedded_catalog();
@@ -536,6 +540,7 @@ pub fn download_and_stage_candidate_blocking(
 pub fn ensure_runtime_ready_or_install_blocking(
     app_data_dir: &Path,
     status: &Arc<Mutex<RuntimeBootstrapStatusSnapshot>>,
+    catalog_cache: &Arc<Mutex<Option<VerifiedCatalog>>>,
     emit: &mut impl FnMut(&'static str, RuntimeBootstrapStatusSnapshot),
 ) -> CommandResult<PathBuf> {
     // Process-committed runtime wins over slot inventory (mapped until restart).
@@ -607,8 +612,8 @@ pub fn ensure_runtime_ready_or_install_blocking(
         };
     }
 
-    let catalog = catalog::embedded_catalog();
-    ensure_runtime_ready_or_install_with_catalog(app_data_dir, status, catalog, emit)
+    let catalog = refreshed_or_embedded_catalog(catalog_cache)?;
+    ensure_runtime_ready_or_install_with_catalog(app_data_dir, status, &catalog, emit)
 }
 
 fn publish_ready(
@@ -716,7 +721,7 @@ pub fn download_runtime(
 ) -> CommandResult<RuntimeBootstrapStatusSnapshot> {
     let app_data_dir = state.shell.app_data_dir.clone();
     let status = Arc::clone(&state.shell.runtime_bootstrap_status);
-    let catalog = download_runtime_source(&state.shell.catalog_cache)?;
+    let catalog = refreshed_or_embedded_catalog(&state.shell.catalog_cache)?;
 
     if RUNTIME_DOWNLOAD_IN_PROGRESS.swap(true, std::sync::atomic::Ordering::SeqCst) {
         // Already running — report current state; do not race a second install.
@@ -1075,16 +1080,48 @@ mod tests {
     }
 
     #[test]
-    fn download_runtime_source_keeps_a_newer_verified_catalog() {
+    fn refreshed_or_embedded_catalog_keeps_a_newer_verified_catalog() {
         let mut refreshed = catalog::embedded_catalog().clone();
         refreshed.generation += 1;
         refreshed.release_id = "refreshed-release".to_owned();
         let cache = Arc::new(Mutex::new(Some(refreshed.clone())));
 
-        let selected = download_runtime_source(&cache).expect("catalog cache should resolve");
+        let selected = refreshed_or_embedded_catalog(&cache).expect("catalog cache should resolve");
 
         assert_eq!(selected.generation, refreshed.generation);
         assert_eq!(selected.release_id, refreshed.release_id);
+    }
+
+    #[test]
+    fn separation_triggered_install_resolves_from_the_refreshed_catalog() {
+        // A refreshed catalog whose generation supersedes the embedded one
+        // but lists no runtime for this target: an install that consults the
+        // refreshed catalog fails at runtime resolution, while one that
+        // silently falls back to the embedded snapshot (#393) proceeds into
+        // the download/worker path and fails much later with a worker error.
+        let mut refreshed = catalog::embedded_catalog().clone();
+        refreshed.generation += 1;
+        refreshed.release_id = "refreshed-without-runtimes".to_owned();
+        refreshed.manifest.artifacts.runtimes.clear();
+        let cache = Arc::new(Mutex::new(Some(refreshed)));
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let status = Arc::new(Mutex::new(snapshot_from_disk(tmp.path())));
+        let mut events: Vec<(&'static str, RuntimeBootstrapStatusSnapshot)> = Vec::new();
+
+        let error = ensure_runtime_ready_or_install_blocking(
+            tmp.path(),
+            &status,
+            &cache,
+            &mut |event, snapshot| events.push((event, snapshot)),
+        )
+        .expect_err("a refreshed catalog without runtimes must fail resolution");
+
+        assert!(
+            error.message.contains("no active runtime"),
+            "the install must resolve against the refreshed catalog, not the embedded snapshot: {}",
+            error.message
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/runtime_bootstrap.rs
+++ b/src-tauri/src/commands/runtime_bootstrap.rs
@@ -400,9 +400,7 @@ pub fn install_and_load_runtime_blocking(
         crate::config::effective_execution_provider_from_dir(app_data_dir),
     )?;
 
-    if let Some(path) =
-        try_activate_staged_runtime(app_data_dir, &runtime.artifact_id, status, emit)?
-    {
+    if let Some(path) = try_activate_staged_runtime(app_data_dir, runtime, status, emit)? {
         return Ok(path);
     }
 
@@ -423,15 +421,16 @@ pub fn install_and_load_runtime_blocking(
         },
     )?;
 
+    let install_key = installed.install_key();
     activation::load_with_watchdog(
         app_data_dir,
         &installed.library_path,
         ActivationTarget {
-            artifact_id: Some(&installed.record.artifact_id),
+            install_key: Some(&install_key),
             execution_providers: Some(&runtime.runtime.execution_providers),
         },
     )?;
-    runtime_bootstrap::activate_first_install(app_data_dir, &installed.record.artifact_id)
+    runtime_bootstrap::activate_first_install(app_data_dir, &install_key)
         .map_err(|error| with_failure_phase(error, RuntimeBootstrapFailurePhase::Activate))?;
 
     let snapshot = snapshot_from_disk(app_data_dir);
@@ -442,7 +441,7 @@ pub fn install_and_load_runtime_blocking(
 
 fn try_activate_staged_runtime(
     app_data_dir: &Path,
-    artifact_id: &str,
+    runtime: &catalog::CatalogRuntime,
     status: &Arc<Mutex<RuntimeBootstrapStatusSnapshot>>,
     emit: &mut impl FnMut(&'static str, RuntimeBootstrapStatusSnapshot),
 ) -> anyhow::Result<Option<PathBuf>> {
@@ -452,8 +451,17 @@ fn try_activate_staged_runtime(
     }
 
     let installed = match inventory.candidate {
-        Some(candidate) if candidate.record.artifact_id == artifact_id => candidate,
-        _ => match runtime_bootstrap::installed_runtime(app_data_dir, artifact_id) {
+        Some(candidate)
+            if candidate.record.artifact_id == runtime.artifact_id
+                && candidate.record.archive_sha256 == runtime.archive_digest =>
+        {
+            candidate
+        }
+        _ => match runtime_bootstrap::find_installed_runtime(
+            app_data_dir,
+            &runtime.artifact_id,
+            &runtime.archive_digest,
+        ) {
             Some(existing) if runtime_bootstrap::verify_runtime_files(&existing)? => existing,
             _ => return Ok(None),
         },
@@ -465,16 +473,17 @@ fn try_activate_staged_runtime(
 
     let base = snapshot_from_disk(app_data_dir);
     report_post_download_progress(status, emit, &base, RuntimeBootstrapState::Probing);
+    let install_key = installed.install_key();
     activation::load_with_watchdog(
         app_data_dir,
         &installed.library_path,
         ActivationTarget {
-            artifact_id: Some(&installed.record.artifact_id),
+            install_key: Some(&install_key),
             execution_providers: None,
         },
     )?;
     report_post_download_progress(status, emit, &base, RuntimeBootstrapState::Activating);
-    runtime_bootstrap::activate_first_install(app_data_dir, &installed.record.artifact_id)
+    runtime_bootstrap::activate_first_install(app_data_dir, &install_key)
         .map_err(|error| with_failure_phase(error, RuntimeBootstrapFailurePhase::Activate))?;
 
     let snapshot = snapshot_from_disk(app_data_dir);
@@ -582,8 +591,9 @@ pub fn ensure_runtime_ready_or_install_blocking(
     }
 
     if let Some(active) = inventory.active {
+        let install_key = active.install_key();
         let target = ActivationTarget {
-            artifact_id: Some(&active.record.artifact_id),
+            install_key: Some(&install_key),
             execution_providers: None,
         };
         return match activation::load_with_watchdog(app_data_dir, &active.library_path, target) {
@@ -895,6 +905,57 @@ mod tests {
             legacy_path: None,
             last_failure: None,
         }
+    }
+
+    #[test]
+    fn a_stale_same_id_install_is_not_activated_for_a_new_digest() {
+        // #394: with no active runtime, the pre-worker activation shortcut
+        // used to accept any verified install matching the artifact id. A
+        // same-id install left by an older catalog generation must not
+        // satisfy a request for the republished digest — the worker install
+        // must proceed instead.
+        use crate::separator::verified_manifest::sha256_hex;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let embedded = catalog::embedded_catalog();
+        let mut runtime = catalog::resolve_runtime(
+            &embedded.manifest,
+            catalog::current_target_triple(),
+            crate::config::ExecutionProviderPreference::default_for_current_platform(),
+        )
+        .expect("embedded runtime")
+        .clone();
+        runtime.archive_digest = sha256_hex(b"republished-generation-archive");
+
+        let stale_dir = runtime_bootstrap::runtime_artifact_dir(tmp.path(), &runtime.artifact_id);
+        std::fs::create_dir_all(&stale_dir).expect("create stale install");
+        let library_bytes = b"stale-generation-library";
+        std::fs::write(
+            stale_dir.join(runtime_bootstrap::ORT_RUNTIME_FILENAME),
+            library_bytes,
+        )
+        .expect("write library");
+        let mut record = catalog::record_from_catalog_runtime(&runtime, embedded);
+        record.archive_sha256 = sha256_hex(b"stale-generation-archive");
+        record.files = vec![catalog::InstalledFileRecord {
+            path: runtime_bootstrap::ORT_RUNTIME_FILENAME.to_owned(),
+            size: library_bytes.len() as u64,
+            sha256: sha256_hex(library_bytes),
+        }];
+        catalog::write_artifact_record(
+            &stale_dir.join(runtime_bootstrap::RUNTIME_RECORD_FILENAME),
+            &record,
+        )
+        .expect("write record");
+
+        let status = Arc::new(Mutex::new(snapshot_from_inventory(&empty_inventory())));
+        let mut emit = |_event: &'static str, _snapshot: RuntimeBootstrapStatusSnapshot| {};
+        let activated = try_activate_staged_runtime(tmp.path(), &runtime, &status, &mut emit)
+            .expect("the digest mismatch must be a clean miss, not an error");
+        assert_eq!(
+            activated, None,
+            "a stale same-id install must not satisfy the republished digest"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/runtime_worker.rs
+++ b/src-tauri/src/commands/runtime_worker.rs
@@ -204,7 +204,7 @@ fn run_worker_with(
     // (#395). A worker killed before this point loses nothing durable — the
     // verified archive cache and the install directory make the retry a
     // re-verification, not a re-download.
-    runtime_bootstrap::stage_candidate(&request.app_data_dir, &installed.record.artifact_id)?;
+    runtime_bootstrap::stage_candidate(&request.app_data_dir, &installed.install_key())?;
 
     write_progress(
         progress_path,
@@ -317,8 +317,14 @@ fn install_runtime_with_verified_archive_cache(
     catalog: &VerifiedCatalog,
     mut progress: impl FnMut(RuntimeWorkerProgress),
 ) -> Result<runtime_bootstrap::InstalledRuntime> {
-    if let Some(existing) = runtime_bootstrap::installed_runtime(app_data_dir, &runtime.artifact_id)
-    {
+    // Reuse requires the installed archive digest to match the target's: a
+    // catalog generation can republish the same artifact id with different
+    // bytes, and matching on id alone turned that update into a no-op (#394).
+    if let Some(existing) = runtime_bootstrap::find_installed_runtime(
+        app_data_dir,
+        &runtime.artifact_id,
+        &runtime.archive_digest,
+    ) {
         if runtime_bootstrap::verify_runtime_files(&existing)? {
             progress(RuntimeWorkerProgress::phase(RuntimeWorkerPhase::Installing));
             return Ok(existing);
@@ -359,7 +365,20 @@ fn install_runtime_with_verified_archive_cache(
             &staging.join(runtime_bootstrap::RUNTIME_RECORD_FILENAME),
             &record,
         )?;
-        let final_dir = runtime_bootstrap::runtime_artifact_dir(app_data_dir, &runtime.artifact_id);
+        // A different-digest install of the same artifact id may occupy the
+        // plain directory — possibly as the currently loaded runtime, whose
+        // files cannot be deleted or replaced while mapped (Windows locks
+        // them). Install side by side under a digest-qualified directory
+        // instead of clearing it.
+        let plain_dir_occupied_by_other_digest =
+            runtime_bootstrap::installed_runtime(app_data_dir, &runtime.artifact_id)
+                .is_some_and(|other| other.record.archive_sha256 != runtime.archive_digest);
+        let install_key = if plain_dir_occupied_by_other_digest {
+            runtime_bootstrap::runtime_install_key(&runtime.artifact_id, &runtime.archive_digest)
+        } else {
+            runtime.artifact_id.clone()
+        };
+        let final_dir = runtime_bootstrap::runtime_artifact_dir(app_data_dir, &install_key);
         if final_dir.exists() {
             fs::remove_dir_all(&final_dir).with_context(|| {
                 format!("failed to clear stale install {}", final_dir.display())
@@ -371,7 +390,7 @@ fn install_runtime_with_verified_archive_cache(
                 final_dir.display()
             )
         })?;
-        runtime_bootstrap::installed_runtime(app_data_dir, &runtime.artifact_id)
+        runtime_bootstrap::installed_runtime(app_data_dir, &install_key)
             .context("freshly installed runtime failed to resolve")
     })();
 
@@ -622,14 +641,18 @@ pub fn install_runtime_with_worker(
         return Err(tag_with_last_phase(error, last_phase));
     }
 
-    runtime_bootstrap::installed_runtime(app_data_dir, &runtime.artifact_id)
-        .context("runtime worker exited successfully without an installed runtime")
-        .map_err(|error| {
-            crate::commands::runtime_bootstrap::with_failure_phase(
-                error,
-                crate::commands::runtime_bootstrap::RuntimeBootstrapFailurePhase::Install,
-            )
-        })
+    runtime_bootstrap::find_installed_runtime(
+        app_data_dir,
+        &runtime.artifact_id,
+        &runtime.archive_digest,
+    )
+    .context("runtime worker exited successfully without an installed runtime")
+    .map_err(|error| {
+        crate::commands::runtime_bootstrap::with_failure_phase(
+            error,
+            crate::commands::runtime_bootstrap::RuntimeBootstrapFailurePhase::Install,
+        )
+    })
 }
 
 #[cfg(test)]
@@ -726,6 +749,113 @@ mod tests {
         )
         .expect("write request");
         (request_path, app_data.join("worker-test.progress.json"))
+    }
+
+    /// Write a fake installed runtime for the fixture's artifact id whose
+    /// record digests match its files but whose archive digest differs from
+    /// the fixture's target archive.
+    fn write_same_id_install_with_digest(
+        app_data: &Path,
+        catalog: &VerifiedCatalog,
+        runtime: &CatalogRuntime,
+        archive_sha256: &str,
+        library_bytes: &[u8],
+    ) {
+        let dir = runtime_bootstrap::runtime_artifact_dir(app_data, &runtime.artifact_id);
+        fs::create_dir_all(&dir).expect("create install dir");
+        fs::write(
+            dir.join(runtime_bootstrap::ORT_RUNTIME_FILENAME),
+            library_bytes,
+        )
+        .expect("write library");
+        let mut record = record_from_catalog_runtime(runtime, catalog);
+        record.archive_sha256 = archive_sha256.to_owned();
+        record.files = vec![catalog::InstalledFileRecord {
+            path: runtime_bootstrap::ORT_RUNTIME_FILENAME.to_owned(),
+            size: library_bytes.len() as u64,
+            sha256: sha256_hex(library_bytes),
+        }];
+        write_artifact_record(
+            &dir.join(runtime_bootstrap::RUNTIME_RECORD_FILENAME),
+            &record,
+        )
+        .expect("write record");
+    }
+
+    #[test]
+    fn a_same_id_digest_swap_installs_side_by_side_and_stages_the_new_digest() {
+        // #394: catalog generation 13 republished `...-cpu-reduced` with new
+        // bytes. Reuse keyed on the artifact id alone returned the stale
+        // gen-12 install, so the update never installed. The active install
+        // may be loaded by the running app (Windows locks mapped files), so
+        // the new digest must land side by side, not replace it.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (catalog, runtime) = offline_install_fixture(dir.path(), "rt-swap", b"gen-13-library");
+        let old_digest = sha256_hex(b"gen-12-archive");
+        write_same_id_install_with_digest(
+            dir.path(),
+            &catalog,
+            &runtime,
+            &old_digest,
+            b"gen-12-library",
+        );
+        runtime_bootstrap::write_slots(
+            dir.path(),
+            &runtime_bootstrap::RuntimeSlots {
+                active: Some("rt-swap".to_owned()),
+                ..runtime_bootstrap::RuntimeSlots::default()
+            },
+        )
+        .expect("write slots");
+        let (request_path, progress_path) = write_worker_request(dir.path(), &catalog, &runtime);
+
+        run_worker_with(&request_path, &progress_path, |_| Ok(()))
+            .expect("the worker must install the republished digest");
+
+        let new_key = runtime_bootstrap::runtime_install_key("rt-swap", &runtime.archive_digest);
+        let slots = runtime_bootstrap::read_slots(dir.path());
+        assert_eq!(
+            slots.candidate.as_deref(),
+            Some(new_key.as_str()),
+            "the new digest must be staged as the candidate, not the stale same-id install"
+        );
+        assert_eq!(
+            slots.active.as_deref(),
+            Some("rt-swap"),
+            "the active slot must stay on the running install"
+        );
+
+        let stale = runtime_bootstrap::installed_runtime(dir.path(), "rt-swap")
+            .expect("the possibly-loaded active install must not be touched");
+        assert_eq!(stale.record.archive_sha256, old_digest);
+
+        let staged = runtime_bootstrap::installed_runtime(dir.path(), &new_key)
+            .expect("the new digest must be installed side by side");
+        assert_eq!(staged.record.archive_sha256, runtime.archive_digest);
+        assert!(runtime_bootstrap::verify_runtime_files(&staged).expect("verify"));
+    }
+
+    #[test]
+    fn an_install_matching_the_target_digest_is_reused_without_redownloading() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (catalog, runtime) = offline_install_fixture(dir.path(), "rt-reuse", b"same-bytes");
+        let (request_path, progress_path) = write_worker_request(dir.path(), &catalog, &runtime);
+        run_worker_with(&request_path, &progress_path, |_| Ok(()))
+            .expect("first install must succeed");
+
+        // Remove the verified archive cache: a second run can only succeed
+        // by reusing the existing digest-equal install, because the download
+        // URL is unreachable.
+        fs::remove_file(runtime_cache_path(dir.path(), &runtime)).expect("drop archive cache");
+
+        run_worker_with(&request_path, &progress_path, |_| Ok(()))
+            .expect("a digest-equal install must be reused without redownloading");
+        assert_eq!(
+            runtime_bootstrap::read_slots(dir.path())
+                .candidate
+                .as_deref(),
+            Some("rt-reuse")
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/runtime_worker.rs
+++ b/src-tauri/src/commands/runtime_worker.rs
@@ -129,6 +129,18 @@ pub fn maybe_run_from_cli() -> Result<bool> {
 }
 
 fn run_worker(request_path: &Path, progress_path: &Path) -> Result<()> {
+    run_worker_with(request_path, progress_path, |library_path| {
+        crate::separator::model::ensure_runtime_loaded_from_path(library_path).map(|_| ())
+    })
+}
+
+/// Seam at the probe: production loads the runtime into this worker process;
+/// tests substitute a probe that succeeds or fails on demand.
+fn run_worker_with(
+    request_path: &Path,
+    progress_path: &Path,
+    probe: impl FnOnce(&Path) -> Result<()>,
+) -> Result<()> {
     let request: RuntimeWorkerRequest =
         serde_json::from_slice(&fs::read(request_path).with_context(|| {
             format!("failed to read worker request {}", request_path.display())
@@ -154,10 +166,6 @@ fn run_worker(request_path: &Path, progress_path: &Path) -> Result<()> {
         },
     )?;
 
-    // Keep the verified install reachable after a worker kill. Startup can
-    // promote this candidate without downloading the archive again.
-    runtime_bootstrap::stage_candidate(&request.app_data_dir, &installed.record.artifact_id)?;
-
     #[cfg(feature = "automation-smoke")]
     if std::env::var_os("OPENKARA_RUNTIME_WORKER_HANG_AFTER_INSTALLING").is_some() {
         thread::sleep(Duration::from_secs(10 * 60));
@@ -182,14 +190,21 @@ fn run_worker(request_path: &Path, progress_path: &Path) -> Result<()> {
         thread::sleep(Duration::from_secs(10 * 60));
     }
 
-    crate::separator::model::ensure_runtime_loaded_from_path(&installed.library_path)
-        .with_context(|| {
-            format!(
-                "failed to load ONNX Runtime from {}",
-                installed.library_path.display()
-            )
-        })?;
+    probe(&installed.library_path).with_context(|| {
+        format!(
+            "failed to load ONNX Runtime from {}",
+            installed.library_path.display()
+        )
+    })?;
     eprintln!("probe succeeded for {}", installed.library_path.display());
+
+    // Stage only after the probe proved the library loads: startup
+    // acknowledges a promoted candidate on the worker probe's authority
+    // (ADR-0023), so an unproven install must never become the candidate
+    // (#395). A worker killed before this point loses nothing durable — the
+    // verified archive cache and the install directory make the retry a
+    // re-verification, not a re-download.
+    runtime_bootstrap::stage_candidate(&request.app_data_dir, &installed.record.artifact_id)?;
 
     write_progress(
         progress_path,
@@ -620,6 +635,158 @@ pub fn install_runtime_with_worker(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::separator::verified_manifest::sha256_hex;
+
+    fn write_tgz(path: &Path, entries: &[(&str, &[u8])]) {
+        let file = fs::File::create(path).expect("create archive");
+        let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::fast());
+        let mut builder = tar::Builder::new(encoder);
+        for (name, bytes) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(bytes.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, name, *bytes)
+                .expect("append entry");
+        }
+        builder
+            .into_inner()
+            .expect("finish tar")
+            .finish()
+            .expect("finish gzip");
+    }
+
+    /// A catalog whose only runtime for this target installs offline: its
+    /// archive is pre-seeded into the verified download cache, so the worker
+    /// never touches the (unreachable) download URL.
+    fn offline_install_fixture(
+        app_data: &Path,
+        artifact_id: &str,
+        library_bytes: &[u8],
+    ) -> (VerifiedCatalog, CatalogRuntime) {
+        let staging = app_data.join("fixture-archives");
+        fs::create_dir_all(&staging).expect("fixture staging dir");
+        let archive_path = staging.join(format!("{artifact_id}.tar.gz"));
+        write_tgz(
+            &archive_path,
+            &[(runtime_bootstrap::ORT_RUNTIME_FILENAME, library_bytes)],
+        );
+        let archive_bytes = fs::read(&archive_path).expect("read archive");
+
+        let runtime = CatalogRuntime {
+            artifact_id: artifact_id.to_owned(),
+            target_triple: Some(catalog::current_target_triple().to_owned()),
+            filename: format!("{artifact_id}.tar.gz"),
+            byte_size: archive_bytes.len() as u64,
+            archive_digest: sha256_hex(&archive_bytes),
+            download_url: "http://127.0.0.1:9/never-fetched.tar.gz".to_owned(),
+            extracted_file_digests: [(
+                runtime_bootstrap::ORT_RUNTIME_FILENAME.to_owned(),
+                catalog::CatalogFileDigest {
+                    sha256: sha256_hex(library_bytes),
+                    size: library_bytes.len() as u64,
+                },
+            )]
+            .into_iter()
+            .collect(),
+            runtime: catalog::CatalogRuntimeMetadata {
+                version: "v1-test".to_owned(),
+                ort_c_api_level: "27".to_owned(),
+                execution_providers: vec!["cpu".to_owned()],
+                supported_model_artifact_ids: vec![],
+                companion_files: vec![],
+            },
+            deprecation: catalog::CatalogDeprecation::default(),
+        };
+
+        let cache_path = runtime_cache_path(app_data, &runtime);
+        fs::create_dir_all(cache_path.parent().expect("cache parent")).expect("cache dir");
+        fs::rename(&archive_path, &cache_path).expect("seed verified archive cache");
+
+        let mut verified = catalog::embedded_catalog().clone();
+        verified.manifest.artifacts.runtimes = vec![runtime.clone()];
+        (verified, runtime)
+    }
+
+    fn write_worker_request(
+        app_data: &Path,
+        catalog: &VerifiedCatalog,
+        runtime: &CatalogRuntime,
+    ) -> (PathBuf, PathBuf) {
+        let request = RuntimeWorkerRequest {
+            app_data_dir: app_data.to_path_buf(),
+            catalog: catalog.clone(),
+            runtime: runtime.clone(),
+        };
+        let request_path = app_data.join("worker-test.request.json");
+        fs::write(
+            &request_path,
+            serde_json::to_vec(&request).expect("serialize request"),
+        )
+        .expect("write request");
+        (request_path, app_data.join("worker-test.progress.json"))
+    }
+
+    #[test]
+    fn a_failed_probe_does_not_stage_the_install_as_candidate() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (catalog, runtime) =
+            offline_install_fixture(dir.path(), "rt-probe-fails", b"not-a-real-dylib");
+        let (request_path, progress_path) = write_worker_request(dir.path(), &catalog, &runtime);
+
+        let error = run_worker_with(&request_path, &progress_path, |_| {
+            anyhow::bail!("scripted probe failure")
+        })
+        .expect_err("a failing probe must fail the worker");
+        assert!(
+            format!("{error:#}").contains("scripted probe failure"),
+            "unexpected error: {error:#}"
+        );
+
+        let slots = runtime_bootstrap::read_slots(dir.path());
+        assert_eq!(
+            slots.candidate, None,
+            "an unproven install must never be staged as the next-launch candidate"
+        );
+        // The verified install itself survives so a retry re-verifies
+        // instead of re-downloading.
+        let installed = runtime_bootstrap::installed_runtime(dir.path(), "rt-probe-fails")
+            .expect("the verified install must survive the failed probe");
+        assert!(runtime_bootstrap::verify_runtime_files(&installed).expect("verify"));
+    }
+
+    #[test]
+    fn a_successful_probe_stages_the_candidate_only_after_probing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (catalog, runtime) =
+            offline_install_fixture(dir.path(), "rt-probe-passes", b"probed-dylib");
+        let (request_path, progress_path) = write_worker_request(dir.path(), &catalog, &runtime);
+
+        let mut candidate_at_probe_time = None;
+        run_worker_with(&request_path, &progress_path, |library_path| {
+            assert!(
+                library_path.is_file(),
+                "probe must see the installed library"
+            );
+            candidate_at_probe_time = Some(runtime_bootstrap::read_slots(dir.path()).candidate);
+            Ok(())
+        })
+        .expect("the worker must succeed when the probe passes");
+
+        assert_eq!(
+            candidate_at_probe_time,
+            Some(None),
+            "the candidate slot must still be empty while the probe runs"
+        );
+        assert_eq!(
+            runtime_bootstrap::read_slots(dir.path())
+                .candidate
+                .as_deref(),
+            Some("rt-probe-passes"),
+            "a proven install must be staged as the next-launch candidate"
+        );
+    }
 
     #[test]
     fn progress_round_trips_with_an_explicit_phase() {

--- a/src-tauri/src/commands/runtime_worker.rs
+++ b/src-tauri/src/commands/runtime_worker.rs
@@ -204,7 +204,19 @@ fn run_worker_with(
     // (#395). A worker killed before this point loses nothing durable — the
     // verified archive cache and the install directory make the retry a
     // re-verification, not a re-download.
-    runtime_bootstrap::stage_candidate(&request.app_data_dir, &installed.install_key())?;
+    //
+    // Reusing the install the active slot already names needs no staging:
+    // promoting a key onto itself would leave `active` and `previous` naming
+    // the same directory, and a failed activation rollback would delete the
+    // only install.
+    let install_key = installed.install_key();
+    if runtime_bootstrap::read_slots(&request.app_data_dir)
+        .active
+        .as_deref()
+        != Some(install_key.as_str())
+    {
+        runtime_bootstrap::stage_candidate(&request.app_data_dir, &install_key)?;
+    }
 
     write_progress(
         progress_path,
@@ -365,15 +377,20 @@ fn install_runtime_with_verified_archive_cache(
             &staging.join(runtime_bootstrap::RUNTIME_RECORD_FILENAME),
             &record,
         )?;
-        // A different-digest install of the same artifact id may occupy the
-        // plain directory — possibly as the currently loaded runtime, whose
-        // files cannot be deleted or replaced while mapped (Windows locks
-        // them). Install side by side under a digest-qualified directory
-        // instead of clearing it.
-        let plain_dir_occupied_by_other_digest =
-            runtime_bootstrap::installed_runtime(app_data_dir, &runtime.artifact_id)
+        // The plain artifact-id directory is unavailable when a
+        // different-digest install of the same artifact id occupies it, or
+        // when the active slot names it even though its record is unreadable
+        // — either way it may be the currently loaded runtime, whose files
+        // cannot be deleted or replaced while mapped (Windows locks them).
+        // Install side by side under a digest-qualified directory instead of
+        // clearing it.
+        let plain_dir_unavailable = runtime_bootstrap::read_slots(app_data_dir)
+            .active
+            .as_deref()
+            == Some(runtime.artifact_id.as_str())
+            || runtime_bootstrap::installed_runtime(app_data_dir, &runtime.artifact_id)
                 .is_some_and(|other| other.record.archive_sha256 != runtime.archive_digest);
-        let install_key = if plain_dir_occupied_by_other_digest {
+        let install_key = if plain_dir_unavailable {
             runtime_bootstrap::runtime_install_key(&runtime.artifact_id, &runtime.archive_digest)
         } else {
             runtime.artifact_id.clone()
@@ -832,6 +849,72 @@ mod tests {
         let staged = runtime_bootstrap::installed_runtime(dir.path(), &new_key)
             .expect("the new digest must be installed side by side");
         assert_eq!(staged.record.archive_sha256, runtime.archive_digest);
+        assert!(runtime_bootstrap::verify_runtime_files(&staged).expect("verify"));
+    }
+
+    #[test]
+    fn reusing_the_active_install_does_not_stage_it_as_candidate() {
+        // Staging the key the active slot already names would make startup
+        // promote it onto itself: `active` and `previous` end up naming the
+        // same directory, and a failed activation rollback deletes the only
+        // install.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (catalog, runtime) = offline_install_fixture(dir.path(), "rt-active", b"active-lib");
+        let (request_path, progress_path) = write_worker_request(dir.path(), &catalog, &runtime);
+        run_worker_with(&request_path, &progress_path, |_| Ok(()))
+            .expect("first install must succeed");
+        runtime_bootstrap::activate_first_install(dir.path(), "rt-active").expect("activate");
+
+        run_worker_with(&request_path, &progress_path, |_| Ok(()))
+            .expect("reusing the active install must succeed");
+
+        let slots = runtime_bootstrap::read_slots(dir.path());
+        assert_eq!(slots.active.as_deref(), Some("rt-active"));
+        assert_eq!(
+            slots.candidate, None,
+            "the active install must not be staged onto itself"
+        );
+    }
+
+    #[test]
+    fn an_unreadable_install_named_by_the_active_slot_is_not_replaced() {
+        // The active slot may name a directory whose record no longer reads
+        // (corruption), while its library is still loaded by the running
+        // app. The worker must not clear that directory; the new install
+        // goes side by side.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (catalog, runtime) = offline_install_fixture(dir.path(), "rt-broken", b"fresh-lib");
+        let plain_dir = runtime_bootstrap::runtime_artifact_dir(dir.path(), "rt-broken");
+        fs::create_dir_all(&plain_dir).expect("create broken install");
+        let loaded_library = plain_dir.join(runtime_bootstrap::ORT_RUNTIME_FILENAME);
+        fs::write(&loaded_library, b"mapped-into-the-running-process").expect("write library");
+        runtime_bootstrap::write_slots(
+            dir.path(),
+            &runtime_bootstrap::RuntimeSlots {
+                active: Some("rt-broken".to_owned()),
+                ..runtime_bootstrap::RuntimeSlots::default()
+            },
+        )
+        .expect("write slots");
+        let (request_path, progress_path) = write_worker_request(dir.path(), &catalog, &runtime);
+
+        run_worker_with(&request_path, &progress_path, |_| Ok(()))
+            .expect("the worker must install despite the unreadable active install");
+
+        assert_eq!(
+            fs::read(&loaded_library).expect("read library"),
+            b"mapped-into-the-running-process",
+            "the directory named by the active slot must not be touched"
+        );
+        let new_key = runtime_bootstrap::runtime_install_key("rt-broken", &runtime.archive_digest);
+        assert_eq!(
+            runtime_bootstrap::read_slots(dir.path())
+                .candidate
+                .as_deref(),
+            Some(new_key.as_str())
+        );
+        let staged = runtime_bootstrap::installed_runtime(dir.path(), &new_key)
+            .expect("the new install must land side by side");
         assert!(runtime_bootstrap::verify_runtime_files(&staged).expect("verify"));
     }
 

--- a/src-tauri/src/runtime_bootstrap_regression.rs
+++ b/src-tauri/src/runtime_bootstrap_regression.rs
@@ -349,12 +349,14 @@ fn run_fault_retry(
         "verified_install_survived_process_exit".to_owned(),
         verified_orphan,
     );
+    // The worker was killed during the probe, so the install was never
+    // proven and must not be staged: startup acknowledges a candidate on
+    // the worker probe's authority without loading it (#395).
     assertions.insert(
-        "verified_candidate_survived_process_exit".to_owned(),
+        "unproven_install_was_not_staged_as_candidate".to_owned(),
         runtime_bootstrap::runtime_inventory(&config.app_data_dir)
             .candidate
-            .as_ref()
-            .is_some_and(|candidate| candidate.record.artifact_id == runtime.artifact_id),
+            .is_none(),
     );
     assertions.insert(
         "runtime_is_not_active_before_restart".to_owned(),
@@ -382,12 +384,9 @@ fn run_restart(
     let orphan = runtime_bootstrap::installed_runtime(&config.app_data_dir, artifact_id)
         .context("restart phase did not find the verified orphan install")?;
     anyhow::ensure!(
-        before_inventory.active.is_none()
-            && before_inventory
-                .candidate
-                .as_ref()
-                .is_some_and(|candidate| candidate.record.artifact_id == artifact_id),
-        "restart phase must begin with the verified runtime candidate"
+        before_inventory.active.is_none() && before_inventory.candidate.is_none(),
+        "restart phase must begin from an unstaged orphan install: the probe never \
+         passed, so the previous process must not have staged a candidate (#395)"
     );
     anyhow::ensure!(
         runtime_bootstrap::verify_runtime_files(&orphan)?,

--- a/src-tauri/src/runtime_bootstrap_regression.rs
+++ b/src-tauri/src/runtime_bootstrap_regression.rs
@@ -401,6 +401,7 @@ fn run_restart(
     let result = command::ensure_runtime_ready_or_install_blocking(
         &config.app_data_dir,
         &status,
+        &Arc::new(Mutex::new(None)),
         &mut |event, snapshot| {
             events.push(RegressionEvent {
                 event: event.to_owned(),

--- a/src-tauri/src/separator/activation.rs
+++ b/src-tauri/src/separator/activation.rs
@@ -509,12 +509,15 @@ pub(crate) fn failure_phase_of(error: &anyhow::Error) -> Option<RuntimeBootstrap
 /// Identity of the install a caller wants committed.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ActivationTarget<'a> {
-    /// Slot artifact id. `None` for a legacy (pre-slot) install, which owns
-    /// no slot and therefore has nothing to roll back to.
-    pub artifact_id: Option<&'a str>,
+    /// Slot value naming the install (the artifact id, or its
+    /// digest-qualified form for a side-by-side install). `None` for a
+    /// legacy (pre-slot) install, which owns no slot and therefore has
+    /// nothing to roll back to.
+    pub install_key: Option<&'a str>,
     /// Execution providers the artifact advertises, when the caller already
     /// resolved them from a catalog newer than the embedded one. `None`
-    /// resolves them from the embedded catalog by `artifact_id`.
+    /// resolves them from the embedded catalog by the install key's
+    /// artifact id.
     pub execution_providers: Option<&'a [String]>,
 }
 
@@ -572,17 +575,12 @@ fn resolve_and_load_with(
         return Ok(None);
     }
 
-    let artifact_id = plan
-        .record
-        .as_ref()
-        .map(|record| record.artifact_id.as_str())
-        .filter(|artifact_id| !artifact_id.is_empty());
     load_with_watchdog_using(
         strategy,
         app_data_dir,
         &plan.library_path,
         ActivationTarget {
-            artifact_id,
+            install_key: plan.install_key.as_deref(),
             execution_providers: None,
         },
     )
@@ -597,7 +595,7 @@ fn load_with_watchdog_using(
 ) -> Result<PathBuf> {
     let error = match strategy.commit(library_path) {
         LoadOutcome::Committed => {
-            acknowledge_pending_activation(app_data_dir, target.artifact_id)?;
+            acknowledge_pending_activation(app_data_dir, target.install_key)?;
             return Ok(library_path.to_path_buf());
         }
         LoadOutcome::ProcessUnavailable(error) => {
@@ -616,7 +614,7 @@ fn load_with_watchdog_using(
     );
     record_directml_timeout(app_data_dir, target, &error);
 
-    match restore_previous_generation(strategy, app_data_dir, target.artifact_id, &error) {
+    match restore_previous_generation(strategy, app_data_dir, target.install_key, &error) {
         Some(previous) => Ok(previous),
         None => Err(with_failure_phase(
             error,
@@ -625,12 +623,12 @@ fn load_with_watchdog_using(
     }
 }
 
-fn acknowledge_pending_activation(app_data_dir: &Path, artifact_id: Option<&str>) -> Result<()> {
-    let Some(artifact_id) = artifact_id else {
+fn acknowledge_pending_activation(app_data_dir: &Path, install_key: Option<&str>) -> Result<()> {
+    let Some(install_key) = install_key else {
         return Ok(());
     };
     let slots = runtime_bootstrap::read_slots(app_data_dir);
-    if slots.activation_pending && slots.active.as_deref() == Some(artifact_id) {
+    if slots.activation_pending && slots.active.as_deref() == Some(install_key) {
         runtime_bootstrap::finish_activation_success(app_data_dir)
             .map_err(|error| with_failure_phase(error, RuntimeBootstrapFailurePhase::Activate))?;
     }
@@ -644,21 +642,21 @@ fn acknowledge_pending_activation(app_data_dir: &Path, artifact_id: Option<&str>
 fn restore_previous_generation(
     strategy: &LoadStrategy,
     app_data_dir: &Path,
-    artifact_id: Option<&str>,
+    install_key: Option<&str>,
     error: &anyhow::Error,
 ) -> Option<PathBuf> {
-    let artifact_id = artifact_id?;
+    let install_key = install_key?;
     if runtime_bootstrap::read_slots(app_data_dir)
         .active
         .as_deref()
-        != Some(artifact_id)
+        != Some(install_key)
     {
         return None;
     }
 
     let restored = match runtime_bootstrap::rollback_failed_activation(
         app_data_dir,
-        artifact_id,
+        install_key,
         &format!("{error:#}"),
     ) {
         Ok(restored) => restored?,
@@ -689,7 +687,8 @@ fn record_directml_timeout(
     error: &anyhow::Error,
 ) {
     let from_catalog = target.execution_providers.is_none().then(|| {
-        target.artifact_id.and_then(|artifact_id| {
+        target.install_key.and_then(|install_key| {
+            let artifact_id = runtime_bootstrap::artifact_id_of_install_key(install_key);
             catalog::runtime_by_artifact_id(&catalog::embedded_catalog().manifest, artifact_id)
                 .map(|runtime| runtime.runtime.execution_providers.as_slice())
         })
@@ -981,7 +980,7 @@ mod tests {
             tmp.path(),
             &fresh,
             ActivationTarget {
-                artifact_id: Some("rt-fresh"),
+                install_key: Some("rt-fresh"),
                 execution_providers: None,
             },
         )
@@ -1078,7 +1077,7 @@ mod tests {
             tmp.path(),
             &active,
             ActivationTarget {
-                artifact_id: Some("rt-active"),
+                install_key: Some("rt-active"),
                 execution_providers: None,
             },
         )
@@ -1111,7 +1110,7 @@ mod tests {
             tmp.path(),
             &stalled,
             ActivationTarget {
-                artifact_id: Some("rt-directml"),
+                install_key: Some("rt-directml"),
                 execution_providers: Some(&providers),
             },
         )
@@ -1142,7 +1141,7 @@ mod tests {
             tmp.path(),
             &stalled,
             ActivationTarget {
-                artifact_id: Some("rt-cpu"),
+                install_key: Some("rt-cpu"),
                 execution_providers: Some(&providers),
             },
         )
@@ -1175,7 +1174,7 @@ mod tests {
             tmp.path(),
             &pending,
             ActivationTarget {
-                artifact_id: Some("rt-pending"),
+                install_key: Some("rt-pending"),
                 execution_providers: None,
             },
         )

--- a/src-tauri/src/separator/runtime_bootstrap.rs
+++ b/src-tauri/src/separator/runtime_bootstrap.rs
@@ -151,13 +151,55 @@ pub struct InstalledRuntime {
     pub library_path: PathBuf,
 }
 
-/// Read the installed runtime for an artifact id, when its record is valid
-/// and the main library file exists. File digests are NOT re-verified here —
-/// call `verify_runtime_files` before trusting it for activation.
-pub fn installed_runtime(app_data_dir: &Path, artifact_id: &str) -> Option<InstalledRuntime> {
-    let dir = runtime_artifact_dir(app_data_dir, artifact_id);
+impl InstalledRuntime {
+    /// The slot value naming this install: its directory name. Equal to the
+    /// artifact id except for a digest-qualified side-by-side install.
+    pub fn install_key(&self) -> String {
+        self.dir
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| self.record.artifact_id.clone())
+    }
+}
+
+const INSTALL_KEY_DIGEST_LEN: usize = 12;
+
+/// Directory name for an install that cannot occupy the plain artifact-id
+/// directory because a different-digest install of the same artifact id
+/// already lives there (a catalog generation republished the id with new
+/// bytes, #394). The occupied directory may be the currently loaded runtime,
+/// whose files must never be replaced in place.
+pub fn runtime_install_key(artifact_id: &str, archive_digest: &str) -> String {
+    let digest_prefix = &archive_digest[..INSTALL_KEY_DIGEST_LEN.min(archive_digest.len())];
+    format!("{artifact_id}+{digest_prefix}")
+}
+
+/// The artifact id named by a slot value, stripping a digest qualifier.
+pub fn artifact_id_of_install_key(install_key: &str) -> &str {
+    match install_key.rsplit_once('+') {
+        Some((artifact_id, digest_prefix))
+            if digest_prefix.len() == INSTALL_KEY_DIGEST_LEN
+                && digest_prefix.bytes().all(|byte| byte.is_ascii_hexdigit()) =>
+        {
+            artifact_id
+        }
+        _ => install_key,
+    }
+}
+
+fn install_key_matches_record(install_key: &str, record: &InstalledArtifactRecord) -> bool {
+    install_key == record.artifact_id
+        || install_key == runtime_install_key(&record.artifact_id, &record.archive_sha256)
+}
+
+/// Read the installed runtime for an install key (a slot value: the artifact
+/// id, or its digest-qualified form), when its record is valid and the main
+/// library file exists. File digests are NOT re-verified here — call
+/// `verify_runtime_files` before trusting it for activation.
+pub fn installed_runtime(app_data_dir: &Path, install_key: &str) -> Option<InstalledRuntime> {
+    let dir = runtime_artifact_dir(app_data_dir, install_key);
     let record = read_artifact_record(&dir.join(RUNTIME_RECORD_FILENAME))?;
-    if record.kind != "runtime" || record.artifact_id != artifact_id {
+    if record.kind != "runtime" || !install_key_matches_record(install_key, &record) {
         return None;
     }
     let library_path = dir.join(ORT_RUNTIME_FILENAME);
@@ -166,6 +208,24 @@ pub fn installed_runtime(app_data_dir: &Path, artifact_id: &str) -> Option<Insta
         dir,
         library_path,
     })
+}
+
+/// Find an install of exactly this artifact id AND archive digest, whether
+/// it lives in the plain artifact-id directory or a digest-qualified one.
+pub fn find_installed_runtime(
+    app_data_dir: &Path,
+    artifact_id: &str,
+    archive_digest: &str,
+) -> Option<InstalledRuntime> {
+    installed_runtime(app_data_dir, artifact_id)
+        .filter(|installed| installed.record.archive_sha256 == archive_digest)
+        .or_else(|| {
+            installed_runtime(
+                app_data_dir,
+                &runtime_install_key(artifact_id, archive_digest),
+            )
+            .filter(|installed| installed.record.archive_sha256 == archive_digest)
+        })
 }
 
 /// Verify every file the record declares by size and streaming SHA-256.
@@ -225,6 +285,9 @@ pub fn delete_legacy_runtime(app_data_dir: &Path) -> Result<()> {
 pub struct StartupLoadPlan {
     pub library_path: PathBuf,
     pub record: Option<InstalledArtifactRecord>,
+    /// Slot value naming the install this plan loads. `None` for a legacy
+    /// (pre-slot) install.
+    pub install_key: Option<String>,
     /// True when this load is proving a freshly promoted candidate. The
     /// caller must report the load result through
     /// `finish_activation_success` or `rollback_failed_activation`.
@@ -255,6 +318,7 @@ pub fn begin_startup(app_data_dir: &Path) -> Result<Option<StartupLoadPlan>> {
                 return Ok(Some(StartupLoadPlan {
                     library_path: pending.library_path,
                     record: Some(pending.record),
+                    install_key: pending_id,
                     proving_candidate: true,
                     is_legacy: false,
                 }));
@@ -283,7 +347,7 @@ pub fn begin_startup(app_data_dir: &Path) -> Result<Option<StartupLoadPlan>> {
                 // Persist pending marker before load so a crash rolls back next launch.
                 let old_active = slots.active.take();
                 slots.previous = old_active;
-                slots.active = Some(candidate_id);
+                slots.active = Some(candidate_id.clone());
                 slots.candidate = None;
                 slots.activation_pending = true;
                 slots.activation_attempts = 1;
@@ -291,6 +355,7 @@ pub fn begin_startup(app_data_dir: &Path) -> Result<Option<StartupLoadPlan>> {
                 return Ok(Some(StartupLoadPlan {
                     library_path: candidate.library_path,
                     record: Some(candidate.record),
+                    install_key: Some(candidate_id),
                     proving_candidate: true,
                     is_legacy: false,
                 }));
@@ -314,6 +379,7 @@ pub fn begin_startup(app_data_dir: &Path) -> Result<Option<StartupLoadPlan>> {
                 return Ok(Some(StartupLoadPlan {
                     library_path: active.library_path,
                     record: Some(active.record),
+                    install_key: Some(active_id),
                     proving_candidate: false,
                     is_legacy: false,
                 }));
@@ -336,6 +402,7 @@ pub fn begin_startup(app_data_dir: &Path) -> Result<Option<StartupLoadPlan>> {
         return Ok(Some(StartupLoadPlan {
             library_path: legacy_path,
             record: None,
+            install_key: None,
             proving_candidate: false,
             is_legacy: true,
         }));
@@ -523,21 +590,158 @@ mod tests {
         (catalog, runtime)
     }
 
-    /// Write a fake installed runtime whose record digests match the files.
-    fn write_fake_install(app_data: &Path, artifact_id: &str, library_bytes: &[u8]) {
+    /// Write a fake installed runtime whose record digests match the files,
+    /// into the directory named by `install_key`.
+    fn write_fake_install_at(
+        app_data: &Path,
+        install_key: &str,
+        artifact_id: &str,
+        archive_sha256: &str,
+        library_bytes: &[u8],
+    ) {
         let (catalog, runtime) = catalog_runtime();
-        let dir = runtime_artifact_dir(app_data, artifact_id);
+        let dir = runtime_artifact_dir(app_data, install_key);
         fs::create_dir_all(&dir).expect("create artifact dir");
         fs::write(dir.join(ORT_RUNTIME_FILENAME), library_bytes).expect("write library");
 
         let mut record = record_from_catalog_runtime(runtime, catalog);
         record.artifact_id = artifact_id.to_owned();
+        record.archive_sha256 = archive_sha256.to_owned();
         record.files = vec![crate::separator::catalog::InstalledFileRecord {
             path: ORT_RUNTIME_FILENAME.to_owned(),
             size: library_bytes.len() as u64,
             sha256: sha256_hex(library_bytes),
         }];
         write_artifact_record(&dir.join(RUNTIME_RECORD_FILENAME), &record).expect("write record");
+    }
+
+    /// Write a fake installed runtime whose record digests match the files.
+    fn write_fake_install(app_data: &Path, artifact_id: &str, library_bytes: &[u8]) {
+        let archive_sha256 = catalog_runtime().1.archive_digest.clone();
+        write_fake_install_at(
+            app_data,
+            artifact_id,
+            artifact_id,
+            &archive_sha256,
+            library_bytes,
+        );
+    }
+
+    #[test]
+    fn an_install_key_strips_only_a_digest_qualifier() {
+        let digest = sha256_hex(b"generation-13-archive");
+        let key = runtime_install_key("rt-cpu-reduced", &digest);
+        assert_eq!(key, format!("rt-cpu-reduced+{}", &digest[..12]));
+        assert_eq!(artifact_id_of_install_key(&key), "rt-cpu-reduced");
+        assert_eq!(
+            artifact_id_of_install_key("rt-cpu-reduced"),
+            "rt-cpu-reduced"
+        );
+        assert_eq!(
+            artifact_id_of_install_key("rt+not-a-digest"),
+            "rt+not-a-digest"
+        );
+    }
+
+    #[test]
+    fn find_installed_runtime_requires_digest_equality() {
+        // #394: generation 13 republished the same artifact id with different
+        // bytes; treating any same-id install as "already installed" made the
+        // update a permanent no-op.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let installed_digest = sha256_hex(b"generation-12-archive");
+        write_fake_install_at(
+            tmp.path(),
+            "rt-swap",
+            "rt-swap",
+            &installed_digest,
+            b"gen-12-library",
+        );
+
+        assert!(
+            find_installed_runtime(tmp.path(), "rt-swap", &installed_digest).is_some(),
+            "the matching digest must resolve the existing install"
+        );
+        assert!(
+            find_installed_runtime(tmp.path(), "rt-swap", &sha256_hex(b"generation-13-archive"))
+                .is_none(),
+            "a same-id install with a different digest is NOT the requested artifact"
+        );
+    }
+
+    #[test]
+    fn a_digest_qualified_install_resolves_by_its_install_key() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let digest = sha256_hex(b"generation-13-archive");
+        let key = runtime_install_key("rt-swap", &digest);
+        write_fake_install_at(tmp.path(), &key, "rt-swap", &digest, b"gen-13-library");
+
+        let installed = installed_runtime(tmp.path(), &key)
+            .expect("a digest-qualified directory must resolve by its key");
+        assert_eq!(installed.install_key(), key);
+        assert_eq!(installed.record.artifact_id, "rt-swap");
+        assert!(
+            find_installed_runtime(tmp.path(), "rt-swap", &digest).is_some(),
+            "the digest lookup must find the side-by-side install"
+        );
+
+        // A directory whose name disagrees with its record identity is
+        // rejected, exactly like the plain-id consistency check.
+        let mismatched = runtime_install_key("rt-swap", &sha256_hex(b"other-archive"));
+        write_fake_install_at(
+            tmp.path(),
+            &mismatched,
+            "rt-swap",
+            &digest,
+            b"gen-13-library",
+        );
+        assert!(installed_runtime(tmp.path(), &mismatched).is_none());
+    }
+
+    #[test]
+    fn begin_startup_promotes_a_digest_qualified_candidate() {
+        // The gen-13 update path: the plain directory holds the active
+        // same-id install, the staged candidate lives in a digest-qualified
+        // directory. Promotion must carry the install key through the slot
+        // swap so the pending activation can be acknowledged.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let old_digest = sha256_hex(b"generation-12-archive");
+        let new_digest = sha256_hex(b"generation-13-archive");
+        let new_key = runtime_install_key("rt-swap", &new_digest);
+        write_fake_install_at(tmp.path(), "rt-swap", "rt-swap", &old_digest, b"gen-12");
+        write_fake_install_at(tmp.path(), &new_key, "rt-swap", &new_digest, b"gen-13");
+        write_slots(
+            tmp.path(),
+            &RuntimeSlots {
+                active: Some("rt-swap".to_owned()),
+                candidate: Some(new_key.clone()),
+                ..RuntimeSlots::default()
+            },
+        )
+        .expect("write slots");
+
+        let plan = begin_startup(tmp.path())
+            .expect("startup")
+            .expect("plan should load the promoted candidate");
+        assert!(plan.proving_candidate);
+        assert_eq!(plan.install_key.as_deref(), Some(new_key.as_str()));
+        assert_eq!(
+            plan.record.as_ref().map(|r| r.artifact_id.as_str()),
+            Some("rt-swap"),
+            "the record keeps the catalog identity"
+        );
+
+        let slots = read_slots(tmp.path());
+        assert_eq!(slots.active.as_deref(), Some(new_key.as_str()));
+        assert_eq!(slots.previous.as_deref(), Some("rt-swap"));
+        assert!(slots.activation_pending);
+
+        finish_activation_success(tmp.path()).expect("finish");
+        assert!(!read_slots(tmp.path()).activation_pending);
+        assert!(
+            runtime_artifact_dir(tmp.path(), "rt-swap").exists(),
+            "the previous same-id generation must survive as the rollback target"
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/separation.rs
+++ b/src-tauri/src/services/separation.rs
@@ -10,8 +10,8 @@ use crate::{
     library_root::LibraryRoot,
     remote,
     separator::{
-        self, error::SeparationError, job::SeparationArtifacts, model::LoadedModel,
-        model_cache::ModelCache,
+        self, catalog::VerifiedCatalog, error::SeparationError, job::SeparationArtifacts,
+        model::LoadedModel, model_cache::ModelCache,
     },
     AppState,
 };
@@ -199,6 +199,7 @@ pub struct SeparationExecutionContext {
     pub app_data_dir: PathBuf,
     pub model_bootstrap_status: Arc<Mutex<ModelBootstrapStatusSnapshot>>,
     pub runtime_bootstrap_status: Arc<Mutex<RuntimeBootstrapStatusSnapshot>>,
+    pub catalog_cache: Arc<Mutex<Option<VerifiedCatalog>>>,
     pub statuses: Arc<Mutex<HashMap<String, SeparationStatusSnapshot>>>,
     pub model_cache: Arc<Mutex<ModelCache<LoadedModel>>>,
     pub cancels: Arc<Mutex<HashMap<String, Arc<AtomicBool>>>>,
@@ -235,6 +236,7 @@ pub fn build_execution_context(state: &AppState) -> CommandResult<SeparationExec
         app_data_dir: state.shell.app_data_dir.clone(),
         model_bootstrap_status: Arc::clone(&state.shell.model_bootstrap_status),
         runtime_bootstrap_status: Arc::clone(&state.shell.runtime_bootstrap_status),
+        catalog_cache: Arc::clone(&state.shell.catalog_cache),
         statuses: Arc::clone(&state.separation.separation_statuses),
         model_cache: Arc::clone(&state.separation.separator_model_cache),
         cancels: Arc::clone(&state.separation.separation_cancels),
@@ -295,6 +297,7 @@ pub fn emit_separation_cancelled<R: Runtime>(
 pub fn ensure_runtime_and_model_blocking<ER, EM>(
     app_data_dir: &Path,
     runtime_status: &Arc<Mutex<RuntimeBootstrapStatusSnapshot>>,
+    catalog_cache: &Arc<Mutex<Option<VerifiedCatalog>>>,
     model_status: &Arc<Mutex<ModelBootstrapStatusSnapshot>>,
     emit_runtime: &mut ER,
     emit_model: &mut EM,
@@ -306,6 +309,7 @@ where
     runtime_bootstrap::ensure_runtime_ready_or_install_blocking(
         app_data_dir,
         runtime_status,
+        catalog_cache,
         emit_runtime,
     )?;
     bootstrap::ensure_active_model_ready_or_install_blocking(app_data_dir, model_status, emit_model)
@@ -318,6 +322,7 @@ where
 pub fn ensure_runtime_and_managed_model_blocking<ER, EM>(
     app_data_dir: &Path,
     runtime_status: &Arc<Mutex<RuntimeBootstrapStatusSnapshot>>,
+    catalog_cache: &Arc<Mutex<Option<VerifiedCatalog>>>,
     model_status: &Arc<Mutex<ModelBootstrapStatusSnapshot>>,
     emit_runtime: &mut ER,
     emit_model: &mut EM,
@@ -329,6 +334,7 @@ where
     runtime_bootstrap::ensure_runtime_ready_or_install_blocking(
         app_data_dir,
         runtime_status,
+        catalog_cache,
         emit_runtime,
     )?;
     bootstrap::ensure_active_managed_model_ready_or_install_blocking(
@@ -541,6 +547,7 @@ pub fn start_job<R: Runtime>(
         app_data_dir,
         model_bootstrap_status,
         runtime_bootstrap_status,
+        catalog_cache,
         statuses,
         model_cache,
         cancels,
@@ -561,6 +568,7 @@ pub fn start_job<R: Runtime>(
         let prerequisite_app_data_dir = app_data_dir.clone();
         let prerequisite_model_status = Arc::clone(&model_bootstrap_status);
         let prerequisite_runtime_status = Arc::clone(&runtime_bootstrap_status);
+        let prerequisite_catalog_cache = Arc::clone(&catalog_cache);
 
         let result = tauri::async_runtime::spawn_blocking(move || -> CommandResult<_> {
             let mut emit_runtime = |event, snapshot| {
@@ -572,6 +580,7 @@ pub fn start_job<R: Runtime>(
             let worker_model_path = ensure_runtime_and_model_blocking(
                 &prerequisite_app_data_dir,
                 &prerequisite_runtime_status,
+                &prerequisite_catalog_cache,
                 &prerequisite_model_status,
                 &mut emit_runtime,
                 &mut emit_model,
@@ -698,6 +707,7 @@ pub fn start_batch_job<R: Runtime>(
         app_data_dir,
         model_bootstrap_status,
         runtime_bootstrap_status,
+        catalog_cache,
         statuses: separation_statuses,
         model_cache,
         cancels,
@@ -731,6 +741,7 @@ pub fn start_batch_job<R: Runtime>(
             let app_data_dir = app_data_dir.clone();
             let app_handle = app_handle.clone();
             let runtime_status = Arc::clone(&runtime_bootstrap_status);
+            let catalog_cache = Arc::clone(&catalog_cache);
             let model_status = Arc::clone(&model_bootstrap_status);
             tauri::async_runtime::spawn_blocking(move || {
                 let mut emit_runtime = |event, snapshot| {
@@ -742,6 +753,7 @@ pub fn start_batch_job<R: Runtime>(
                 ensure_runtime_and_model_blocking(
                     &app_data_dir,
                     &runtime_status,
+                    &catalog_cache,
                     &model_status,
                     &mut emit_runtime,
                     &mut emit_model,


### PR DESCRIPTION
## What changed

Three defects in the ONNX Runtime bootstrap/update path, one commit each:

1. **Separation-triggered installs ignored the refreshed catalog** (#393, `6897238d`). `ensure_runtime_ready_or_install_blocking` resolved its install from `catalog::embedded_catalog()` directly, so a separation started after the background update check had fetched a newer catalog still installed the embedded generation. It now resolves through `refreshed_or_embedded_catalog` (the same source the settings download command uses), taking the shell's `catalog_cache` when a newer verified catalog is present and falling back to embedded.

2. **Same-id digest-swap updates were no-ops** (#394, `e76e790e`). The worker's reuse check matched on artifact id alone, so a catalog generation that republishes an id with different bytes (generation 13 reuses `...-cpu-reduced` as a static-CRT rebuild) short-circuited into the stale install — the update stayed "available" forever and the gen-12 runtime kept failing on hosts without the VC++ redist (#284). Reuse (worker + pre-worker activation shortcut) now requires archive-digest equality. Because the plain artifact-id directory may hold the runtime the current process has loaded (Windows locks mapped files; never-replaced-in-place invariant), a republished digest installs side by side into `<artifact_id>+<digest-prefix>`; slot values become install keys, which the slot machinery already treats as opaque names. Status snapshots keep reporting the catalog artifact id, so **no IPC contract changes**.

3. **Bad candidates were staged before probing** (#395, `33330865`). The worker staged its install as the next-launch candidate before probing that the library loads; a failed/killed probe left the unproven candidate staged, and startup promotes a candidate on the worker probe's authority without loading it (ADR-0023) — one failed probe became a bad active runtime. Staging now happens only after a successful probe. A worker killed before staging loses nothing durable: the verified archive cache and the install directory make the retry a re-verification, not a re-download.

Each fix carries a regression test verified to fail against the old implementation (reuse check reverted → side-by-side + stale-activation tests fail; staging order reverted → probe-staging tests fail; catalog source reverted → refreshed-catalog resolution test fails).

## Verification

- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy --all-targets -- -D warnings` — PASS
- [x] `cargo test` (src-tauri, with models + runtime dylib present) — PASS (1187 lib + all integration tests)
- [x] `cargo check --all-targets --features automation-smoke` — PASS (regression harness updated for the new staging order)
- [x] `pnpm lint` / `pnpm build` / `pnpm test` — PASS (2254 tests)
- [ ] `pnpm tauri build` — not run locally; release packaging is exercised by CI and the release workflow

## Contracts

No public IPC command/payload/event changed (`RuntimeBootstrapStatusSnapshot.active_artifact_id` still reports the catalog artifact id); `docs/references/contracts/` untouched.

## Residual risk

Slot files now may contain digest-qualified install keys (`<id>+<12-hex>`). Older app versions reading such a slot file would fail the record consistency check and treat the entry as absent — the same behavior as any unknown slot value; the runtime worker then reinstalls cleanly. Forward direction (old slots → new code) is unchanged since plain ids remain valid install keys.

Fixes #393, fixes #394, fixes #395.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime installation reliability by using refreshed, verified catalogs when available.
  * Prevented activation of stale or mismatched runtime packages.
  * Added support for safely handling republished runtime artifacts with changed archive contents.
  * Improved recovery after runtime probing failures and timeouts.
  * Enhanced runtime reuse, promotion, rollback, and activation validation.
  * Ensured runtime candidates are staged only after successful validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->