### PR TITLE
fix(ci): update the nightly release in place instead of recreating it

### DIFF
--- a/.github/workflows/nightly-installers.yml
+++ b/.github/workflows/nightly-installers.yml
@@ -264,7 +264,7 @@ jobs:
           cat "${NOTES_FILE}"
           echo "title=nightly-$(date -u +%Y%m%d)-${HEAD_SHA:0:7}" >> "$GITHUB_OUTPUT"
 
-      - name: Recreate rolling nightly prerelease
+      - name: Publish rolling nightly prerelease
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
@@ -274,23 +274,38 @@ jobs:
           STAGING_DIR: ${{ runner.temp }}/nightly-assets
         run: |
           set -euo pipefail
-          # Delete-and-recreate keeps the release rolling: stale assets from a
-          # previous package version can never linger, and the nightly tag
-          # always points at the commit the assets were built from.
-          gh release delete nightly --repo "${GH_REPO}" --cleanup-tag --yes \
-            || echo "No existing nightly release to delete."
-          gh api --method DELETE "repos/${GH_REPO}/git/refs/tags/nightly" 2>/dev/null \
-            || echo "No orphan nightly tag to delete."
-
-          # --prerelease is load-bearing: GitHub resolves releases/latest (the
-          # production updater endpoint) only to non-prerelease releases.
-          gh release create nightly \
-            --repo "${GH_REPO}" \
-            --target "${TARGET_SHA}" \
-            --prerelease \
-            --title "${RELEASE_TITLE}" \
-            --notes-file "${NOTES_FILE}" \
-            "${STAGING_DIR}"/*
+          # Do not delete-and-recreate the `nightly` tag. After a GITHUB_TOKEN
+          # deletes that tag, a later create on the same name returns
+          # HTTP 403 Resource not accessible by integration. Edit in place
+          # and move the existing tag. Create only when the release is absent.
+          #
+          # --prerelease and --latest=false keep releases/latest on stable.
+          if gh release view nightly --repo "${GH_REPO}" >/dev/null 2>&1; then
+            gh release edit nightly \
+              --repo "${GH_REPO}" \
+              --title "${RELEASE_TITLE}" \
+              --notes-file "${NOTES_FILE}" \
+              --prerelease \
+              --latest=false \
+              --target "${TARGET_SHA}"
+            gh release upload nightly \
+              --repo "${GH_REPO}" \
+              --clobber \
+              "${STAGING_DIR}"/*
+            gh api --method PATCH "repos/${GH_REPO}/git/refs/tags/nightly" \
+              --field sha="${TARGET_SHA}" \
+              --field force=true \
+              >/dev/null
+          else
+            gh release create nightly \
+              --repo "${GH_REPO}" \
+              --target "${TARGET_SHA}" \
+              --prerelease \
+              --latest=false \
+              --title "${RELEASE_TITLE}" \
+              --notes-file "${NOTES_FILE}" \
+              "${STAGING_DIR}"/*
+          fi
 
       - name: Verify nightly release invariants
         env:

--- a/tests/nightly-installers-workflow.test.ts
+++ b/tests/nightly-installers-workflow.test.ts
@@ -49,9 +49,15 @@ describe("nightly installers workflow", () => {
     // GitHub resolves releases/latest (the production updater endpoint) only
     // to non-prerelease releases, so the prerelease flag is load-bearing.
     expect(workflow).toContain("--prerelease");
+    expect(workflow).toContain("--latest=false");
     expect(workflow).toContain("gh release create nightly");
-    expect(workflow).toContain("gh release delete nightly");
-    expect(workflow).toContain("--cleanup-tag");
+    expect(workflow).toContain("gh release edit nightly");
+    expect(workflow).toContain("gh release upload nightly");
+    expect(workflow).toContain("--clobber");
+    expect(workflow).toContain("git/refs/tags/nightly");
+    // Recreating a deleted `nightly` tag with GITHUB_TOKEN returns HTTP 403.
+    expect(workflow).not.toContain("gh release delete nightly");
+    expect(workflow).not.toContain("--cleanup-tag");
     // Updater assets must never ship on the nightly release.
     expect(workflow).toContain("latest.json");
     expect(workflow).toMatch(/-name '\*\.sig'/);


### PR DESCRIPTION
## What changed

The 13 August nightly built every installer, then failed at publish:

`HTTP 403: Resource not accessible by integration` on `gh release create nightly`

That happens after `gh release delete nightly --cleanup-tag`. GITHUB_TOKEN can create the `nightly` tag once, but not recreate it after delete.

The publish job now edits the existing prerelease, uploads with `--clobber`, and PATCHes `refs/tags/nightly` to the new SHA. It creates the release only when none exists.

## Verification

- [x] `pnpm exec vitest run tests/nightly-installers-workflow.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

The nightly release workflow now updates the existing prerelease instead of deleting and recreating it.

- Uploads installer assets with `--clobber`.
- Moves the `nightly` tag with the Git ref API.
- Creates the release only when no release exists.
- Updates workflow tests for the new release and tag behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->