### PR TITLE
ci: pin GitHub Actions to latest releases and Node 24 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,7 +397,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: always()
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
@@ -530,7 +530,7 @@ jobs:
           persist-credentials: false
 
       - name: actionlint
-        uses: reviewdog/action-actionlint@50842263c20a7c46bd0065b9e624d3c569db061e # v1.73.0
+        uses: reviewdog/action-actionlint@dbe5299849118fd6f099ba563d263d770955a64a # v1.73.2
         with:
           actionlint_flags: ""
 
@@ -612,7 +612,7 @@ jobs:
       # Prebuilt binary rather than `cargo install`, which rebuilt cargo-shear
       # from source on every run of a job whose actual work takes seconds.
       - name: Install cargo-shear
-        uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
+        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
         with:
           tool: cargo-shear@1.12.4
 
@@ -672,7 +672,7 @@ jobs:
           rustc --version
 
       - name: Restore Rust cache
-        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: ${{ github.workflow }}-${{ matrix.os }}-debug
           workspaces: ./src-tauri -> target
@@ -720,7 +720,7 @@ jobs:
         run: cargo clippy --all-targets -- -D warnings
 
       - name: Install nextest
-        uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
+        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
         with:
           tool: nextest
 
@@ -764,7 +764,7 @@ jobs:
           toolchain: stable
 
       - name: Restore Rust cache
-        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: ${{ github.workflow }}-windows-latest-debug
           workspaces: ./src-tauri -> target
@@ -836,7 +836,7 @@ jobs:
           toolchain: stable
 
       - name: Restore Rust cache
-        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: ${{ github.workflow }}-ubuntu-22.04-release
           workspaces: ./src-tauri -> target
@@ -972,7 +972,7 @@ jobs:
           fi
 
       - name: Restore Rust cache
-        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: ${{ github.workflow }}-${{ matrix.os }}-release
           workspaces: ./src-tauri -> target

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Mirror to Codeberg
-        uses: cssnr/mirror-repository-action@2af5bf347684245f52b5f56502956a57f9b8813e # v1
+        uses: cssnr/mirror-repository-action@2af5bf347684245f52b5f56502956a57f9b8813e # v1.2.0
         with:
           host: https://codeberg.org
           username: thedavidweng

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -58,4 +58,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v3.0.2-node.24
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -489,7 +489,7 @@ jobs:
           targets: ${{ matrix.rust_targets }}
 
       - name: Restore Rust cache
-        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: ${{ runner.os == 'Windows' && 'openkara-windows-release' || format('{0}-{1}-release', github.workflow, matrix.os) }}
           key: ${{ runner.os == 'Windows' && github.sha || matrix.os }}

--- a/.github/workflows/reusable-linux-installed-app-smoke.yml
+++ b/.github/workflows/reusable-linux-installed-app-smoke.yml
@@ -100,7 +100,7 @@ jobs:
           targets: ${{ inputs.rust_target }}
 
       - name: Restore Rust cache
-        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: openkara-linux-release-${{ inputs.tauri_target }}
           workspaces: ./src-tauri -> target

--- a/.github/workflows/reusable-macos-installed-app-smoke.yml
+++ b/.github/workflows/reusable-macos-installed-app-smoke.yml
@@ -100,7 +100,7 @@ jobs:
           targets: ${{ inputs.rust_target }}
 
       - name: Restore Rust cache
-        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: openkara-macos-release-${{ inputs.tauri_target }}
           workspaces: ./src-tauri -> target

--- a/.github/workflows/reusable-separation-smoke.yml
+++ b/.github/workflows/reusable-separation-smoke.yml
@@ -59,7 +59,7 @@ jobs:
           toolchain: stable
 
       - name: Restore Rust cache
-        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: ${{ github.workflow }}-${{ inputs.os }}-smoke
           workspaces: ./src-tauri -> target

--- a/.github/workflows/reusable-windows-installed-app.yml
+++ b/.github/workflows/reusable-windows-installed-app.yml
@@ -114,7 +114,7 @@ jobs:
           toolchain: stable
 
       - name: Restore Rust cache
-        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           # Stable across commits so adjacent pushes hit the cache. Do not key
           # on github.sha — that forced a cold cache on every push.

--- a/.github/workflows/spectral-candidate.yml
+++ b/.github/workflows/spectral-candidate.yml
@@ -61,7 +61,7 @@ jobs:
           toolchain: stable
 
       - name: Restore Rust cache
-        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: spectral-candidate-${{ matrix.os }}
           workspaces: ./src-tauri -> target
@@ -134,7 +134,7 @@ jobs:
         run: node scripts/prepare-onnx-runtime.mjs --target "${ORT_TARGET}"
 
       - name: Install nextest
-        uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
+        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
         with:
           tool: nextest
 


### PR DESCRIPTION
Pins remaining GitHub Actions (including floating majors) to current latest releases and keeps Node on 24 Active LTS (Krypton). No application code changes.