### PR TITLE
fix(preview): let landing demo song rows receive clicks

### DIFF
--- a/src/components/Layout/AppLayout.preview.test.tsx
+++ b/src/components/Layout/AppLayout.preview.test.tsx
@@ -308,6 +308,22 @@ describe("AppLayout preview mode", () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
+  it("allows click interactions on song-switch targets in preview mode", () => {
+    const onClick = vi.fn();
+    const { container } = render(
+      <AppLayout initialWindowShellState={macShellState} previewMode />,
+    );
+
+    const outer = container.firstElementChild as HTMLElement;
+    const songSwitch = document.createElement("button");
+    songSwitch.setAttribute("data-preview-song-switch", "true");
+    songSwitch.addEventListener("click", onClick);
+    outer.appendChild(songSwitch);
+
+    fireEvent.click(songSwitch);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
   it("allows click interactions on play-toggle targets in preview mode", () => {
     const onClick = vi.fn();
     const { container } = render(

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -32,6 +32,7 @@ function isPreviewAllowedTarget(target: EventTarget | null): boolean {
       target.closest("[data-preview-lyrics-interactive='true']") != null ||
       target.closest("[data-preview-sidebar-toggle='true']") != null ||
       target.closest("[data-preview-play-toggle='true']") != null ||
+      target.closest("[data-preview-song-switch='true']") != null ||
       target.closest("[data-preview-song-list='true']") != null)
   );
 }

--- a/src/components/Library/SongListItem.test.tsx
+++ b/src/components/Library/SongListItem.test.tsx
@@ -252,6 +252,7 @@ describe("SongListItem", () => {
     );
 
     const selection = getByRole("button", { name: song.title });
+    expect(selection.getAttribute("data-preview-song-switch")).toBeNull();
     fireEvent.click(selection);
     fireEvent.keyDown(selection, { key: "Enter" });
 
@@ -292,6 +293,7 @@ describe("SongListItem", () => {
     );
 
     const selection = getByRole("button", { name: song.title });
+    expect(selection.getAttribute("data-preview-song-switch")).toBe("true");
     fireEvent.click(selection);
 
     expect(mockPlayerState.playNow).toHaveBeenCalledTimes(1);

--- a/src/components/Library/SongListItem.tsx
+++ b/src/components/Library/SongListItem.tsx
@@ -260,6 +260,7 @@ export function SongListItem({
         aria-pressed={isSelected}
         className="absolute inset-0 z-0 cursor-pointer rounded-[14px] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]"
         data-song-action="select"
+        data-preview-song-switch={previewMode ? "true" : undefined}
       />
 
       <CoverArtThumbnail

--- a/tests/ci/website-preview-pointer-contract.test.ts
+++ b/tests/ci/website-preview-pointer-contract.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const projectRoot = fileURLToPath(new URL("../..", import.meta.url));
+const siteCss = readFileSync(join(projectRoot, "website/src/site.css"), "utf8");
+
+describe("website preview pointer contract", () => {
+  test("song-switch buttons stay clickable in the playlist-only preview", () => {
+    const blocklistStart = siteCss.indexOf(
+      "button:not([data-preview-playlist-switch",
+    );
+    expect(blocklistStart).toBeGreaterThan(-1);
+    const blocklist = siteCss.slice(blocklistStart, blocklistStart + 500);
+    expect(blocklist).toContain(':not([data-preview-song-switch="true"])');
+    expect(blocklist).toContain("pointer-events: none");
+  });
+});

--- a/website/src/site.css
+++ b/website/src/site.css
@@ -445,7 +445,7 @@ a {
     [data-preview-lyrics-interactive="true"]
   ):not([data-preview-sidebar-toggle="true"]):not(
     [data-preview-play-toggle="true"]
-  ),
+  ):not([data-preview-song-switch="true"]),
 .product-preview [data-preview-interaction-mode="playlist-only"] input,
 .product-preview
   [data-preview-interaction-mode="playlist-only"]
@@ -462,7 +462,10 @@ a {
   [data-preview-sidebar-toggle="true"],
 .product-preview
   [data-preview-interaction-mode="playlist-only"]
-  [data-preview-play-toggle="true"] {
+  [data-preview-play-toggle="true"],
+.product-preview
+  [data-preview-interaction-mode="playlist-only"]
+  [data-preview-song-switch="true"] {
   cursor: pointer;
 }
 


### PR DESCRIPTION
## What changed
Landing preview song rows already called `playNow`, but `website/src/site.css` still set `pointer-events: none` on every button except playlist / lyrics / sidebar / play-toggle. Clicks never reached the row.

Preview song buttons now carry `data-preview-song-switch` and are excluded from that blocklist.

## Verification
- [x] `pnpm exec vitest run` SongListItem, AppLayout.preview, website-preview-pointer-contract — PASS (39 tests)
- [x] `oxlint` on touched files — PASS
- [ ] Playwright website/UI smoke — not run locally (CI)

## Product standards
Interaction and accessibility. Changed surface: website preview click allowlist. Evidence: unit tests for the marker, capture allowlist, and CSS blocklist contract.

## Residual risk
Live site stays broken until this deploys. Separate and other preview-disabled buttons remain inert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Behavior Change

Preview song buttons now receive pointer events and trigger the existing `playNow` handlers. Other preview-disabled buttons remain inactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->