### PR TITLE
fix(preview): start Earfquake at 00:23 and switch demo songs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,9 +21,9 @@ pnpm tauri build    # release bundle
 
 ## Checks
 
-Git hooks run most of these for you. `pre-commit` formats the staged files.
-`pre-push` runs the format check, the lint, and patch coverage. Run the rest
-before you open a pull request.
+Git hooks run most of these for you. `pre-commit` formats the staged files
+and runs knip. `pre-push` runs the format check, the lint, knip, and patch
+coverage. Run the rest before you open a pull request.
 
 ```bash
 node --run lint                                  # frontend lint

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -21,10 +21,17 @@ pre-commit:
       glob: "*.rs"
       run: cd src-tauri && cargo fmt
       stage_fixed: true
+    knip:
+      glob: "*.{ts,tsx,js,jsx,mjs,cjs,json}"
+      exclude:
+        - "pnpm-lock.yaml"
+        - "src-tauri/**"
+      run: pnpm knip --no-progress
 
 # Mirrors CI checks (ci.yml) so local pushes fail the same way CI would.
-# pre-commit only formats staged files; these checks verify the entire repo
-# to catch files that slipped through a prior --no-verify or partial staging.
+# pre-commit formats staged files and runs knip. These checks verify the
+# entire repo to catch files that slipped through a prior --no-verify or
+# partial staging.
 #
 # Every command runs through skip-delete-only-push.sh: a push that only
 # deletes remote refs transfers no commits, so there is nothing for these
@@ -43,6 +50,9 @@ pre-push:
     lint:
       use_stdin: true
       run: sh scripts/git-hooks/skip-delete-only-push.sh 'node --run lint'
+    knip:
+      use_stdin: true
+      run: sh scripts/git-hooks/skip-delete-only-push.sh 'pnpm knip --no-progress'
     standards-route:
       use_stdin: true
       run: sh scripts/git-hooks/skip-delete-only-push.sh 'node --run check:standards'

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -252,12 +252,12 @@ export function Sidebar({ header, previewMode = false }: SidebarProps = {}) {
             </span>
             <SortModeSelector />
           </div>
-          <SongList />
+          <SongList previewMode={previewMode} />
         </div>
       )}
       {activePlaylistId && (
         <div className="mt-4 flex flex-1 flex-col overflow-hidden px-2">
-          <SongList />
+          <SongList previewMode={previewMode} />
         </div>
       )}
 

--- a/src/components/Library/SongList.tsx
+++ b/src/components/Library/SongList.tsx
@@ -36,7 +36,11 @@ function useAtLeast600Px(): boolean {
   return matches;
 }
 
-export function SongList() {
+interface SongListProps {
+  previewMode?: boolean;
+}
+
+export function SongList({ previewMode = false }: SongListProps = {}) {
   const songs = useLibraryStore((s) => s.songs);
   const filter = useLibraryStore((s) => s.filter);
   const separationStatuses = useLibraryStore((s) => s.separationStatuses);
@@ -177,7 +181,11 @@ export function SongList() {
                 className="absolute left-0 top-0 w-full"
                 style={{ transform: `translateY(${virtualRow.start}px)` }}
               >
-                <SongListItem song={song} orderedHashes={orderedHashes} />
+                <SongListItem
+                  song={song}
+                  orderedHashes={orderedHashes}
+                  previewMode={previewMode}
+                />
               </div>
             );
           })}

--- a/src/components/Library/SongListItem.test.tsx
+++ b/src/components/Library/SongListItem.test.tsx
@@ -47,8 +47,9 @@ const {
     setSongsInstrumental: vi.fn(),
   },
   mockPlayerState: {
-    snapshot: null,
+    snapshot: null as { song_id: string; is_playing: boolean } | null,
     playSong: vi.fn(),
+    playNow: vi.fn(),
     loadState: vi.fn(),
   },
   mockLyricsState: {
@@ -175,6 +176,7 @@ describe("SongListItem", () => {
     mockLibraryState.batchSeparation = null;
     mockLibraryState.separationStatuses = {};
     mockLibraryState.uploadStatuses = {};
+    mockPlayerState.snapshot = null;
   });
 
   test("shows a cancel affordance while separating and calls the API on click", () => {
@@ -260,6 +262,39 @@ describe("SongListItem", () => {
     );
     expect(mockPlayerState.playSong).toHaveBeenCalledWith(song.hash);
     expect(selection.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  test("preview mode plays the clicked song immediately", () => {
+    const song = {
+      hash: "preview-song",
+      file_path: "Artist/Preview Song.mp3",
+      audio_source_kind: "original" as const,
+      cdg_path: null,
+      media_g_container: null,
+      instrumental: false,
+      language: null,
+      title: "Preview Song",
+      artist: "Artist",
+      album: null,
+      duration_ms: 180_000,
+      cover_art: null,
+      has_cover_art: false,
+      artwork_thumb_path: null,
+      imported_at: 0,
+      original_ext: "mp3",
+    };
+    mockPlayerState.snapshot = {
+      song_id: "other-song",
+      is_playing: true,
+    };
+    const { getByRole } = render(
+      <SongListItem song={song} orderedHashes={[song.hash]} previewMode />,
+    );
+
+    fireEvent.click(getByRole("button", { name: song.title }));
+
+    expect(mockPlayerState.playNow).toHaveBeenCalledWith(song.hash);
+    expect(mockPlayerState.playSong).not.toHaveBeenCalled();
   });
 
   test("opens the song actions from the keyboard context-menu shortcut", () => {

--- a/src/components/Library/SongListItem.test.tsx
+++ b/src/components/Library/SongListItem.test.tsx
@@ -291,10 +291,15 @@ describe("SongListItem", () => {
       <SongListItem song={song} orderedHashes={[song.hash]} previewMode />,
     );
 
-    fireEvent.click(getByRole("button", { name: song.title }));
+    const selection = getByRole("button", { name: song.title });
+    fireEvent.click(selection);
 
+    expect(mockPlayerState.playNow).toHaveBeenCalledTimes(1);
     expect(mockPlayerState.playNow).toHaveBeenCalledWith(song.hash);
     expect(mockPlayerState.playSong).not.toHaveBeenCalled();
+
+    fireEvent.doubleClick(selection);
+    expect(mockPlayerState.playNow).toHaveBeenCalledTimes(1);
   });
 
   test("opens the song actions from the keyboard context-menu shortcut", () => {

--- a/src/components/Library/SongListItem.tsx
+++ b/src/components/Library/SongListItem.tsx
@@ -249,11 +249,11 @@ export function SongListItem({
         type="button"
         onClick={(event) => {
           selectSongFromEvent(event);
-          if (previewMode) {
+          if (previewMode && event.detail < 2) {
             handlePlay();
           }
         }}
-        onDoubleClick={handlePlay}
+        onDoubleClick={previewMode ? undefined : handlePlay}
         onContextMenu={handleContextMenu}
         onKeyDown={handleSelectionKeyDown}
         aria-label={songDisplayTitle(song)}

--- a/src/components/Library/SongListItem.tsx
+++ b/src/components/Library/SongListItem.tsx
@@ -29,9 +29,14 @@ import type { Song } from "@/types/ipc";
 interface SongListItemProps {
   song: Song;
   orderedHashes: string[];
+  previewMode?: boolean;
 }
 
-export function SongListItem({ song, orderedHashes }: SongListItemProps) {
+export function SongListItem({
+  song,
+  orderedHashes,
+  previewMode = false,
+}: SongListItemProps) {
   const backend = useBackend();
   const { t } = useTranslation();
   const isSelected = useLibraryStore((s) => s.selectedSongIds.has(song.hash));
@@ -44,6 +49,7 @@ export function SongListItem({ song, orderedHashes }: SongListItemProps) {
     batchSeparationInProgress(s.batchSeparation),
   );
   const playSong = usePlayerStore((s) => s.playSong);
+  const playNow = usePlayerStore((s) => s.playNow);
   const closeSettings = useSettingsStore((s) => s.close);
 
   const [editDialogOpen, setEditDialogOpen] = useState(false);
@@ -92,6 +98,11 @@ export function SongListItem({ song, orderedHashes }: SongListItemProps) {
         : null;
 
   const handlePlay = () => {
+    if (previewMode) {
+      void playNow(song.hash);
+      closeSettings();
+      return;
+    }
     const current = usePlayerStore.getState().snapshot;
     if (current?.song_id && current.song_id !== song.hash) {
       useQueueStore.getState().addToQueue(song.hash);
@@ -236,7 +247,12 @@ export function SongListItem({ song, orderedHashes }: SongListItemProps) {
     >
       <button
         type="button"
-        onClick={selectSongFromEvent}
+        onClick={(event) => {
+          selectSongFromEvent(event);
+          if (previewMode) {
+            handlePlay();
+          }
+        }}
         onDoubleClick={handlePlay}
         onContextMenu={handleContextMenu}
         onKeyDown={handleSelectionKeyDown}

--- a/src/components/Lyrics/LyricsPanel.test.tsx
+++ b/src/components/Lyrics/LyricsPanel.test.tsx
@@ -674,6 +674,7 @@ describe("LyricsPanel contextual reveal", () => {
       "[aria-label='lyrics.switchToCentered']",
     ) as HTMLButtonElement;
     expect(button).toBeTruthy();
+    expect(button.getAttribute("data-preview-lyrics-interactive")).toBe("true");
     act(() => {
       button.click();
     });

--- a/src/components/Lyrics/LyricsPanelToolbar.tsx
+++ b/src/components/Lyrics/LyricsPanelToolbar.tsx
@@ -78,6 +78,7 @@ export function LyricsPanelToolbar({
         <Tooltip label={alignmentLabel}>
           <button
             type="button"
+            data-preview-lyrics-interactive="true"
             onClick={onToggleAlignment}
             aria-label={alignmentLabel}
             className={`${BUTTON_CLASS} ${

--- a/src/hooks/use-lyrics-engine.test.tsx
+++ b/src/hooks/use-lyrics-engine.test.tsx
@@ -372,6 +372,36 @@ describe("useLyricsEngine", () => {
     vi.mocked(lyricsEngine.createUserScrollGuard).mockRestore();
   });
 
+  test("song change jumps to the active lyric line", () => {
+    mockPlayerState.positionMs = 6_000;
+
+    act(() => {
+      root.render(<ScrollHarness lyricsFontStep={0} />);
+    });
+
+    const viewport = host.querySelector(
+      "[data-testid='scroll-viewport']",
+    ) as HTMLDivElement;
+    defineNumber(viewport, "clientHeight", 100);
+    defineNumber(viewport, "scrollHeight", 500);
+    const line0 = viewport.querySelector("[data-lyrics-line-index='0']")!;
+    const line1 = viewport.querySelector("[data-lyrics-line-index='1']")!;
+    defineNumber(line0, "offsetTop", 0);
+    defineNumber(line0, "clientHeight", 40);
+    defineNumber(line1, "offsetTop", 200);
+    defineNumber(line1, "clientHeight", 40);
+
+    act(() => {
+      rafCb?.(1000);
+    });
+    expect(viewport.scrollTop).toBe(170);
+
+    act(() => {
+      root.render(<ScrollHarness lyricsFontStep={0} songId="song-2" />);
+    });
+    expect(viewport.scrollTop).toBe(170);
+  });
+
   test("focus resync updates the active line without consuming a seek latch", () => {
     act(() => {
       root.render(<Harness />);

--- a/src/hooks/use-lyrics-engine.ts
+++ b/src/hooks/use-lyrics-engine.ts
@@ -1,5 +1,6 @@
 import { useEffect, useLayoutEffect, useRef, type RefObject } from "react";
 import { getScrollTopForLineIndex } from "@/components/Lyrics/lyrics-scroll";
+import { findActiveLyricLineIndex } from "@/lib/lyrics-timing";
 import {
   createUserScrollGuard,
   shouldRunLyricsEngineLoop,
@@ -119,7 +120,8 @@ export function useLyricsEngine(input: {
       typeof window.matchMedia === "function" &&
       window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
-    const isSongChange = engineSongIdRef.current !== songId;
+    const previousSongId = engineSongIdRef.current;
+    const isSongChange = previousSongId !== songId;
     engineSongIdRef.current = songId;
 
     const scrollState = scrollStateRef.current;
@@ -129,21 +131,35 @@ export function useLyricsEngine(input: {
     lastSeekRevisionRef.current = usePlayerStore.getState().seekRevision;
 
     if (isSongChange) {
-      scrollSpring.jumpTo(0);
-      scrollState.targetScrollTopRef.current = null;
+      const container = containerRef.current;
+      const { lines } = session.getState();
+      const adjustedMs = session.toAdjustedMs(session.readPositionMs());
+      const activeIndex = findActiveLyricLineIndex(lines, adjustedMs);
+      const measuredTarget =
+        previousSongId != null && container && activeIndex >= 0
+          ? getScrollTopForLineIndex(container, activeIndex)
+          : null;
+      const nextTop = measuredTarget ?? 0;
+      scrollSpring.jumpTo(nextTop);
+      scrollState.targetScrollTopRef.current =
+        measuredTarget === null ? null : nextTop;
+      scrollState.prevActiveIndexRef.current =
+        measuredTarget === null ? -1 : activeIndex;
       scrollState.lastResumeGenerationRef.current =
         session.scroll.peekResumeGeneration();
 
-      const container = containerRef.current;
       if (container) {
         const write = () => {
-          container.scrollTop = 0;
+          container.scrollTop = nextTop;
         };
         if (guardRef.current) {
           guardRef.current.withProgrammatic(write);
         } else {
           write();
         }
+      }
+      if (previousSongId != null) {
+        session.scroll.requestResume();
       }
     } else {
       session.scroll.requestResume();

--- a/src/mock/preview-songs.test.ts
+++ b/src/mock/preview-songs.test.ts
@@ -69,6 +69,19 @@ describe("preview playback start", () => {
     expect(nextLyrics.lines[0]?.text).toContain("初");
   });
 
+  test("play falls back to loopStartPositionMs when no play start is set", async () => {
+    const { internals } = createTauriMock({
+      ...E2E_MOCK_DATA,
+      playStartPositionMs: undefined,
+      playStartPositionBySongId: undefined,
+      loopStartPositionMs: 12_000,
+    });
+    const snapshot = (await internals.invoke("play", {
+      songId: "earfquake",
+    })) as { position_ms: number };
+    expect(snapshot.position_ms).toBe(12_000);
+  });
+
   test("e2e mock play still starts at zero", async () => {
     const { internals } = createTauriMock(E2E_MOCK_DATA);
     const snapshot = (await internals.invoke("play", {

--- a/src/mock/preview-songs.test.ts
+++ b/src/mock/preview-songs.test.ts
@@ -4,6 +4,13 @@ import {
   PREVIEW_SONGS,
   PRIMARY_PREVIEW_SONG_HASH,
 } from "./preview-songs";
+import {
+  E2E_MOCK_DATA,
+  MOCK_DATA,
+  PREVIEW_EARFQUAKE_START_MS,
+  PREVIEW_OTHER_SONG_START_MS,
+} from "./tauri-mock-data";
+import { createTauriMock } from "./tauri-mock-impl";
 
 describe("shared preview catalog", () => {
   test("places One Last Kiss after Earfquake in recently imported order", () => {
@@ -27,5 +34,46 @@ describe("shared preview catalog", () => {
     expect(forgotten?.words?.length).toBeGreaterThan(1);
     expect(forgotten?.bg_words?.length).toBeGreaterThan(0);
     expect(forgotten?.roman).toBeTruthy();
+  });
+});
+
+describe("preview playback start", () => {
+  test("Earfquake starts at 00:23", async () => {
+    const { internals } = createTauriMock(MOCK_DATA);
+    const snapshot = (await internals.invoke("play", {
+      songId: "earfquake",
+    })) as { position_ms: number; song_id: string };
+    expect(snapshot.song_id).toBe("earfquake");
+    expect(snapshot.position_ms).toBe(PREVIEW_EARFQUAKE_START_MS);
+  });
+
+  test("switching songs loads that song's lyrics and demo start", async () => {
+    const { internals } = createTauriMock(MOCK_DATA);
+    await internals.invoke("play", { songId: "earfquake" });
+    const firstLyrics = (await internals.invoke("fetch_lyrics", {
+      songId: "earfquake",
+    })) as { song_id: string; lines: Array<{ text: string }> };
+    expect(firstLyrics.song_id).toBe("earfquake");
+    expect(firstLyrics.lines[0]?.text).toContain("For real");
+
+    const switched = (await internals.invoke("play", {
+      songId: "one-last-kiss",
+    })) as { position_ms: number; song_id: string };
+    expect(switched.song_id).toBe("one-last-kiss");
+    expect(switched.position_ms).toBe(PREVIEW_OTHER_SONG_START_MS);
+
+    const nextLyrics = (await internals.invoke("fetch_lyrics", {
+      songId: "one-last-kiss",
+    })) as { song_id: string; lines: Array<{ text: string }> };
+    expect(nextLyrics.song_id).toBe("one-last-kiss");
+    expect(nextLyrics.lines[0]?.text).toContain("初");
+  });
+
+  test("e2e mock play still starts at zero", async () => {
+    const { internals } = createTauriMock(E2E_MOCK_DATA);
+    const snapshot = (await internals.invoke("play", {
+      songId: "earfquake",
+    })) as { position_ms: number };
+    expect(snapshot.position_ms).toBe(0);
   });
 });

--- a/src/mock/preview-songs.test.ts
+++ b/src/mock/preview-songs.test.ts
@@ -89,4 +89,27 @@ describe("preview playback start", () => {
     })) as { position_ms: number };
     expect(snapshot.position_ms).toBe(0);
   });
+
+  test("setMockLyrics overrides catalog lyrics for the next fetch", async () => {
+    const { internals, helpers } = createTauriMock(E2E_MOCK_DATA);
+    helpers.setMockLyrics({
+      raw_lrc: "override",
+      lines: [
+        {
+          time_ms: 0,
+          text: "Lyric line 0",
+          words: null,
+          bg_words: null,
+          section: null,
+          roman: null,
+        },
+      ],
+      offset_ms: 0,
+      source: "test",
+    });
+    const lyrics = (await internals.invoke("fetch_lyrics", {
+      songId: "earfquake",
+    })) as { lines: Array<{ text: string }> };
+    expect(lyrics.lines[0]?.text).toBe("Lyric line 0");
+  });
 });

--- a/src/mock/tauri-mock-data.ts
+++ b/src/mock/tauri-mock-data.ts
@@ -30,7 +30,6 @@ export const MOCK_PLAYLISTS = [
 ];
 
 export const PREVIEW_EARFQUAKE_START_MS = 23_000;
-export const PREVIEW_FROZEN_POSITION_MS = PREVIEW_EARFQUAKE_START_MS;
 export const PREVIEW_OTHER_SONG_START_MS = 59_560;
 
 const PRIMARY_PREVIEW_DURATION_MS =
@@ -107,7 +106,7 @@ export const MOCK_DATA: MockData = {
     song_id: PRIMARY_PREVIEW_SONG_HASH,
     state: "playing",
     is_playing: true,
-    position_ms: PREVIEW_FROZEN_POSITION_MS,
+    position_ms: PREVIEW_EARFQUAKE_START_MS,
     duration_ms: PRIMARY_PREVIEW_DURATION_MS,
     buffered_ms: PRIMARY_PREVIEW_DURATION_MS,
     volume: 0.8,

--- a/src/mock/tauri-mock-data.ts
+++ b/src/mock/tauri-mock-data.ts
@@ -29,7 +29,9 @@ export const MOCK_PLAYLISTS = [
   },
 ];
 
-export const PREVIEW_FROZEN_POSITION_MS = 59560;
+export const PREVIEW_EARFQUAKE_START_MS = 23_000;
+export const PREVIEW_FROZEN_POSITION_MS = PREVIEW_EARFQUAKE_START_MS;
+export const PREVIEW_OTHER_SONG_START_MS = 59_560;
 
 const PRIMARY_PREVIEW_DURATION_MS =
   PREVIEW_SONGS.find((song) => song.hash === PRIMARY_PREVIEW_SONG_HASH)
@@ -133,7 +135,11 @@ export const MOCK_DATA: MockData = {
   },
 
   loopPlayback: true,
-  loopStartPositionMs: 0,
+  loopStartPositionMs: PREVIEW_EARFQUAKE_START_MS,
+  playStartPositionMs: PREVIEW_OTHER_SONG_START_MS,
+  playStartPositionBySongId: {
+    earfquake: PREVIEW_EARFQUAKE_START_MS,
+  },
 };
 
 export const E2E_MOCK_DATA: MockData = {
@@ -141,6 +147,9 @@ export const E2E_MOCK_DATA: MockData = {
   playlists: [],
   playlistSongs: {},
   loopPlayback: false,
+  playStartPositionMs: 0,
+  playStartPositionBySongId: {},
+  loopStartPositionMs: 0,
   playbackSnapshot: {
     transport_generation: 0,
     song_id: null,

--- a/src/mock/tauri-mock-impl.ts
+++ b/src/mock/tauri-mock-impl.ts
@@ -173,7 +173,10 @@ export function createTauriMock(data: any): TauriMockResult {
 
   function resolvePlayStartMs(songId: string, durationMs: number): number {
     const requested =
-      data.playStartPositionBySongId?.[songId] ?? data.playStartPositionMs ?? 0;
+      data.playStartPositionBySongId?.[songId] ??
+      data.playStartPositionMs ??
+      data.loopStartPositionMs ??
+      0;
     return Math.min(Math.max(0, requested), Math.max(0, durationMs - 1));
   }
 

--- a/src/mock/tauri-mock-impl.ts
+++ b/src/mock/tauri-mock-impl.ts
@@ -49,6 +49,8 @@ export interface MockData {
   };
   loopPlayback?: boolean;
   loopStartPositionMs?: number;
+  playStartPositionMs?: number;
+  playStartPositionBySongId?: Record<string, number>;
 }
 
 export interface MockSong {
@@ -169,6 +171,12 @@ export function createTauriMock(data: any): TauriMockResult {
     return transportGeneration;
   }
 
+  function resolvePlayStartMs(songId: string, durationMs: number): number {
+    const requested =
+      data.playStartPositionBySongId?.[songId] ?? data.playStartPositionMs ?? 0;
+    return Math.min(Math.max(0, requested), Math.max(0, durationMs - 1));
+  }
+
   function schedulePlaybackEnd(): void {
     if (playbackEndTimer) {
       clearTimeout(playbackEndTimer);
@@ -183,7 +191,10 @@ export function createTauriMock(data: any): TauriMockResult {
       const gen = (currentPlaybackSnapshot as any).transport_generation;
       if (gen !== transportGeneration) return;
       if (data.loopPlayback) {
-        const loopMs = data.loopStartPositionMs ?? 0;
+        const loopMs = resolvePlayStartMs(
+          snap.song_id || data.primarySongHash,
+          snap.duration_ms || 0,
+        );
         currentPlaybackSnapshot = {
           ...currentPlaybackSnapshot,
           state: "playing",
@@ -387,15 +398,17 @@ export function createTauriMock(data: any): TauriMockResult {
       const songId =
         (args && (args.songId || args.song_id)) || data.primarySongHash;
       const song = mockSongs.find((s: any) => s.hash === songId);
+      const durationMs = song ? song.duration_ms : 300000;
+      const positionMs = resolvePlayStartMs(songId, durationMs);
       bumpTransportGeneration();
       currentPlaybackSnapshot = {
         ...currentPlaybackSnapshot,
         song_id: songId,
         state: "playing",
         is_playing: true,
-        position_ms: 0,
-        duration_ms: song ? song.duration_ms : 300000,
-        buffered_ms: 0,
+        position_ms: positionMs,
+        duration_ms: durationMs,
+        buffered_ms: durationMs,
       };
       schedulePlaybackEnd();
       return clone(currentPlaybackSnapshot);
@@ -479,14 +492,14 @@ export function createTauriMock(data: any): TauriMockResult {
 
     fetch_lyrics: (args: any) => {
       const songId = args && args.songId;
-      const payload =
-        lyricsOverride || (songId && mockLyricsBySongId[songId]) || mockLyrics;
+      const bySong = songId ? mockLyricsBySongId[songId] : null;
+      const payload = bySong || lyricsOverride || mockLyrics;
       return { ...payload, song_id: songId };
     },
     fetch_lyrics_online: (args: any) => {
       const songId = args && args.songId;
-      const payload =
-        lyricsOverride || (songId && mockLyricsBySongId[songId]) || mockLyrics;
+      const bySong = songId ? mockLyricsBySongId[songId] : null;
+      const payload = bySong || lyricsOverride || mockLyrics;
       return { ...payload, song_id: songId };
     },
     save_manual_lyrics: (args: any) => ({

--- a/src/mock/tauri-mock-impl.ts
+++ b/src/mock/tauri-mock-impl.ts
@@ -171,6 +171,12 @@ export function createTauriMock(data: any): TauriMockResult {
     return transportGeneration;
   }
 
+  function resolveLyrics(songId: string | undefined): any {
+    if (lyricsOverride) return lyricsOverride;
+    if (songId && mockLyricsBySongId[songId]) return mockLyricsBySongId[songId];
+    return mockLyrics;
+  }
+
   function resolvePlayStartMs(songId: string, durationMs: number): number {
     const requested =
       data.playStartPositionBySongId?.[songId] ??
@@ -495,15 +501,11 @@ export function createTauriMock(data: any): TauriMockResult {
 
     fetch_lyrics: (args: any) => {
       const songId = args && args.songId;
-      const bySong = songId ? mockLyricsBySongId[songId] : null;
-      const payload = bySong || lyricsOverride || mockLyrics;
-      return { ...payload, song_id: songId };
+      return { ...resolveLyrics(songId), song_id: songId };
     },
     fetch_lyrics_online: (args: any) => {
       const songId = args && args.songId;
-      const bySong = songId ? mockLyricsBySongId[songId] : null;
-      const payload = bySong || lyricsOverride || mockLyrics;
-      return { ...payload, song_id: songId };
+      return { ...resolveLyrics(songId), song_id: songId };
     },
     save_manual_lyrics: (args: any) => ({
       raw_lrc: (args && args.text) || "",

--- a/tests/ci/lefthook-contract.test.ts
+++ b/tests/ci/lefthook-contract.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const projectRoot = fileURLToPath(new URL("../..", import.meta.url));
+const lefthook = readFileSync(join(projectRoot, "lefthook.yml"), "utf8");
+
+describe("lefthook gates", () => {
+  test("pre-commit and pre-push both run knip", () => {
+    expect(lefthook).toMatch(
+      /pre-commit:[\s\S]*?knip:[\s\S]*?pnpm knip --no-progress/,
+    );
+    expect(lefthook).toMatch(
+      /pre-push:[\s\S]*?knip:[\s\S]*?pnpm knip --no-progress/,
+    );
+  });
+});

--- a/tests/ci/lefthook-contract.test.ts
+++ b/tests/ci/lefthook-contract.test.ts
@@ -6,13 +6,61 @@ import { describe, expect, test } from "vitest";
 const projectRoot = fileURLToPath(new URL("../..", import.meta.url));
 const lefthook = readFileSync(join(projectRoot, "lefthook.yml"), "utf8");
 
+function topLevelHookBlock(yaml: string, hook: string): string {
+  const lines = yaml.split(/\r?\n/);
+  const start = lines.findIndex((line) => line === `${hook}:`);
+  if (start < 0) {
+    throw new Error(`lefthook.yml is missing the ${hook} hook`);
+  }
+  const body: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^[A-Za-z]/.test(line)) {
+      break;
+    }
+    body.push(line);
+  }
+  return body.join("\n");
+}
+
+function hookCommandBlock(hookBody: string, command: string): string | null {
+  const lines = hookBody.split(/\r?\n/);
+  const start = lines.findIndex((line) => line === `    ${command}:`);
+  if (start < 0) {
+    return null;
+  }
+  const body: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^    [A-Za-z0-9_-]+:\s*$/.test(line)) {
+      break;
+    }
+    body.push(line);
+  }
+  return body.join("\n");
+}
+
+function hookRunsKnip(yaml: string, hook: string): boolean {
+  const command = hookCommandBlock(topLevelHookBlock(yaml, hook), "knip");
+  return command != null && /run:.*pnpm knip --no-progress/.test(command);
+}
+
 describe("lefthook gates", () => {
   test("pre-commit and pre-push both run knip", () => {
-    expect(lefthook).toMatch(
-      /pre-commit:[\s\S]*?knip:[\s\S]*?pnpm knip --no-progress/,
-    );
-    expect(lefthook).toMatch(
-      /pre-push:[\s\S]*?knip:[\s\S]*?pnpm knip --no-progress/,
-    );
+    expect(hookRunsKnip(lefthook, "pre-commit")).toBe(true);
+    expect(hookRunsKnip(lefthook, "pre-push")).toBe(true);
+  });
+
+  test("knip assertions stay inside their own hook", () => {
+    const onlyPushRunsKnip = [
+      "pre-commit:",
+      "  commands:",
+      "    oxfmt:",
+      "      run: pnpm exec oxfmt",
+      "pre-push:",
+      "  commands:",
+      "    knip:",
+      "      run: pnpm knip --no-progress",
+    ].join("\n");
+    expect(hookRunsKnip(onlyPushRunsKnip, "pre-commit")).toBe(false);
+    expect(hookRunsKnip(onlyPushRunsKnip, "pre-push")).toBe(true);
   });
 });


### PR DESCRIPTION
## What changed
The website demo plays Earfquake from `00:23` (`'Cause you make my earthquake`). Clicking another catalog song now replaces the current track and loads that song's lyrics at a demo offset, instead of queuing or keeping Earfquake lyrics.

Centered-lyrics remains clickable in the landing preview.

## Verification
- [x] `pnpm tsc --noEmit --project tsconfig.json` — PASS
- [x] `pnpm lint` — PASS
- [x] `pnpm exec vitest run` (preview/song-list/lyrics-engine) — PASS (40 tests)
- [ ] `pnpm tauri build` — SKIPPED (preview mock and list interaction only)

## Residual risk
Other catalog songs still start at `00:59.560` so they land on a lyric line. E2E mock play remains at `0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Starts the landing-page preview of “Earfquake” at `00:23`.
- Starts other catalog songs at `00:59.560`.
- Starts E2E mock playback at `0`.
- Replaces the current track when a user selects another catalog song.
- Loads lyrics for the selected song.
- Prevents duplicate preview playback after a second click.
- Keeps centered lyrics clickable.
- Preserves lyric alignment when the song changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->