### PR TITLE
feat: snap lyric browse and slim the landing preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Desktop.ini
 .idea/
 .cursor/
 .claude/
+.grok/
 .agents/*
 !.agents/skills/
 *.swp

--- a/src/components/Layout/AppLayout.preview.test.tsx
+++ b/src/components/Layout/AppLayout.preview.test.tsx
@@ -101,7 +101,7 @@ vi.mock("./SidebarRail", () => ({
   ),
 }));
 
-vi.mock("./ToastContainer", () => ({
+vi.mock("@/components/Layout/ToastContainer", () => ({
   ToastContainer: () => <div data-testid="toast-container" />,
 }));
 
@@ -321,6 +321,22 @@ describe("AppLayout preview mode", () => {
     outer.appendChild(songSwitch);
 
     fireEvent.click(songSwitch);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows click interactions on playback-interactive targets in preview mode", () => {
+    const onClick = vi.fn();
+    const { container } = render(
+      <AppLayout initialWindowShellState={macShellState} previewMode />,
+    );
+
+    const outer = container.firstElementChild as HTMLElement;
+    const playback = document.createElement("button");
+    playback.setAttribute("data-preview-playback-interactive", "true");
+    playback.addEventListener("click", onClick);
+    outer.appendChild(playback);
+
+    fireEvent.click(playback);
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 

--- a/src/components/Layout/AppLayout.test.tsx
+++ b/src/components/Layout/AppLayout.test.tsx
@@ -86,7 +86,7 @@ vi.mock("./SidebarRail", () => ({
   ),
 }));
 
-vi.mock("./ToastContainer", () => ({
+vi.mock("@/components/Layout/ToastContainer", () => ({
   ToastContainer: () => <div data-testid="toast-container" />,
 }));
 

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, type SyntheticEvent } from "react";
 import { Sidebar } from "./Sidebar";
 import { SidebarRail } from "./SidebarRail";
 import { WindowChrome } from "./WindowChrome";
-import { ToastContainer } from "./ToastContainer";
+import { ToastContainer } from "@/components/Layout/ToastContainer";
 import { MainContentView } from "./MainContentView";
 import { ImportCdgChoiceDialog } from "@/components/Library/ImportCdgChoiceDialog";
 import { getShortcutPlatform } from "@/lib/app-shortcuts";
@@ -32,6 +32,7 @@ function isPreviewAllowedTarget(target: EventTarget | null): boolean {
       target.closest("[data-preview-lyrics-interactive='true']") != null ||
       target.closest("[data-preview-sidebar-toggle='true']") != null ||
       target.closest("[data-preview-play-toggle='true']") != null ||
+      target.closest("[data-preview-playback-interactive='true']") != null ||
       target.closest("[data-preview-song-switch='true']") != null ||
       target.closest("[data-preview-song-list='true']") != null)
   );

--- a/src/components/Lyrics/LyricLine.test.tsx
+++ b/src/components/Lyrics/LyricLine.test.tsx
@@ -349,8 +349,9 @@ describe("LyricLine", () => {
     expect(mockControllerInstances).toHaveLength(1);
     expect(controller.deactivateLine).toHaveBeenCalled();
     expect(controller.destroy).not.toHaveBeenCalled();
-    expect(container.querySelectorAll("[data-karaoke-fill]")).toHaveLength(2);
-    expect(container.innerHTML).toContain("--bright-mask-alpha: 0.2");
+    expect(container.querySelectorAll("[data-karaoke-fill]")).toHaveLength(0);
+    expect(container.innerHTML).toContain("text-[var(--color-lyrics-past)]");
+    expect(container.innerHTML).not.toContain("--bright-mask-alpha");
 
     await act(async () => {
       root.unmount();
@@ -576,11 +577,12 @@ describe("LyricLine", () => {
       />,
     );
 
-    expect(markup).toContain("--bright-mask-alpha:0.2");
-    expect(markup).toContain("--dark-mask-alpha:0.2");
+    expect(markup).toContain("text-[var(--color-lyrics-past)]");
+    expect(markup).not.toContain("data-karaoke-fill");
+    expect(markup).not.toContain("--bright-mask-alpha");
   });
 
-  test("renders future line words with active text color", () => {
+  test("renders future line words with future text color", () => {
     const markup = renderToStaticMarkup(
       <LyricLine
         line={{
@@ -600,8 +602,9 @@ describe("LyricLine", () => {
       />,
     );
 
-    expect(markup).toContain("--bright-mask-alpha:0.2");
-    expect(markup).toContain("--dark-mask-alpha:0.2");
+    expect(markup).toContain("text-[var(--color-lyrics-future)]");
+    expect(markup).not.toContain("data-karaoke-fill");
+    expect(markup).not.toContain("--bright-mask-alpha");
   });
 
   test("renders audience presentation with bg_words", () => {
@@ -685,8 +688,8 @@ describe("LyricLine", () => {
       />,
     );
 
-    expect(smallStep).toContain("max(max(5vh, 2.5vw), 12px) * 0.76");
-    expect(largeStep).toContain("max(max(5vh, 2.5vw), 12px) * 1.28");
+    expect(smallStep).toContain("clamp(2.15rem, 1.7vw + 1.8vh, 3rem) * 0.76");
+    expect(largeStep).toContain("clamp(2.15rem, 1.7vw + 1.8vh, 3rem) * 1.28");
     expect(smallStep).toContain("max(0.5em, 10px)");
     expect(smallStep).toContain('data-lyrics-roman="true"');
     expect(smallStep).not.toContain("text-[0.5em]");

--- a/src/components/Lyrics/LyricLine.tsx
+++ b/src/components/Lyrics/LyricLine.tsx
@@ -3,9 +3,7 @@ import { useTranslation } from "react-i18next";
 import {
   ACTIVE_BRIGHT_ALPHA,
   ACTIVE_DARK_ALPHA,
-  INACTIVE_MASK_ALPHA,
   KaraokeFillController,
-  applyWordMask,
 } from "./karaoke-fill";
 import {
   buildAudiencePresentationSpec,
@@ -16,6 +14,9 @@ import { usePlayerStore } from "@/stores/player-store";
 import type { LyricLine as LyricLineType } from "@/types/ipc";
 import {
   CENTERED_BG_FONT_SIZE,
+  CENTERED_LINE_LETTER_SPACING,
+  CENTERED_LINE_LINE_HEIGHT,
+  CENTERED_LINE_PADDING,
   CENTERED_ROMAN_FONT_SIZE,
   displayWordText,
   getCenteredLineFontSize,
@@ -119,14 +120,6 @@ export const LyricLine = memo(function LyricLine({
   wordsRef.current = words;
 
   useEffect(() => {
-    if (hasWordMask) {
-      for (const el of wordElsRef.current) {
-        if (el) {
-          applyWordMask(el);
-        }
-      }
-    }
-
     if (shouldUseKaraokeFill) {
       if (!karaokeRef.current) {
         karaokeRef.current = new KaraokeFillController();
@@ -146,7 +139,7 @@ export const LyricLine = memo(function LyricLine({
 
     lyricsLineRuntime.unregisterKaraoke(lineIndex);
     karaokeRef.current?.deactivateLine();
-  }, [hasWordMask, lineIndex, shouldUseKaraokeFill]);
+  }, [lineIndex, shouldUseKaraokeFill]);
 
   useEffect(
     () => () => {
@@ -169,26 +162,25 @@ export const LyricLine = memo(function LyricLine({
       } items-baseline gap-x-8 gap-y-1.5 text-left ${
         isSeekable ? "cursor-pointer group/line" : ""
       }`
-    : `flex flex-col items-center gap-[0.3em] text-center ${
+    : `flex flex-col items-center gap-[0.28em] text-center ${
         isSeekable ? "cursor-pointer group/line" : ""
       }`;
   const lineStyle = {
-    fontFamily:
-      '-apple-system, BlinkMacSystemFont, "Helvetica Neue", "Noto Sans SC", "Noto Sans JP", "Noto Sans KR", system-ui, sans-serif',
+    fontFamily: "inherit",
     ...(usesCenteredLineType
       ? {
           fontSize: getCenteredLineFontSize(lyricsFontStep),
-          lineHeight: 1.2,
+          lineHeight: CENTERED_LINE_LINE_HEIGHT,
+          letterSpacing: CENTERED_LINE_LETTER_SPACING,
+          padding: CENTERED_LINE_PADDING,
+          fontWeight: state === "active" || state === "plain" ? 600 : 500,
+          textWrap: "pretty" as const,
         }
       : undefined),
-    ...(hasWordMask
+    ...(shouldUseKaraokeFill
       ? ({
-          "--bright-mask-alpha": shouldUseKaraokeFill
-            ? String(ACTIVE_BRIGHT_ALPHA)
-            : String(INACTIVE_MASK_ALPHA),
-          "--dark-mask-alpha": shouldUseKaraokeFill
-            ? String(ACTIVE_DARK_ALPHA)
-            : String(INACTIVE_MASK_ALPHA),
+          "--bright-mask-alpha": String(ACTIVE_BRIGHT_ALPHA),
+          "--dark-mask-alpha": String(ACTIVE_DARK_ALPHA),
         } as CSSProperties)
       : undefined),
     ...(presentation === "audience" && !isLeftAligned
@@ -207,11 +199,15 @@ export const LyricLine = memo(function LyricLine({
       className={(presentation === "audience"
         ? `tracking-tight min-w-0 break-words ${hoverClass}`
         : usesCenteredLineType
-          ? `font-semibold tracking-tight min-w-0 break-words ${hoverClass}`
+          ? `tracking-tight min-w-0 break-words ${hoverClass}`
           : `${textSizeClass} min-w-0 break-words ${hoverClass}`
       ).trim()}
       style={{
-        fontWeight: state === "active" ? 500 : 400,
+        fontWeight: usesCenteredLineType
+          ? "inherit"
+          : state === "active" || state === "plain"
+            ? 500
+            : 400,
         ...(presentation === "audience"
           ? {
               fontSize: audiencePresentationSpec.fontSizePx,
@@ -267,7 +263,7 @@ export const LyricLine = memo(function LyricLine({
           </span>
         ) : null;
 
-        if (hasWordMask) {
+        if (shouldUseKaraokeFill) {
           return (
             <span key={idx}>
               <span className="inline-flex flex-col items-center align-bottom">
@@ -338,9 +334,7 @@ export const LyricLine = memo(function LyricLine({
       className={(presentation === "audience"
         ? `motion-surface font-bold tracking-tight min-w-0 break-words ${hoverClass}`
         : `motion-surface ${
-            usesCenteredLineType
-              ? "font-semibold tracking-tight"
-              : textSizeClass
+            usesCenteredLineType ? "tracking-tight" : textSizeClass
           } min-w-0 break-words ${
             state === "plain" || state === "active"
               ? "text-[var(--color-lyrics-active)]"

--- a/src/components/Lyrics/LyricsEmptyState.tsx
+++ b/src/components/Lyrics/LyricsEmptyState.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { LyricsEditDialog } from "./LyricsEditDialog";
+import { LyricsEditDialog } from "@/components/Lyrics/LyricsEditDialog";
 import { usePlayerStore } from "@/stores/player-store";
 import { useLyricsStore } from "@/stores/lyrics-store";
 

--- a/src/components/Lyrics/LyricsPanel.test.tsx
+++ b/src/components/Lyrics/LyricsPanel.test.tsx
@@ -681,6 +681,18 @@ describe("LyricsPanel contextual reveal", () => {
 
     expect(mockLyricsState.toggleLyricsAlignment).toHaveBeenCalled();
 
+    const romanize = host.querySelector(
+      "[aria-label='lyrics.romanizeTooltip']",
+    ) as HTMLButtonElement;
+    expect(romanize).toBeTruthy();
+    expect(romanize.getAttribute("data-preview-lyrics-interactive")).toBe(
+      "true",
+    );
+    act(() => {
+      romanize.click();
+    });
+    expect(mockLyricsState.toggleRomanized).toHaveBeenCalled();
+
     act(() => {
       root.unmount();
     });

--- a/src/components/Lyrics/LyricsPanel.tsx
+++ b/src/components/Lyrics/LyricsPanel.tsx
@@ -95,10 +95,15 @@ export function LyricsPanel({
         data-testid="lyrics-scroll-viewport"
         data-preview-lyrics-interactive="true"
         className={`flex w-full flex-1 overflow-y-auto animate-[song-fade-in_var(--motion-duration-slow)_var(--motion-ease-emphasized-out)] ${
-          isAudience ? "" : spaciousStageLayout ? "px-16 py-10" : "px-12 py-8"
+          isAudience
+            ? ""
+            : spaciousStageLayout
+              ? "px-16 pt-10 pb-24"
+              : "px-12 pt-8 pb-20"
         }`}
         style={{
           overflowAnchor: "none",
+          overscrollBehaviorY: "contain",
           ...(isAudience
             ? {
                 padding: `${audienceSpec.verticalPaddingPx}px ${audienceSpec.horizontalPaddingPx}px`,

--- a/src/components/Lyrics/LyricsPanel.tsx
+++ b/src/components/Lyrics/LyricsPanel.tsx
@@ -93,6 +93,7 @@ export function LyricsPanel({
         ref={model.containerRef}
         key={songId}
         data-testid="lyrics-scroll-viewport"
+        data-lyrics-viewport="true"
         data-preview-lyrics-interactive="true"
         className={`flex w-full flex-1 overflow-y-auto animate-[song-fade-in_var(--motion-duration-slow)_var(--motion-ease-emphasized-out)] ${
           isAudience

--- a/src/components/Lyrics/LyricsPanelToolbar.tsx
+++ b/src/components/Lyrics/LyricsPanelToolbar.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { AlignLeft, Edit2, Languages, LoaderCircle } from "lucide-react";
 import { Tooltip } from "@/components/Overlay/Tooltip";
 import type { LyricsAlignment } from "@/lib/lyrics-session";
-import { LyricsEditDialog } from "./LyricsEditDialog";
+import { LyricsEditDialog } from "@/components/Lyrics/LyricsEditDialog";
 
 const ACTIVE_BUTTON_CLASS =
   "border-[color-mix(in_srgb,var(--color-accent)_40%,var(--color-border-light))] bg-[color-mix(in_srgb,var(--color-accent)_18%,var(--color-sidebar))] text-[var(--color-control-primary)]";
@@ -51,8 +51,10 @@ export function LyricsPanelToolbar({
         <Tooltip label={t("lyrics.romanizeTooltip")}>
           <button
             type="button"
+            data-preview-lyrics-interactive="true"
             onClick={onToggleRomanized}
             aria-label={t("lyrics.romanizeTooltip")}
+            aria-pressed={showRomanized}
             disabled={isRomanizing}
             className={`${BUTTON_CLASS} ${
               showRomanized ? ACTIVE_BUTTON_CLASS : IDLE_BUTTON_CLASS

--- a/src/components/Lyrics/karaoke-fill.test.ts
+++ b/src/components/Lyrics/karaoke-fill.test.ts
@@ -103,7 +103,7 @@ describe("KaraokeFillController", () => {
     expect(wordEl.style.maskPosition).toBe("-12px 0px");
   });
 
-  test("deactivateLine keeps the mask so inactive dual-alpha can stay applied", () => {
+  test("deactivateLine clears the mask so the line can return to solid color", () => {
     const lineEl = document.createElement("div");
     const wordEl = createMockEl();
     controller.activateLine(
@@ -113,7 +113,8 @@ describe("KaraokeFillController", () => {
     );
     expect(wordEl.style.maskSize || wordEl.style.webkitMaskSize).toContain("%");
     controller.deactivateLine();
-    expect(wordEl.style.maskSize || wordEl.style.webkitMaskSize).toContain("%");
+    expect(wordEl.style.maskImage || wordEl.style.webkitMaskImage).toBe("");
+    expect(wordEl.style.maskSize || wordEl.style.webkitMaskSize).toBe("");
   });
 
   test("update remasures when the word box changes size", () => {

--- a/src/components/Lyrics/karaoke-fill.ts
+++ b/src/components/Lyrics/karaoke-fill.ts
@@ -1,6 +1,6 @@
 export const INACTIVE_MASK_ALPHA = 0.2;
 export const ACTIVE_BRIGHT_ALPHA = 1;
-export const ACTIVE_DARK_ALPHA = 0.18;
+export const ACTIVE_DARK_ALPHA = 0.4;
 export const WORD_FADE_HEIGHT_RATIO = 0.5;
 
 const BRIGHT = "rgba(0,0,0,var(--bright-mask-alpha, 1))";
@@ -77,6 +77,7 @@ export function applyWordMask(element: HTMLElement): {
   style.webkitMaskRepeat = "no-repeat";
   style.webkitMaskOrigin = "left";
   style.webkitMaskSize = size;
+  setWordMaskProgress(element, 0, measured.width, measured.fade);
   return measured;
 }
 
@@ -166,6 +167,9 @@ export class KaraokeFillController {
 
   deactivateLine() {
     this.disconnectWordObserver();
+    for (const word of this.wordFills) {
+      clearWordMask(word.element);
+    }
     this.wordFills = [];
     this.activeLineEl = null;
     this.activeWordEls = [];

--- a/src/components/Lyrics/lyric-line-typography.test.ts
+++ b/src/components/Lyrics/lyric-line-typography.test.ts
@@ -26,8 +26,10 @@ describe("wordTokenGap", () => {
 });
 
 describe("centered focus type scale", () => {
-  test("puts the viewport line size on the line, not a rem step", () => {
+  test("puts a clamped display size on the line, not a rem step", () => {
     expect(getCenteredLineFontSize(0)).toBe(CENTERED_LINE_FONT_SIZE_BASE);
+    expect(CENTERED_LINE_FONT_SIZE_BASE).toContain("clamp(");
+    expect(CENTERED_LINE_FONT_SIZE_BASE).not.toContain("5vh");
     expect(getCenteredLineFontSize(-2)).toBe(
       `calc(${CENTERED_LINE_FONT_SIZE_BASE} * 0.76)`,
     );

--- a/src/components/Lyrics/lyric-line-typography.test.ts
+++ b/src/components/Lyrics/lyric-line-typography.test.ts
@@ -3,6 +3,7 @@ import {
   CENTERED_BG_FONT_SIZE,
   CENTERED_LINE_FONT_SIZE_BASE,
   CENTERED_ROMAN_FONT_SIZE,
+  evaluateCenteredLineFontSizePx,
   getCenteredLineFontSize,
   shouldEmphasizeWord,
   wordTokenGap,
@@ -35,6 +36,16 @@ describe("centered focus type scale", () => {
     );
     expect(getCenteredLineFontSize(2)).toBe(
       `calc(${CENTERED_LINE_FONT_SIZE_BASE} * 1.28)`,
+    );
+  });
+
+  test("clamps the display size at small, mid, and large viewports", () => {
+    expect(evaluateCenteredLineFontSizePx(0, 320, 480)).toBeCloseTo(34.4, 5);
+    expect(evaluateCenteredLineFontSizePx(0, 1600, 900)).toBeCloseTo(43.4, 5);
+    expect(evaluateCenteredLineFontSizePx(0, 1920, 1080)).toBeCloseTo(48, 5);
+    expect(evaluateCenteredLineFontSizePx(-2, 1920, 1080)).toBeCloseTo(
+      48 * 0.76,
+      5,
     );
   });
 

--- a/src/components/Lyrics/lyric-line-typography.ts
+++ b/src/components/Lyrics/lyric-line-typography.ts
@@ -49,10 +49,13 @@ const CENTERED_LINE_FONT_STEP_SCALE = {
   [2]: 1.28,
 } as const;
 
-/** Viewport line size for centered focus. Secondary rows use em of this. */
-export const CENTERED_LINE_FONT_SIZE_BASE = "max(max(5vh, 2.5vw), 12px)";
+export const CENTERED_LINE_FONT_SIZE_BASE =
+  "clamp(2.15rem, 1.7vw + 1.8vh, 3rem)";
 export const CENTERED_ROMAN_FONT_SIZE = "max(0.5em, 10px)";
 export const CENTERED_BG_FONT_SIZE = "max(0.7em, 10px)";
+export const CENTERED_LINE_LINE_HEIGHT = 1.22;
+export const CENTERED_LINE_LETTER_SPACING = "-0.02em";
+export const CENTERED_LINE_PADDING = "0.42em 0.12em";
 
 function clampStep(lyricsFontStep: number): FontStep {
   return Math.max(-2, Math.min(2, lyricsFontStep)) as FontStep;

--- a/src/components/Lyrics/lyric-line-typography.ts
+++ b/src/components/Lyrics/lyric-line-typography.ts
@@ -89,6 +89,19 @@ export function getCenteredLineFontSize(lyricsFontStep: number): string {
   return `calc(${CENTERED_LINE_FONT_SIZE_BASE} * ${scale})`;
 }
 
+export function evaluateCenteredLineFontSizePx(
+  lyricsFontStep: number,
+  viewportWidthPx: number,
+  viewportHeightPx: number,
+  rootFontSizePx = 16,
+): number {
+  const scale = CENTERED_LINE_FONT_STEP_SCALE[clampStep(lyricsFontStep)];
+  const minPx = 2.15 * rootFontSizePx;
+  const maxPx = 3 * rootFontSizePx;
+  const preferredPx = 0.017 * viewportWidthPx + 0.018 * viewportHeightPx;
+  return Math.min(maxPx, Math.max(minPx, preferredPx)) * scale;
+}
+
 export function getSeekableHoverClass(
   presentation: LyricsPresentation,
   isSeekable: boolean,

--- a/src/components/Lyrics/lyrics-scroll.test.ts
+++ b/src/components/Lyrics/lyrics-scroll.test.ts
@@ -1,5 +1,14 @@
+// @vitest-environment jsdom
+
 import { describe, expect, test } from "vitest";
-import { getCenteredScrollTop } from "./lyrics-scroll";
+import {
+  collectLineSnapScrollTops,
+  getCenteredScrollTop,
+  nearestSnapScrollTop,
+  projectDecelerationOffset,
+  resolveLyricScrollLanding,
+  stepLineSnapScrollTop,
+} from "./lyrics-scroll";
 
 describe("getCenteredScrollTop", () => {
   test("centers the active lyric line when there is enough space", () => {
@@ -44,5 +53,60 @@ describe("getCenteredScrollTop", () => {
         lineHeight: 140,
       }),
     ).toBe(540);
+  });
+
+  test("places the focus line above the optical center", () => {
+    expect(
+      getCenteredScrollTop({
+        viewportHeight: 400,
+        scrollHeight: 1200,
+        lineOffsetTop: 500,
+        lineHeight: 80,
+        alignPosition: 0.38,
+      }),
+    ).toBe(388);
+  });
+});
+
+describe("lyric line snap landings", () => {
+  test("projects a flick with Apple's deceleration form", () => {
+    expect(projectDecelerationOffset(0)).toBe(0);
+    expect(projectDecelerationOffset(1000)).toBeCloseTo(499, 0);
+    expect(projectDecelerationOffset(-1000)).toBeCloseTo(-499, 0);
+  });
+
+  test("picks the nearest snap from a projected rest point", () => {
+    const snaps = [0, 120, 240, 360];
+    expect(nearestSnapScrollTop(snaps, 130)).toBe(120);
+    expect(resolveLyricScrollLanding(snaps, 130, 0)).toBe(120);
+    expect(resolveLyricScrollLanding(snaps, 130, 800)).toBe(360);
+    expect(resolveLyricScrollLanding([], 130, 800)).toBeNull();
+  });
+
+  test("steps one snap in the wheel direction", () => {
+    const snaps = [0, 120, 240];
+    expect(stepLineSnapScrollTop(snaps, 0, 1)).toBe(120);
+    expect(stepLineSnapScrollTop(snaps, 120, 1)).toBe(240);
+    expect(stepLineSnapScrollTop(snaps, 240, 1)).toBe(240);
+    expect(stepLineSnapScrollTop(snaps, 240, -1)).toBe(120);
+    expect(stepLineSnapScrollTop(snaps, 0, -1)).toBe(0);
+  });
+
+  test("collects unique snap tops for each measured line", () => {
+    const container = document.createElement("div");
+    Object.defineProperty(container, "clientHeight", { value: 400 });
+    Object.defineProperty(container, "scrollHeight", { value: 1200 });
+
+    for (const [index, top] of [80, 280, 480].entries()) {
+      const line = document.createElement("div");
+      line.dataset.lyricsLineIndex = String(index);
+      Object.defineProperty(line, "offsetTop", { value: top });
+      Object.defineProperty(line, "clientHeight", { value: 80 });
+      container.append(line);
+    }
+
+    expect(collectLineSnapScrollTops(container, 3, 0.38)).toEqual([
+      0, 168, 368,
+    ]);
   });
 });

--- a/src/components/Lyrics/lyrics-scroll.ts
+++ b/src/components/Lyrics/lyrics-scroll.ts
@@ -1,8 +1,12 @@
+export const LIST_ALIGN_POSITION = 0.5;
+export const FOCUS_ALIGN_POSITION = 0.38;
+
 interface CenteredScrollTopInput {
   viewportHeight: number;
   scrollHeight: number;
   lineOffsetTop: number;
   lineHeight: number;
+  alignPosition?: number;
 }
 
 export function getCenteredScrollTop({
@@ -10,8 +14,10 @@ export function getCenteredScrollTop({
   scrollHeight,
   lineOffsetTop,
   lineHeight,
+  alignPosition = LIST_ALIGN_POSITION,
 }: CenteredScrollTopInput): number {
-  const centeredTop = lineOffsetTop + lineHeight / 2 - viewportHeight / 2;
+  const centeredTop =
+    lineOffsetTop + lineHeight / 2 - viewportHeight * alignPosition;
   const maxScrollTop = Math.max(0, scrollHeight - viewportHeight);
 
   return Math.max(0, Math.min(maxScrollTop, Math.round(centeredTop)));
@@ -53,6 +59,7 @@ function getLineScrollMetrics(
 export function getScrollTopForLineIndex(
   container: HTMLElement,
   lineIndex: number,
+  alignPosition: number = LIST_ALIGN_POSITION,
 ): number | null {
   const metrics = getLineScrollMetrics(container, lineIndex);
   if (!metrics) {
@@ -64,5 +71,96 @@ export function getScrollTopForLineIndex(
     scrollHeight: container.scrollHeight,
     lineOffsetTop: metrics.offsetTop,
     lineHeight: metrics.height,
+    alignPosition,
   });
+}
+
+export const SCROLL_DECELERATION_RATE = 0.998;
+
+export function projectDecelerationOffset(
+  velocityPxPerSec: number,
+  decelerationRate = SCROLL_DECELERATION_RATE,
+): number {
+  if (
+    velocityPxPerSec === 0 ||
+    decelerationRate <= 0 ||
+    decelerationRate >= 1
+  ) {
+    return 0;
+  }
+  return (
+    ((velocityPxPerSec / 1000) * decelerationRate) / (1 - decelerationRate)
+  );
+}
+
+export function collectLineSnapScrollTops(
+  container: HTMLElement,
+  lineCount: number,
+  alignPosition: number = LIST_ALIGN_POSITION,
+): number[] {
+  const snaps: number[] = [];
+  let previous = Number.NaN;
+  for (let index = 0; index < lineCount; index += 1) {
+    const top = getScrollTopForLineIndex(container, index, alignPosition);
+    if (top === null || top === previous) {
+      continue;
+    }
+    snaps.push(top);
+    previous = top;
+  }
+  return snaps;
+}
+
+export function nearestSnapScrollTop(
+  snaps: readonly number[],
+  position: number,
+): number | null {
+  if (snaps.length === 0) {
+    return null;
+  }
+  let best = snaps[0];
+  let bestDist = Math.abs(position - best);
+  for (let index = 1; index < snaps.length; index += 1) {
+    const dist = Math.abs(position - snaps[index]);
+    if (dist < bestDist) {
+      best = snaps[index];
+      bestDist = dist;
+    }
+  }
+  return best;
+}
+
+export function resolveLyricScrollLanding(
+  snaps: readonly number[],
+  position: number,
+  velocityPxPerSec: number,
+): number | null {
+  return nearestSnapScrollTop(
+    snaps,
+    position + projectDecelerationOffset(velocityPxPerSec),
+  );
+}
+
+export function stepLineSnapScrollTop(
+  snaps: readonly number[],
+  position: number,
+  direction: 1 | -1,
+): number | null {
+  if (snaps.length === 0) {
+    return null;
+  }
+  if (direction > 0) {
+    for (const snap of snaps) {
+      if (snap > position + 0.5) {
+        return snap;
+      }
+    }
+    return snaps[snaps.length - 1];
+  }
+  for (let index = snaps.length - 1; index >= 0; index -= 1) {
+    if (snaps[index] < position - 0.5) {
+      return snaps[index];
+    }
+  }
+  return snaps[0];
 }

--- a/src/components/Player/AudioLevelSlider.tsx
+++ b/src/components/Player/AudioLevelSlider.tsx
@@ -11,6 +11,7 @@ interface AudioLevelSliderProps {
   widthClass?: string;
   ariaLabel?: string;
   inputRef?: React.RefObject<HTMLInputElement | null>;
+  previewInteractive?: boolean;
 }
 
 function formatAudioLevelTooltip(label: string, value: number): string {
@@ -27,6 +28,7 @@ export function AudioLevelSlider({
   widthClass = "w-16",
   ariaLabel,
   inputRef,
+  previewInteractive = false,
 }: AudioLevelSliderProps) {
   const [isDragging, setIsDragging] = useState(false);
 
@@ -68,6 +70,9 @@ export function AudioLevelSlider({
         }}
         className={`native-slider audio-level-slider shrink-0 ${widthClass}`}
         disabled={disabled}
+        data-preview-playback-interactive={
+          previewInteractive ? "true" : undefined
+        }
         data-dragging={isDragging ? "true" : undefined}
         aria-label={ariaLabel ?? label}
       />

--- a/src/components/Player/PlayControls.tsx
+++ b/src/components/Player/PlayControls.tsx
@@ -48,6 +48,7 @@ export function PlayControls({
     >
       <button
         onClick={skipBack}
+        data-preview-playback-interactive={previewMode ? "true" : undefined}
         className="motion-icon-button rounded-full p-2 opacity-80 hover:bg-[var(--color-ghost-hover)] hover:text-[var(--color-text)] hover:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]/50"
         aria-label={t("player.previous")}
       >
@@ -72,6 +73,7 @@ export function PlayControls({
       </button>
       <button
         onClick={skipForward}
+        data-preview-playback-interactive={previewMode ? "true" : undefined}
         className="motion-icon-button rounded-full p-2 opacity-80 hover:bg-[var(--color-ghost-hover)] hover:text-[var(--color-text)] hover:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]/50"
         aria-label={t("player.next")}
       >

--- a/src/components/Player/PlaybackBar.test.tsx
+++ b/src/components/Player/PlaybackBar.test.tsx
@@ -50,20 +50,53 @@ vi.mock("./NowPlayingInfo", () => ({
 }));
 
 vi.mock("./PlayControls", () => ({
-  PlayControls: ({ density }: { density?: string }) => (
-    <div data-play-controls-density={density}>Play controls</div>
+  PlayControls: ({
+    density,
+    previewMode,
+  }: {
+    density?: string;
+    previewMode?: boolean;
+  }) => (
+    <div
+      data-play-controls-density={density}
+      data-preview-mode={previewMode ? "true" : undefined}
+    >
+      Play controls
+    </div>
   ),
 }));
 
 vi.mock("./SeekBar", () => ({
-  SeekBar: ({ density }: { density?: string }) => (
-    <div data-seek-bar-density={density}>Seek bar</div>
+  SeekBar: ({
+    density,
+    previewMode,
+  }: {
+    density?: string;
+    previewMode?: boolean;
+  }) => (
+    <div
+      data-seek-bar-density={density}
+      data-preview-mode={previewMode ? "true" : undefined}
+    >
+      Seek bar
+    </div>
   ),
 }));
 
 vi.mock("./VolumeSliders", () => ({
-  VolumeSliders: ({ density }: { density?: string }) => (
-    <div data-volume-sliders-density={density}>Stem sliders</div>
+  VolumeSliders: ({
+    density,
+    previewMode,
+  }: {
+    density?: string;
+    previewMode?: boolean;
+  }) => (
+    <div
+      data-volume-sliders-density={density}
+      data-preview-mode={previewMode ? "true" : undefined}
+    >
+      Stem sliders
+    </div>
   ),
 }));
 
@@ -161,6 +194,12 @@ describe("PlaybackBar", () => {
     expect(markup).toContain('data-volume-sliders-density="tight"');
     expect(markup).toContain("Queue button");
     expect(markup).toContain("audio-level-slider shrink-0 w-[64px]");
+  });
+
+  test("marks playback children as preview-interactive", () => {
+    const markup = renderToStaticMarkup(<PlaybackBar previewMode />);
+    expect(markup).toContain('data-preview-mode="true"');
+    expect(markup).toContain('data-preview-playback-interactive="true"');
   });
 
   test("keeps one shared structure for the flush playback bar chrome", () => {

--- a/src/components/Player/PlaybackBar.tsx
+++ b/src/components/Player/PlaybackBar.tsx
@@ -127,7 +127,7 @@ export function PlaybackBar({
           style={centerZoneStyle}
         >
           <PlayControls density={density} previewMode={previewMode} />
-          <SeekBar density={density} />
+          <SeekBar density={density} previewMode={previewMode} />
           <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
             <RemoteReconnectIndicator />
           </div>
@@ -139,11 +139,12 @@ export function PlaybackBar({
           style={{ gap: layoutTokens.rightZoneGap }}
         >
           <QueueButton />
-          <VolumeSliders density={density} />
+          <VolumeSliders density={density} previewMode={previewMode} />
 
           <div
             className="flex shrink-0 items-center"
             style={{ gap: layoutTokens.masterVolumeGap }}
+            data-preview-playback-interactive={previewMode ? "true" : undefined}
           >
             <Tooltip
               label={volume === 0 ? t("player.unmute") : t("player.mute")}
@@ -151,6 +152,9 @@ export function PlaybackBar({
               <button
                 id="master-mute"
                 type="button"
+                data-preview-playback-interactive={
+                  previewMode ? "true" : undefined
+                }
                 onClick={handleMasterMuteToggle}
                 aria-label={
                   volume === 0 ? t("player.unmute") : t("player.mute")
@@ -172,6 +176,7 @@ export function PlaybackBar({
               onChange={setVolume}
               widthClass={layoutTokens.masterVolumeWidthClass}
               ariaLabel={t("player.volume")}
+              previewInteractive={previewMode}
             />
           </div>
         </div>

--- a/src/components/Player/SeekBar.tsx
+++ b/src/components/Player/SeekBar.tsx
@@ -18,6 +18,7 @@ import {
 
 interface SeekBarProps {
   density?: PlaybackBarDensity;
+  previewMode?: boolean;
 }
 
 const KEYBOARD_SEEK_STEP_MS = 5_000;
@@ -27,7 +28,10 @@ function clampPosition(positionMs: number, durationMs: number): number {
   return Math.max(0, Math.min(durationMs, positionMs));
 }
 
-export function SeekBar({ density = "relaxed" }: SeekBarProps = {}) {
+export function SeekBar({
+  density = "relaxed",
+  previewMode = false,
+}: SeekBarProps = {}) {
   const { playback } = useBackend();
   const { t } = useTranslation();
   const snapshot = usePlayerStore((s) => s.snapshot);
@@ -295,6 +299,7 @@ export function SeekBar({ density = "relaxed" }: SeekBarProps = {}) {
       <div
         ref={barRef}
         id="seek-slider"
+        data-preview-playback-interactive={previewMode ? "true" : undefined}
         className={`group relative h-1.5 ${PLAYBACK_BAR_SEEK_RAIL_MIN_WIDTH_CLASS} flex-1 rounded-full bg-[var(--color-border)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-focus-ring)]`}
         onMouseDown={handleMouseDown}
         role="slider"

--- a/src/components/Player/VolumeSliders.tsx
+++ b/src/components/Player/VolumeSliders.tsx
@@ -31,10 +31,12 @@ const STEM_POPUP_RAIL_TRAIL_CLASS = "mr-[14px]";
 
 interface VolumeSlidersProps {
   density?: PlaybackBarDensity;
+  previewMode?: boolean;
 }
 
 export function VolumeSliders({
   density = "relaxed",
+  previewMode = false,
 }: VolumeSlidersProps = {}) {
   const { t } = useTranslation();
   const snapshot = usePlayerStore((s) => s.snapshot);
@@ -334,6 +336,7 @@ export function VolumeSliders({
   const fourStemPopupRows = (
     <div className="flex flex-col gap-2">
       <StemSlider
+        previewInteractive={previewMode}
         icon={Drum}
         label={t("stems.drums")}
         value={stemVolumes.drums}
@@ -343,6 +346,7 @@ export function VolumeSliders({
         iconButtonVariant="playback_bar"
       />
       <StemSlider
+        previewInteractive={previewMode}
         icon={Guitar}
         label={t("stems.bass")}
         value={stemVolumes.bass}
@@ -352,6 +356,7 @@ export function VolumeSliders({
         iconButtonVariant="playback_bar"
       />
       <StemSlider
+        previewInteractive={previewMode}
         icon={AudioWaveform}
         label={t("stems.other")}
         value={stemVolumes.other}
@@ -366,6 +371,7 @@ export function VolumeSliders({
   const tightPopupRows = (
     <div className="flex flex-col gap-2">
       <StemSlider
+        previewInteractive={previewMode}
         icon={Mic2}
         label={t("stems.vocals")}
         value={stemVolumes.vocals}
@@ -376,6 +382,7 @@ export function VolumeSliders({
         playbackActionName="vocals-mute"
       />
       <StemSlider
+        previewInteractive={previewMode}
         icon={Music}
         label={t("stems.accompaniment")}
         value={accompDragValue ?? accompValue}
@@ -391,6 +398,7 @@ export function VolumeSliders({
         <>
           <div className="h-px bg-[color-mix(in_srgb,var(--color-border)_85%,transparent)]" />
           <StemSlider
+            previewInteractive={previewMode}
             icon={Drum}
             label={t("stems.drums")}
             value={stemVolumes.drums}
@@ -400,6 +408,7 @@ export function VolumeSliders({
             iconButtonVariant="playback_bar"
           />
           <StemSlider
+            previewInteractive={previewMode}
             icon={Guitar}
             label={t("stems.bass")}
             value={stemVolumes.bass}
@@ -409,6 +418,7 @@ export function VolumeSliders({
             iconButtonVariant="playback_bar"
           />
           <StemSlider
+            previewInteractive={previewMode}
             icon={AudioWaveform}
             label={t("stems.other")}
             value={stemVolumes.other}
@@ -429,6 +439,7 @@ export function VolumeSliders({
             ref={popupRef}
             data-state="open"
             data-stem-popup="true"
+            data-preview-playback-interactive={previewMode ? "true" : undefined}
             className={popupSurfaceClassName}
             style={{ left: popupPos.left, bottom: popupPos.bottom }}
           >
@@ -440,7 +451,11 @@ export function VolumeSliders({
 
   if (collapsedMode) {
     return (
-      <div ref={tightAnchorRef} className="relative shrink-0">
+      <div
+        ref={tightAnchorRef}
+        className="relative shrink-0"
+        data-preview-playback-interactive={previewMode ? "true" : undefined}
+      >
         <Tooltip label={triggerLabel}>
           <button
             ref={triggerRef}
@@ -476,8 +491,10 @@ export function VolumeSliders({
       className={`flex items-center ${
         density === "relaxed" ? "gap-5" : "gap-3"
       }`}
+      data-preview-playback-interactive={previewMode ? "true" : undefined}
     >
       <StemSlider
+        previewInteractive={previewMode}
         icon={Mic2}
         label={t("stems.vocals")}
         value={stemVolumes.vocals}
@@ -491,6 +508,7 @@ export function VolumeSliders({
 
       <div className="flex items-center gap-2">
         <StemSlider
+          previewInteractive={previewMode}
           icon={Music}
           label={t("stems.accompaniment")}
           value={accompDragValue ?? accompValue}
@@ -545,6 +563,7 @@ interface StemSliderProps {
   disabled?: boolean;
   sliderWidthClass?: string;
   muteButtonRef?: React.RefObject<HTMLButtonElement | null>;
+  previewInteractive?: boolean;
 }
 
 export function StemSlider({
@@ -561,6 +580,7 @@ export function StemSlider({
   disabled = false,
   sliderWidthClass = "w-16 mr-[14px]",
   muteButtonRef,
+  previewInteractive = false,
 }: StemSliderProps) {
   const { t } = useTranslation();
   const muteLabel =
@@ -606,6 +626,7 @@ export function StemSlider({
           disabled={disabled}
           widthClass={sliderWidthClass}
           ariaLabel={label}
+          previewInteractive={previewInteractive}
         />
       </div>
     );
@@ -641,6 +662,7 @@ export function StemSlider({
         disabled={disabled}
         widthClass={sliderWidthClass}
         ariaLabel={label}
+        previewInteractive={previewInteractive}
       />
     </div>
   );

--- a/src/hooks/use-lyrics-engine.ts
+++ b/src/hooks/use-lyrics-engine.ts
@@ -1,7 +1,13 @@
 import { useEffect, useLayoutEffect, useRef, type RefObject } from "react";
-import { getScrollTopForLineIndex } from "@/components/Lyrics/lyrics-scroll";
+import {
+  FOCUS_ALIGN_POSITION,
+  LIST_ALIGN_POSITION,
+  getScrollTopForLineIndex,
+} from "@/components/Lyrics/lyrics-scroll";
 import { findActiveLyricLineIndex } from "@/lib/lyrics-timing";
 import {
+  beginUserLineSnap,
+  beginUserLineStep,
   createUserScrollGuard,
   shouldRunLyricsEngineLoop,
   tickLyricsEngineFrame,
@@ -64,7 +70,10 @@ export function useLyricsEngine(input: {
     prevActiveIndexRef: { current: -1 },
     prevAdjustedMsRef: { current: null },
     lastResumeGenerationRef: { current: 0 },
+    userSnapTopRef: { current: null },
   });
+  const focusStageRef = useRef(focusStage);
+  focusStageRef.current = focusStage;
   const lastSeekRevisionRef = useRef(usePlayerStore.getState().seekRevision);
   const engineSongIdRef = useRef<string | null | undefined>(undefined);
 
@@ -77,10 +86,44 @@ export function useLyricsEngine(input: {
       return;
     }
 
+    const alignPosition = () =>
+      focusStageRef.current ? FOCUS_ALIGN_POSITION : LIST_ALIGN_POSITION;
+    const prefersReducedMotion = () =>
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
     const guard = createUserScrollGuard(container, USER_SCROLL_PAUSE_MS, {
       scrollControl: session.scroll,
       onActiveChange: (active) => {
         onUserScrollActiveChangeRef.current?.(active);
+      },
+      onUserGesture: () => {
+        const snap = scrollStateRef.current.userSnapTopRef;
+        if (snap) {
+          snap.current = null;
+        }
+      },
+      onCoast: ({ scrollTop, velocityPxPerSec }) => {
+        beginUserLineSnap({
+          container,
+          scrollState: scrollStateRef.current,
+          lineCount: session.getState().lines.length,
+          alignPosition: alignPosition(),
+          position: scrollTop,
+          velocityPxPerSec,
+          reducedMotion: prefersReducedMotion(),
+        });
+      },
+      onDiscreteStep: (direction) => {
+        beginUserLineStep({
+          container,
+          scrollState: scrollStateRef.current,
+          lineCount: session.getState().lines.length,
+          alignPosition: alignPosition(),
+          position: container.scrollTop,
+          direction,
+          reducedMotion: prefersReducedMotion(),
+        });
       },
     });
     guardRef.current = guard;
@@ -137,7 +180,11 @@ export function useLyricsEngine(input: {
       const activeIndex = findActiveLyricLineIndex(lines, adjustedMs);
       const measuredTarget =
         previousSongId != null && container && activeIndex >= 0
-          ? getScrollTopForLineIndex(container, activeIndex)
+          ? getScrollTopForLineIndex(
+              container,
+              activeIndex,
+              focusStage ? FOCUS_ALIGN_POSITION : undefined,
+            )
           : null;
       const nextTop = measuredTarget ?? 0;
       scrollSpring.jumpTo(nextTop);
@@ -251,6 +298,7 @@ export function useLyricsEngine(input: {
       const target = getScrollTopForLineIndex(
         currentContainer,
         activeLineIndex,
+        focusStage ? FOCUS_ALIGN_POSITION : undefined,
       );
       if (target === null) {
         return;
@@ -296,5 +344,5 @@ export function useLyricsEngine(input: {
       }
       observer.disconnect();
     };
-  }, [containerRef, isPlainText, session, viewportActive, songId]);
+  }, [containerRef, focusStage, isPlainText, session, viewportActive, songId]);
 }

--- a/src/lib/i18n-language.test.ts
+++ b/src/lib/i18n-language.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import { createLanguageTable } from "./i18n-language";
+
+function setNavigatorLanguage(value: string): void {
+  Object.defineProperty(navigator, "language", {
+    value,
+    configurable: true,
+  });
+}
+
+describe("createLanguageTable", () => {
+  it("keeps only loaded codes and preserves the product order", () => {
+    const { SUPPORTED_LANGUAGES } = createLanguageTable([
+      "zh-CN",
+      "en",
+      "xx",
+      "ja",
+    ]);
+    expect(SUPPORTED_LANGUAGES.map((language) => language.code)).toEqual([
+      "en",
+      "zh-CN",
+      "ja",
+    ]);
+  });
+
+  it("falls back within the loaded landing pair", () => {
+    const { detectSystemLanguage } = createLanguageTable(["en", "zh-CN"]);
+    setNavigatorLanguage("zh-TW");
+    expect(detectSystemLanguage()).toBe("zh-CN");
+    setNavigatorLanguage("ja-JP");
+    expect(detectSystemLanguage()).toBe("en");
+  });
+});

--- a/src/lib/i18n-language.test.ts
+++ b/src/lib/i18n-language.test.ts
@@ -32,4 +32,10 @@ describe("createLanguageTable", () => {
     setNavigatorLanguage("ja-JP");
     expect(detectSystemLanguage()).toBe("en");
   });
+
+  it("keeps a persisted language only when the table loaded it", () => {
+    const { resolveAppLanguage } = createLanguageTable(["en", "zh-CN"]);
+    expect(resolveAppLanguage("zh-CN", () => "en")).toBe("zh-CN");
+    expect(resolveAppLanguage("ja", () => "en")).toBe("en");
+  });
 });

--- a/src/lib/i18n-language.ts
+++ b/src/lib/i18n-language.ts
@@ -1,0 +1,100 @@
+export const LANGUAGE_PRIORITY = [
+  "en",
+  "zh-CN",
+  "ja",
+  "ko",
+  "zh-TW",
+  "es",
+  "pt-BR",
+  "fr",
+  "de",
+  "it",
+  "ru",
+  "id",
+  "vi",
+  "th",
+  "tr",
+  "pl",
+  "nl",
+] as const;
+
+export type SupportedLanguageCode = (typeof LANGUAGE_PRIORITY)[number];
+export type SupportedLanguageNameKey = `languageNames.${SupportedLanguageCode}`;
+
+export interface SupportedLanguage {
+  code: SupportedLanguageCode;
+  nameKey: SupportedLanguageNameKey;
+}
+
+function isSupportedLanguageCode(code: string): code is SupportedLanguageCode {
+  return (LANGUAGE_PRIORITY as readonly string[]).includes(code);
+}
+
+function orderIndex(code: SupportedLanguageCode): number {
+  const index = LANGUAGE_PRIORITY.indexOf(code);
+  return index === -1 ? Number.POSITIVE_INFINITY : index;
+}
+
+export function createLanguageTable(loadedCodes: readonly string[]): {
+  SUPPORTED_LANGUAGES: SupportedLanguage[];
+  detectSystemLanguage: () => string;
+  resolveAppLanguage: (
+    persistedLanguage: string | null | undefined,
+    detectSystem?: () => string,
+  ) => string;
+} {
+  const SUPPORTED_LANGUAGES = loadedCodes
+    .filter(isSupportedLanguageCode)
+    .sort((a, b) => orderIndex(a) - orderIndex(b) || a.localeCompare(b))
+    .map((code) => ({
+      code,
+      nameKey: `languageNames.${code}` as SupportedLanguageNameKey,
+    }));
+
+  function detectSystemLanguage(): string {
+    const nav = navigator.language;
+    const supported = new Set<string>(SUPPORTED_LANGUAGES.map((l) => l.code));
+
+    if (supported.has(nav)) return nav;
+
+    const parts = nav.toLowerCase().split("-");
+    const base = parts[0];
+
+    if (base === "zh") {
+      const traditional =
+        parts.includes("hant") ||
+        parts.some((p) => p === "tw" || p === "hk" || p === "mo");
+      const preferred = traditional ? "zh-TW" : "zh-CN";
+      if (supported.has(preferred)) return preferred;
+      if (supported.has("zh-CN")) return "zh-CN";
+      if (supported.has("zh-TW")) return "zh-TW";
+    }
+
+    if (base === "pt" && supported.has("pt-BR")) return "pt-BR";
+
+    if (supported.has(base)) return base;
+    const shared = SUPPORTED_LANGUAGES.find(
+      (l) => l.code.toLowerCase().split("-")[0] === base,
+    );
+    return shared?.code ?? "en";
+  }
+
+  function resolveAppLanguage(
+    persistedLanguage: string | null | undefined,
+    detectSystem: () => string = detectSystemLanguage,
+  ): string {
+    if (typeof persistedLanguage === "string") {
+      const trimmed = persistedLanguage.trim();
+      if (trimmed.length > 0) {
+        return trimmed;
+      }
+    }
+    return detectSystem();
+  }
+
+  return {
+    SUPPORTED_LANGUAGES,
+    detectSystemLanguage,
+    resolveAppLanguage,
+  };
+}

--- a/src/lib/i18n-language.ts
+++ b/src/lib/i18n-language.ts
@@ -85,7 +85,10 @@ export function createLanguageTable(loadedCodes: readonly string[]): {
   ): string {
     if (typeof persistedLanguage === "string") {
       const trimmed = persistedLanguage.trim();
-      if (trimmed.length > 0) {
+      if (
+        trimmed.length > 0 &&
+        SUPPORTED_LANGUAGES.some((language) => language.code === trimmed)
+      ) {
         return trimmed;
       }
     }

--- a/src/lib/lyrics-engine.test.ts
+++ b/src/lib/lyrics-engine.test.ts
@@ -4,6 +4,8 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { LyricsScrollControl } from "@/lib/lyrics-session";
 import { Spring } from "@/lib/spring";
 import {
+  beginUserLineSnap,
+  COAST_SETTLE_MS,
   computeLineChangeLyricsScrollTop,
   createUserScrollGuard,
   isLyricsPlaybackSeekJump,
@@ -213,6 +215,47 @@ describe("createUserScrollGuard", () => {
 
     guard.destroy();
   });
+
+  test("coasts into a snap sample after the flick settles", () => {
+    const onCoast = vi.fn();
+    const container = makeContainer();
+    const guard = createUserScrollGuard(container, PAUSE_MS, {
+      scrollControl,
+      onCoast,
+    });
+
+    container.scrollTop = 140;
+    container.dispatchEvent(new WheelEvent("wheel", { deltaY: 40 }));
+    expect(onCoast).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(COAST_SETTLE_MS);
+    expect(onCoast).toHaveBeenCalledWith({
+      scrollTop: 140,
+      velocityPxPerSec: expect.any(Number),
+    });
+
+    guard.destroy();
+  });
+
+  test("turns a discrete wheel notch into a one-line step", () => {
+    const onDiscreteStep = vi.fn();
+    const container = makeContainer();
+    const guard = createUserScrollGuard(container, PAUSE_MS, {
+      scrollControl,
+      onDiscreteStep,
+    });
+
+    const event = new WheelEvent("wheel", {
+      deltaY: 3,
+      deltaMode: WheelEvent.DOM_DELTA_LINE,
+      cancelable: true,
+    });
+    container.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+    expect(onDiscreteStep).toHaveBeenCalledWith(1);
+
+    guard.destroy();
+  });
 });
 
 describe("isLyricsPlaybackSeekJump", () => {
@@ -297,6 +340,7 @@ describe("tickLyricsEngineScroll", () => {
       prevActiveIndexRef: { current: 0 },
       prevAdjustedMsRef: { current: 0 as number | null },
       lastResumeGenerationRef: { current: 0 },
+      userSnapTopRef: { current: null as number | null },
     };
 
     return { container, scrollSpring, scrollState };
@@ -645,6 +689,36 @@ describe("tickLyricsEngineScroll", () => {
     expect(container.scrollTop).toBe(170);
   });
 
+  test("springs to a user snap target while follow is still unlocked", () => {
+    const { container, scrollSpring, scrollState } = makeScrollFixture();
+    scrollState.userSnapTopRef = { current: 170 };
+    scrollState.prevAdjustedMsRef.current = 15000;
+    scrollState.prevActiveIndexRef.current = 1;
+    scrollSpring.syncPosition(80);
+    scrollSpring.setTarget(170);
+    container.scrollTop = 80;
+
+    tickLyricsEngineScroll({
+      container,
+      lines: [{ time_ms: 0 }, { time_ms: 15000 }],
+      adjustedMs: 15000,
+      scrollState,
+      scrollControl,
+      userScrollGuard: {
+        isActive: () => true,
+        clear: () => {},
+        withProgrammatic: (fn) => fn(),
+        unlockWithIdleRelock: () => {},
+        destroy: () => {},
+      },
+      reducedMotion: true,
+      dt: 0.016,
+    });
+
+    expect(container.scrollTop).toBe(170);
+    expect(scrollSpring.getPosition()).toBe(170);
+  });
+
   test("does not overwrite scrollTop while the user has unlocked follow", () => {
     const { container, scrollSpring, scrollState } = makeScrollFixture();
     scrollSpring.jumpTo(0);
@@ -669,6 +743,22 @@ describe("tickLyricsEngineScroll", () => {
     });
 
     expect(container.scrollTop).toBe(180);
+  });
+
+  test("beginUserLineSnap lands a flick on the projected line", () => {
+    const { container, scrollSpring, scrollState } = makeScrollFixture();
+    scrollState.userSnapTopRef = { current: null };
+    beginUserLineSnap({
+      container,
+      scrollState,
+      lineCount: 2,
+      position: 40,
+      velocityPxPerSec: 900,
+      reducedMotion: false,
+    });
+    expect(scrollState.userSnapTopRef.current).toBe(170);
+    expect(scrollSpring.getVelocity()).toBe(900);
+    expect(scrollSpring.isSettled()).toBe(false);
   });
 
   test("idle relock resume snaps scrollTop back while the active line is unchanged", () => {

--- a/src/lib/lyrics-engine.test.ts
+++ b/src/lib/lyrics-engine.test.ts
@@ -237,6 +237,40 @@ describe("createUserScrollGuard", () => {
     guard.destroy();
   });
 
+  test("drops leftover flick velocity after a long sample gap", () => {
+    let now = 1_000;
+    vi.spyOn(performance, "now").mockImplementation(() => now);
+    const onCoast = vi.fn();
+    const container = makeContainer();
+    const guard = createUserScrollGuard(container, PAUSE_MS, {
+      scrollControl,
+      onCoast,
+    });
+
+    container.scrollTop = 0;
+    container.dispatchEvent(new Event("scroll"));
+    now += 16;
+    container.scrollTop = 80;
+    container.dispatchEvent(new Event("scroll"));
+    container.dispatchEvent(new WheelEvent("wheel", { deltaY: 40 }));
+    vi.advanceTimersByTime(COAST_SETTLE_MS);
+    expect(onCoast.mock.calls[0]?.[0].velocityPxPerSec).toBeGreaterThan(0);
+
+    onCoast.mockClear();
+    now += 200;
+    container.scrollTop = 88;
+    container.dispatchEvent(new WheelEvent("wheel", { deltaY: 8 }));
+    container.dispatchEvent(new Event("scroll"));
+    vi.advanceTimersByTime(COAST_SETTLE_MS);
+    expect(onCoast).toHaveBeenCalledWith({
+      scrollTop: 88,
+      velocityPxPerSec: 0,
+    });
+
+    vi.restoreAllMocks();
+    guard.destroy();
+  });
+
   test("turns a discrete wheel notch into a one-line step", () => {
     const onDiscreteStep = vi.fn();
     const container = makeContainer();

--- a/src/lib/lyrics-engine.ts
+++ b/src/lib/lyrics-engine.ts
@@ -1,4 +1,10 @@
-import { getScrollTopForLineIndex } from "@/components/Lyrics/lyrics-scroll";
+import {
+  FOCUS_ALIGN_POSITION,
+  collectLineSnapScrollTops,
+  getScrollTopForLineIndex,
+  resolveLyricScrollLanding,
+  stepLineSnapScrollTop,
+} from "@/components/Lyrics/lyrics-scroll";
 import type { LyricsLineRuntime } from "@/lib/lyrics-line-runtime";
 import type { LyricsScrollControl, LyricsSession } from "@/lib/lyrics-session";
 import { findActiveLyricLineIndex } from "@/lib/lyrics-timing";
@@ -6,8 +12,14 @@ import type { Spring } from "@/lib/spring";
 
 const USER_SCROLL_PAUSE_MS = 4000;
 const SEEK_JUMP_MS = 400;
+const COAST_SETTLE_MS = 64;
 
-export { USER_SCROLL_PAUSE_MS, SEEK_JUMP_MS };
+export { USER_SCROLL_PAUSE_MS, SEEK_JUMP_MS, COAST_SETTLE_MS };
+
+export interface LyricScrollCoastSample {
+  scrollTop: number;
+  velocityPxPerSec: number;
+}
 
 export interface UserScrollGuard {
   isActive: () => boolean;
@@ -28,6 +40,9 @@ export function createUserScrollGuard(
     };
     onActiveChange?: (active: boolean) => void;
     onIdleRelock?: () => void;
+    onCoast?: (sample: LyricScrollCoastSample) => void;
+    onDiscreteStep?: (direction: 1 | -1) => void;
+    onUserGesture?: () => void;
   },
 ): UserScrollGuard {
   const scrollControl = options.scrollControl;
@@ -38,12 +53,20 @@ export function createUserScrollGuard(
   const onActiveChange = options.onActiveChange;
   const onIdleRelock =
     options.onIdleRelock ?? (() => scrollControl.requestResume());
+  const onCoast = options.onCoast;
+  const onDiscreteStep = options.onDiscreteStep;
+  const onUserGesture = options.onUserGesture;
 
   let unlocked = false;
   let programmaticDepth = 0;
   let pointerDown = false;
   let lastProgrammaticScrollTop = container.scrollTop;
   let timer: ReturnType<typeof setTimeout> | null = null;
+  let coastTimer: ReturnType<typeof setTimeout> | null = null;
+  let lastSampleTop = container.scrollTop;
+  let lastSampleAt = 0;
+  let velocityPxPerSec = 0;
+  let coastConsumed = false;
 
   const setUnlocked = (next: boolean) => {
     if (unlocked === next) {
@@ -66,19 +89,68 @@ export function createUserScrollGuard(
     if (scrollControl.isUnlockSuppressed()) {
       return;
     }
+    onUserGesture?.();
+    coastConsumed = false;
     setUnlocked(true);
     armIdleRelock();
   };
 
-  const onScroll = () => {
-    if (programmaticDepth > 0) {
+  const clearCoast = () => {
+    if (coastTimer !== null) {
+      timers.clearTimeout(coastTimer);
+      coastTimer = null;
+    }
+  };
+
+  const emitCoast = () => {
+    coastTimer = null;
+    if (!unlocked || pointerDown || scrollControl.isUnlockSuppressed()) {
       return;
     }
+    coastConsumed = true;
+    onCoast?.({
+      scrollTop: container.scrollTop,
+      velocityPxPerSec,
+    });
+  };
+
+  const scheduleCoast = () => {
+    if (!onCoast) {
+      return;
+    }
+    clearCoast();
+    coastTimer = timers.setTimeout(emitCoast, COAST_SETTLE_MS);
+  };
+
+  const sampleVelocity = () => {
+    const now =
+      typeof performance !== "undefined" ? performance.now() : Date.now();
+    const dtMs = lastSampleAt === 0 ? 0 : now - lastSampleAt;
+    if (dtMs > 0 && dtMs < 120) {
+      const instant = ((container.scrollTop - lastSampleTop) / dtMs) * 1000;
+      velocityPxPerSec = velocityPxPerSec * 0.55 + instant * 0.45;
+    }
+    lastSampleTop = container.scrollTop;
+    lastSampleAt = now;
+  };
+
+  const onScroll = () => {
+    if (programmaticDepth > 0) {
+      lastSampleTop = container.scrollTop;
+      lastSampleAt =
+        typeof performance !== "undefined" ? performance.now() : Date.now();
+      return;
+    }
+    sampleVelocity();
     if (Math.abs(container.scrollTop - lastProgrammaticScrollTop) < 1) {
       return;
     }
     if (pointerDown) {
       unlockFromUser();
+      return;
+    }
+    if (unlocked && !coastConsumed) {
+      scheduleCoast();
     }
   };
 
@@ -86,7 +158,18 @@ export function createUserScrollGuard(
     if (event.deltaY === 0 && event.deltaX === 0) {
       return;
     }
+    const discrete =
+      event.deltaMode === WheelEvent.DOM_DELTA_LINE ||
+      event.deltaMode === WheelEvent.DOM_DELTA_PAGE;
+    if (discrete && onDiscreteStep) {
+      event.preventDefault();
+      unlockFromUser();
+      const direction: 1 | -1 = event.deltaY < 0 ? -1 : 1;
+      onDiscreteStep(direction);
+      return;
+    }
     unlockFromUser();
+    scheduleCoast();
   };
 
   const onTouchMove = () => {
@@ -95,14 +178,21 @@ export function createUserScrollGuard(
 
   const onPointerDown = () => {
     pointerDown = true;
+    clearCoast();
   };
 
   const onPointerUp = () => {
+    if (!pointerDown) {
+      return;
+    }
     pointerDown = false;
+    if (unlocked && !coastConsumed) {
+      scheduleCoast();
+    }
   };
 
   container.addEventListener("scroll", onScroll, { passive: true });
-  container.addEventListener("wheel", onWheel, { passive: true });
+  container.addEventListener("wheel", onWheel, { passive: false });
   container.addEventListener("touchmove", onTouchMove, { passive: true });
   container.addEventListener("pointerdown", onPointerDown, { passive: true });
   window.addEventListener("pointerup", onPointerUp, { passive: true });
@@ -113,6 +203,9 @@ export function createUserScrollGuard(
     clear: () => {
       if (timer !== null) timers.clearTimeout(timer);
       timer = null;
+      clearCoast();
+      velocityPxPerSec = 0;
+      coastConsumed = false;
       setUnlocked(false);
     },
     unlockWithIdleRelock: () => {
@@ -135,8 +228,10 @@ export function createUserScrollGuard(
       window.removeEventListener("pointerup", onPointerUp);
       window.removeEventListener("pointercancel", onPointerUp);
       if (timer !== null) timers.clearTimeout(timer);
+      clearCoast();
       pointerDown = false;
       unlocked = false;
+      velocityPxPerSec = 0;
     },
   };
 }
@@ -145,6 +240,7 @@ export function computeLineChangeLyricsScrollTop(
   container: HTMLElement,
   lines: { time_ms: number }[],
   adjustedMs: number,
+  alignPosition?: number,
 ): number | null {
   if (lines.length === 0) {
     return null;
@@ -152,10 +248,10 @@ export function computeLineChangeLyricsScrollTop(
 
   const activeIndex = findActiveLyricLineIndex(lines, adjustedMs);
   if (activeIndex < 0) {
-    return getScrollTopForLineIndex(container, 0);
+    return getScrollTopForLineIndex(container, 0, alignPosition);
   }
 
-  return getScrollTopForLineIndex(container, activeIndex);
+  return getScrollTopForLineIndex(container, activeIndex, alignPosition);
 }
 
 export function isLyricsPlaybackSeekJump(
@@ -170,6 +266,70 @@ export function isLyricsPlaybackSeekJump(
   // 2× realtime + slack for timer jitter / IPC catch-up.
   const maxNaturalAdvanceMs = dtSeconds * 1000 * 2 + 50;
   return delta > Math.max(SEEK_JUMP_MS, maxNaturalAdvanceMs);
+}
+
+export function beginUserLineSnap(input: {
+  container: HTMLElement;
+  scrollState: LyricsEngineScrollState;
+  lineCount: number;
+  alignPosition?: number;
+  position: number;
+  velocityPxPerSec: number;
+  reducedMotion: boolean;
+}): void {
+  const snaps = collectLineSnapScrollTops(
+    input.container,
+    input.lineCount,
+    input.alignPosition,
+  );
+  const landing = resolveLyricScrollLanding(
+    snaps,
+    input.position,
+    input.velocityPxPerSec,
+  );
+  if (landing === null || !input.scrollState.userSnapTopRef) {
+    return;
+  }
+  input.scrollState.userSnapTopRef.current = landing;
+  if (
+    input.reducedMotion ||
+    (Math.abs(landing - input.position) < 0.5 &&
+      Math.abs(input.velocityPxPerSec) < 12)
+  ) {
+    input.scrollState.scrollSpring.jumpTo(landing);
+    return;
+  }
+  input.scrollState.scrollSpring.syncPosition(input.position);
+  input.scrollState.scrollSpring.setVelocity(input.velocityPxPerSec);
+  input.scrollState.scrollSpring.setTarget(landing);
+}
+
+export function beginUserLineStep(input: {
+  container: HTMLElement;
+  scrollState: LyricsEngineScrollState;
+  lineCount: number;
+  alignPosition?: number;
+  position: number;
+  direction: 1 | -1;
+  reducedMotion: boolean;
+}): void {
+  const snaps = collectLineSnapScrollTops(
+    input.container,
+    input.lineCount,
+    input.alignPosition,
+  );
+  const landing = stepLineSnapScrollTop(snaps, input.position, input.direction);
+  if (landing === null || !input.scrollState.userSnapTopRef) {
+    return;
+  }
+  input.scrollState.userSnapTopRef.current = landing;
+  if (input.reducedMotion || Math.abs(landing - input.position) < 0.5) {
+    input.scrollState.scrollSpring.jumpTo(landing);
+    return;
+  }
+  input.scrollState.scrollSpring.syncPosition(input.position);
+  input.scrollState.scrollSpring.setVelocity(0);
+  input.scrollState.scrollSpring.setTarget(landing);
 }
 
 function bindSpringToViewport(
@@ -188,6 +348,7 @@ export interface LyricsEngineScrollState {
   prevActiveIndexRef: { current: number };
   prevAdjustedMsRef: { current: number | null };
   lastResumeGenerationRef: { current: number };
+  userSnapTopRef?: { current: number | null };
 }
 
 export function tickLyricsEngineScroll(input: {
@@ -201,6 +362,7 @@ export function tickLyricsEngineScroll(input: {
   reducedMotion: boolean;
   dt: number;
   audienceMode?: boolean;
+  alignPosition?: number;
 }): void {
   const {
     container,
@@ -213,6 +375,7 @@ export function tickLyricsEngineScroll(input: {
     reducedMotion,
     dt,
     audienceMode = false,
+    alignPosition,
   } = input;
   const {
     scrollSpring,
@@ -220,6 +383,7 @@ export function tickLyricsEngineScroll(input: {
     prevActiveIndexRef,
     prevAdjustedMsRef,
     lastResumeGenerationRef,
+    userSnapTopRef,
   } = scrollState;
 
   const seekJump = isLyricsPlaybackSeekJump(
@@ -239,22 +403,55 @@ export function tickLyricsEngineScroll(input: {
 
   const audienceSeekUnlock = isSeek && audienceMode && userScrollGuard !== null;
 
+  const writeScrollTop = (value: number) => {
+    if (userScrollGuard) {
+      userScrollGuard.withProgrammatic(() => {
+        container.scrollTop = value;
+      });
+    } else {
+      container.scrollTop = value;
+    }
+  };
+
   if (shouldResetScroll) {
     if (!audienceSeekUnlock) {
       userScrollGuard?.clear();
     }
     prevActiveIndexRef.current = -1;
     targetScrollTopRef.current = null;
+    if (userSnapTopRef) {
+      userSnapTopRef.current = null;
+    }
   }
 
   if (!audienceSeekUnlock && userScrollGuard?.isActive()) {
+    const userSnapTop = userSnapTopRef?.current ?? null;
+    if (userSnapTop !== null) {
+      if (reducedMotion) {
+        scrollSpring.jumpTo(userSnapTop);
+        writeScrollTop(userSnapTop);
+        targetScrollTopRef.current = userSnapTop;
+        return;
+      }
+      if (!scrollSpring.isSettled()) {
+        scrollSpring.update(dt);
+      }
+      writeScrollTop(scrollSpring.getPosition());
+      targetScrollTopRef.current = userSnapTop;
+      return;
+    }
     bindSpringToViewport(scrollSpring, container);
     targetScrollTopRef.current = container.scrollTop;
     return;
   }
 
   const activeIndex = findActiveLyricLineIndex(lines, adjustedMs);
-  const target = computeLineChangeLyricsScrollTop(container, lines, adjustedMs);
+  const target = computeLineChangeLyricsScrollTop(
+    container,
+    lines,
+    adjustedMs,
+    alignPosition,
+  );
 
   if (target === null) {
     if (shouldResetScroll) {
@@ -265,16 +462,6 @@ export function tickLyricsEngineScroll(input: {
     }
     return;
   }
-
-  const writeScrollTop = (value: number) => {
-    if (userScrollGuard) {
-      userScrollGuard.withProgrammatic(() => {
-        container.scrollTop = value;
-      });
-    } else {
-      container.scrollTop = value;
-    }
-  };
 
   if (reducedMotion || shouldResetScroll) {
     const snapTarget =
@@ -382,6 +569,7 @@ export function tickLyricsEngineFrame(input: LyricsEngineFrameInput): void {
     reducedMotion,
     dt,
     audienceMode,
+    alignPosition: focusStage ? FOCUS_ALIGN_POSITION : undefined,
   });
 }
 

--- a/src/lib/lyrics-engine.ts
+++ b/src/lib/lyrics-engine.ts
@@ -129,6 +129,8 @@ export function createUserScrollGuard(
     if (dtMs > 0 && dtMs < 120) {
       const instant = ((container.scrollTop - lastSampleTop) / dtMs) * 1000;
       velocityPxPerSec = velocityPxPerSec * 0.55 + instant * 0.45;
+    } else {
+      velocityPxPerSec = 0;
     }
     lastSampleTop = container.scrollTop;
     lastSampleAt = now;

--- a/src/lib/lyrics-focus-layout.ts
+++ b/src/lib/lyrics-focus-layout.ts
@@ -1,4 +1,4 @@
-export const FOCUS_LINE_GAP_PX = 24;
+export const FOCUS_LINE_GAP_PX = 16;
 export const FOCUS_HEAD_PAD_RATIO = 0.38;
 
 export function focusHeadPadPx(viewportHeight: number): number {

--- a/src/lib/lyrics-line-runtime.test.ts
+++ b/src/lib/lyrics-line-runtime.test.ts
@@ -8,8 +8,9 @@ describe("getLineVisualTargets", () => {
   test("focus stage makes the current line dominate neighbors", () => {
     expect(getLineVisualTargets(0, "focus").targetScale).toBe(1);
     expect(getLineVisualTargets(1, "focus").targetScale).toBe(0.97);
-    expect(getLineVisualTargets(0, "focus").targetOpacity).toBe(0.85);
+    expect(getLineVisualTargets(0, "focus").targetOpacity).toBe(1);
     expect(getLineVisualTargets(1, "focus").targetBlur).toBeGreaterThan(0);
+    expect(getLineVisualTargets(1, "focus").targetBlur).toBeLessThan(1);
     expect(getLineVisualTargets(0, "focus").targetBlur).toBe(0);
   });
 });

--- a/src/lib/lyrics-line-runtime.ts
+++ b/src/lib/lyrics-line-runtime.ts
@@ -22,14 +22,18 @@ export function getLineVisualTargets(
   targetBlur: number;
 } {
   if (distance === 0) {
-    return { targetScale: 1, targetOpacity: 0.85, targetBlur: 0 };
+    return { targetScale: 1, targetOpacity: 1, targetBlur: 0 };
+  }
+
+  if (stage === "focus") {
+    return {
+      targetScale: 0.97,
+      targetOpacity: 1,
+      targetBlur: Math.min(1.1, 0.22 * distance),
+    };
   }
 
   const blur = Math.min(5, 1 + distance);
-  if (stage === "focus") {
-    return { targetScale: 0.97, targetOpacity: 1, targetBlur: blur };
-  }
-
   const targetScale =
     distance === 1 ? 0.98 : Math.max(0.94, 1 - distance * 0.018);
   return { targetScale, targetOpacity: 1, targetBlur: blur };

--- a/src/lib/spring.test.ts
+++ b/src/lib/spring.test.ts
@@ -41,6 +41,16 @@ describe("Spring", () => {
     expect(spring.isSettled()).toBe(true);
   });
 
+  test("hands off a flick velocity from the current position", () => {
+    const spring = new Spring(10);
+    spring.syncPosition(40);
+    spring.setVelocity(200);
+    spring.setTarget(120);
+    expect(spring.getPosition()).toBe(40);
+    expect(spring.getVelocity()).toBe(200);
+    expect(spring.isSettled()).toBe(false);
+  });
+
   test("update is a no-op when settled", () => {
     const spring = new Spring(1);
     spring.setTarget(1);

--- a/src/lib/spring.ts
+++ b/src/lib/spring.ts
@@ -75,4 +75,16 @@ export class Spring {
     this.velocity = 0;
     this.settled = true;
   }
+
+  syncPosition(position: number) {
+    this.position = position;
+    this.settled = false;
+  }
+
+  setVelocity(velocity: number) {
+    this.velocity = velocity;
+    if (velocity !== 0) {
+      this.settled = false;
+    }
+  }
 }

--- a/src/mock/preview-songs.test.ts
+++ b/src/mock/preview-songs.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import {
   PREVIEW_LYRICS,
   PREVIEW_SONGS,
@@ -22,6 +22,12 @@ describe("shared preview catalog", () => {
       "one-last-kiss",
     ]);
     expect(PRIMARY_PREVIEW_SONG_HASH).toBe("earfquake");
+  });
+
+  test("keeps cover art on every preview song", () => {
+    for (const song of PREVIEW_SONGS) {
+      expect(song.has_cover_art, song.hash).toBe(true);
+    }
   });
 
   test("embeds AMLL word-timed lyrics for One Last Kiss", () => {
@@ -80,6 +86,56 @@ describe("preview playback start", () => {
       songId: "earfquake",
     })) as { position_ms: number };
     expect(snapshot.position_ms).toBe(12_000);
+  });
+
+  test("get_cover_art loads JPEG URLs when inline cover bytes are absent", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => new Uint8Array([255, 216, 255]).buffer,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    try {
+      const { internals } = createTauriMock({
+        ...E2E_MOCK_DATA,
+        songs: E2E_MOCK_DATA.songs.map((song) => ({
+          ...song,
+          cover_art: null,
+        })),
+        coverArtUrls: { earfquake: "/covers/earfquake.jpg" },
+      });
+      const bytes = (await internals.invoke("get_cover_art", {
+        hash: "earfquake",
+      })) as number[];
+      expect(fetchMock).toHaveBeenCalledWith("/covers/earfquake.jpg");
+      expect(bytes).toEqual([255, 216, 255]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  test("stemsCompleted records a finished four-stem job for every song", async () => {
+    const { internals } = createTauriMock({
+      ...E2E_MOCK_DATA,
+      stemsCompleted: true,
+    });
+    const statuses = (await internals.invoke(
+      "get_all_separation_statuses",
+    )) as Array<{
+      song_id: string;
+      state: string;
+      drums_path: string | null;
+      vocals_path: string | null;
+      bass_path: string | null;
+      other_path: string | null;
+    }>;
+    expect(statuses).toHaveLength(E2E_MOCK_DATA.songs.length);
+    for (const status of statuses) {
+      expect(status.state).toBe("completed");
+      expect(status.drums_path).toContain(status.song_id);
+      expect(status.vocals_path).toBeTruthy();
+      expect(status.bass_path).toBeTruthy();
+      expect(status.other_path).toBeTruthy();
+    }
   });
 
   test("e2e mock play still starts at zero", async () => {

--- a/src/mock/preview-songs.test.ts
+++ b/src/mock/preview-songs.test.ts
@@ -113,6 +113,49 @@ describe("preview playback start", () => {
     }
   });
 
+  test("get_cover_art returns null when the cover fetch or body fails", async () => {
+    const rejectFetch = vi.fn().mockRejectedValue(new Error("network"));
+    vi.stubGlobal("fetch", rejectFetch);
+    try {
+      const { internals } = createTauriMock({
+        ...E2E_MOCK_DATA,
+        songs: E2E_MOCK_DATA.songs.map((song) => ({
+          ...song,
+          cover_art: null,
+        })),
+        coverArtUrls: { earfquake: "/covers/earfquake.jpg" },
+      });
+      await expect(
+        internals.invoke("get_cover_art", { hash: "earfquake" }),
+      ).resolves.toBeNull();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+
+    const rejectBody = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => {
+        throw new Error("decode");
+      },
+    });
+    vi.stubGlobal("fetch", rejectBody);
+    try {
+      const { internals } = createTauriMock({
+        ...E2E_MOCK_DATA,
+        songs: E2E_MOCK_DATA.songs.map((song) => ({
+          ...song,
+          cover_art: null,
+        })),
+        coverArtUrls: { earfquake: "/covers/earfquake.jpg" },
+      });
+      await expect(
+        internals.invoke("get_cover_art", { hash: "earfquake" }),
+      ).resolves.toBeNull();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   test("stemsCompleted records a finished four-stem job for every song", async () => {
     const { internals } = createTauriMock({
       ...E2E_MOCK_DATA,
@@ -125,6 +168,7 @@ describe("preview playback start", () => {
       state: string;
       drums_path: string | null;
       vocals_path: string | null;
+      accomp_path: string | null;
       bass_path: string | null;
       other_path: string | null;
     }>;
@@ -133,6 +177,7 @@ describe("preview playback start", () => {
       expect(status.state).toBe("completed");
       expect(status.drums_path).toContain(status.song_id);
       expect(status.vocals_path).toBeTruthy();
+      expect(status.accomp_path).toBeTruthy();
       expect(status.bass_path).toBeTruthy();
       expect(status.other_path).toBeTruthy();
     }

--- a/src/mock/tauri-mock-impl.ts
+++ b/src/mock/tauri-mock-impl.ts
@@ -435,11 +435,15 @@ export function createTauriMock(data: any): TauriMockResult {
       if (!url || typeof fetch !== "function") {
         return null;
       }
-      const response = await fetch(url);
-      if (!response.ok) {
+      try {
+        const response = await fetch(url);
+        if (!response.ok) {
+          return null;
+        }
+        return Array.from(new Uint8Array(await response.arrayBuffer()));
+      } catch {
         return null;
       }
-      return Array.from(new Uint8Array(await response.arrayBuffer()));
     },
     get_playback_state: () => clone(currentPlaybackSnapshot),
     play: (args: any) => {

--- a/src/mock/tauri-mock-impl.ts
+++ b/src/mock/tauri-mock-impl.ts
@@ -51,6 +51,8 @@ export interface MockData {
   loopStartPositionMs?: number;
   playStartPositionMs?: number;
   playStartPositionBySongId?: Record<string, number>;
+  coverArtUrls?: Record<string, string>;
+  stemsCompleted?: boolean;
 }
 
 export interface MockSong {
@@ -134,6 +136,27 @@ export function createTauriMock(data: any): TauriMockResult {
   const playlistSongs = new Map<string, any[]>();
   const menuResources = new Map<number, any>();
   const separationStatuses: Record<string, any> = {};
+  function completedFourStemStatus(songHash: any) {
+    const stemDir = "/tmp/openkara-stems/" + songHash;
+    return {
+      song_id: songHash,
+      state: "completed",
+      percent: 100,
+      cache_hit: true,
+      vocals_path: stemDir + "/vocals.ogg",
+      accomp_path: stemDir + "/accomp.ogg",
+      drums_path: stemDir + "/drums.ogg",
+      bass_path: stemDir + "/bass.ogg",
+      other_path: stemDir + "/other.ogg",
+      model_variant: "htdemucs",
+      error: null,
+    };
+  }
+  if (data.stemsCompleted) {
+    for (const song of mockSongs) {
+      separationStatuses[song.hash] = completedFourStemStatus(song.hash);
+    }
+  }
   let nextPlaylistId = 1;
   let nextEventId = 1;
   let nextMenuRid = 1;
@@ -402,6 +425,22 @@ export function createTauriMock(data: any): TauriMockResult {
       recent_operations: [],
     }),
 
+    get_cover_art: async (args: any) => {
+      const hash = args && (args.hash || args.song_id || args.songId);
+      const song = mockSongs.find((entry: any) => entry.hash === hash);
+      if (song && song.cover_art && song.cover_art.length > 0) {
+        return clone(song.cover_art);
+      }
+      const url = hash ? (data.coverArtUrls || {})[hash] : null;
+      if (!url || typeof fetch !== "function") {
+        return null;
+      }
+      const response = await fetch(url);
+      if (!response.ok) {
+        return null;
+      }
+      return Array.from(new Uint8Array(await response.arrayBuffer()));
+    },
     get_playback_state: () => clone(currentPlaybackSnapshot),
     play: (args: any) => {
       const songId =

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -909,6 +909,26 @@
   -webkit-mask-repeat: no-repeat;
 }
 
+[data-lyrics-stage="focus"]:hover [data-lyrics-line-index] {
+  filter: none !important;
+}
+
+[data-testid="lyrics-scroll-viewport"] {
+  mask-image: linear-gradient(
+    to bottom,
+    transparent 0,
+    #000 2.5rem,
+    #000 calc(100% - 4.5rem),
+    transparent 100%
+  );
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-lyrics-stage="focus"] [data-lyrics-line-index] {
+    filter: none !important;
+  }
+}
+
 .marquee-active {
   animation: marquee-scroll 8s ease-in-out infinite;
   white-space: nowrap;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -913,8 +913,15 @@
   filter: none !important;
 }
 
-[data-testid="lyrics-scroll-viewport"] {
+[data-lyrics-viewport="true"] {
   mask-image: linear-gradient(
+    to bottom,
+    transparent 0,
+    #000 2.5rem,
+    #000 calc(100% - 4.5rem),
+    transparent 100%
+  );
+  -webkit-mask-image: linear-gradient(
     to bottom,
     transparent 0,
     #000 2.5rem,

--- a/tests/ci/website-preview-bundle-contract.test.ts
+++ b/tests/ci/website-preview-bundle-contract.test.ts
@@ -35,5 +35,6 @@ describe("website preview bundle contract", () => {
     expect(websiteVite).toContain("SettingsOverlay");
     expect(websiteVite).toContain("QueuePanel");
     expect(websiteVite).toContain("UpdateBanner");
+    expect(websiteVite).toContain("escapeRegExpLiteral");
   });
 });

--- a/tests/ci/website-preview-bundle-contract.test.ts
+++ b/tests/ci/website-preview-bundle-contract.test.ts
@@ -4,6 +4,12 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
 import { PREVIEW_SONGS } from "../../src/mock/preview-songs";
 import {
+  isPreviewCatalogModule,
+  slimPreviewCatalogSource,
+} from "../../website/src/slim-preview-catalog";
+import {
+  PREVIEW_I18N_MODULE_PATTERN,
+  PREVIEW_ROMANIZER_MODULE_PATTERN,
   UNUSED_PREVIEW_MODULES,
   previewUnusedModulePattern,
 } from "../../website/src/preview-aliases";
@@ -13,26 +19,38 @@ const websiteVite = readFileSync(
   join(projectRoot, "website/vite.config.ts"),
   "utf8",
 );
-const catalogSlim = readFileSync(
-  join(projectRoot, "website/src/slim-preview-catalog.ts"),
-  "utf8",
-);
 
 describe("website preview bundle contract", () => {
   test("aliases the romanizer to the preview stub", () => {
     expect(websiteVite).toContain("preview-romanizer.ts");
-    expect(websiteVite).toContain("@\\/lib\\/lyrics-romanizer");
+    expect(websiteVite).toContain("PREVIEW_ROMANIZER_MODULE_PATTERN");
+    expect(
+      PREVIEW_ROMANIZER_MODULE_PATTERN.test("@/lib/lyrics-romanizer"),
+    ).toBe(true);
+    expect(
+      PREVIEW_ROMANIZER_MODULE_PATTERN.test("@/lib/lyrics-romanizer/worker"),
+    ).toBe(false);
   });
 
   test("aliases i18n to the landing locale pair", () => {
     expect(websiteVite).toContain("preview-i18n.ts");
-    expect(websiteVite).toContain("@\\/lib\\/i18n");
+    expect(websiteVite).toContain("PREVIEW_I18N_MODULE_PATTERN");
+    expect(PREVIEW_I18N_MODULE_PATTERN.test("@/lib/i18n")).toBe(true);
+    expect(PREVIEW_I18N_MODULE_PATTERN.test("@/lib/i18n/extra")).toBe(false);
   });
 
   test("strips inline catalog payloads that the preview never edits", () => {
-    expect(websiteVite).toContain("slim-preview-catalog");
-    expect(catalogSlim).toContain("cover_art_base64");
-    expect(catalogSlim).toContain("raw_lrc");
+    expect(websiteVite).toContain("slimPreviewCatalogPlugin");
+    expect(isPreviewCatalogModule("/repo/src/mock/preview-songs.ts")).toBe(
+      true,
+    );
+    const slimed = slimPreviewCatalogSource(
+      'cover_art_base64: "/9j/4AAQ", raw_lrc: "[00:00.00] keep-me",',
+    );
+    expect(slimed).toContain('cover_art_base64: ""');
+    expect(slimed).toContain('raw_lrc: ""');
+    expect(slimed).not.toContain("/9j/");
+    expect(slimed).not.toContain("keep-me");
   });
 
   test("matches unused preview surfaces on their exact module ids", () => {

--- a/tests/ci/website-preview-bundle-contract.test.ts
+++ b/tests/ci/website-preview-bundle-contract.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const projectRoot = fileURLToPath(new URL("../..", import.meta.url));
+const websiteVite = readFileSync(
+  join(projectRoot, "website/vite.config.ts"),
+  "utf8",
+);
+const catalogSlim = readFileSync(
+  join(projectRoot, "website/src/slim-preview-catalog.ts"),
+  "utf8",
+);
+
+describe("website preview bundle contract", () => {
+  test("aliases the romanizer to the preview stub", () => {
+    expect(websiteVite).toContain("preview-romanizer.ts");
+    expect(websiteVite).toContain("@\\/lib\\/lyrics-romanizer");
+  });
+
+  test("aliases i18n to the landing locale pair", () => {
+    expect(websiteVite).toContain("preview-i18n.ts");
+    expect(websiteVite).toContain("@\\/lib\\/i18n");
+  });
+
+  test("strips inline catalog payloads that the preview never edits", () => {
+    expect(websiteVite).toContain("slim-preview-catalog");
+    expect(catalogSlim).toContain("cover_art_base64");
+    expect(catalogSlim).toContain("raw_lrc");
+  });
+
+  test("aliases unused preview surfaces to empty stubs", () => {
+    expect(websiteVite).toContain("preview-unused.ts");
+    expect(websiteVite).toContain("SettingsOverlay");
+    expect(websiteVite).toContain("QueuePanel");
+    expect(websiteVite).toContain("UpdateBanner");
+  });
+});

--- a/tests/ci/website-preview-bundle-contract.test.ts
+++ b/tests/ci/website-preview-bundle-contract.test.ts
@@ -1,7 +1,12 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
+import { PREVIEW_SONGS } from "../../src/mock/preview-songs";
+import {
+  UNUSED_PREVIEW_MODULES,
+  previewUnusedModulePattern,
+} from "../../website/src/preview-aliases";
 
 const projectRoot = fileURLToPath(new URL("../..", import.meta.url));
 const websiteVite = readFileSync(
@@ -30,11 +35,32 @@ describe("website preview bundle contract", () => {
     expect(catalogSlim).toContain("raw_lrc");
   });
 
-  test("aliases unused preview surfaces to empty stubs", () => {
+  test("matches unused preview surfaces on their exact module ids", () => {
     expect(websiteVite).toContain("preview-unused.ts");
-    expect(websiteVite).toContain("SettingsOverlay");
-    expect(websiteVite).toContain("QueuePanel");
-    expect(websiteVite).toContain("UpdateBanner");
-    expect(websiteVite).toContain("escapeRegExpLiteral");
+    expect(websiteVite).toContain("previewUnusedModulePattern");
+    for (const modulePath of UNUSED_PREVIEW_MODULES) {
+      const pattern = previewUnusedModulePattern(modulePath);
+      expect(pattern.test(`@/${modulePath}`), modulePath).toBe(true);
+      expect(pattern.test(`@/${modulePath}/extra`), modulePath).toBe(false);
+    }
+  });
+
+  test("ships a JPEG cover asset for every preview song hash", () => {
+    const previewCovers = readFileSync(
+      join(projectRoot, "website/src/preview-covers.ts"),
+      "utf8",
+    );
+    const appPreview = readFileSync(
+      join(projectRoot, "website/src/AppPreview.tsx"),
+      "utf8",
+    );
+    expect(previewCovers).toContain("../../src/mock/covers/*.jpg");
+    expect(appPreview).toContain("coverArtUrls: PREVIEW_COVER_URLS");
+    for (const song of PREVIEW_SONGS) {
+      expect(
+        existsSync(join(projectRoot, "src/mock/covers", `${song.hash}.jpg`)),
+        song.hash,
+      ).toBe(true);
+    }
   });
 });

--- a/tests/ci/website-preview-catalog-slim.test.ts
+++ b/tests/ci/website-preview-catalog-slim.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+import {
+  isPreviewCatalogModule,
+  slimPreviewCatalogSource,
+} from "../../website/src/slim-preview-catalog";
+
+describe("preview catalog slim", () => {
+  test("matches the generated catalog even with a Vite query suffix", () => {
+    expect(isPreviewCatalogModule("/repo/src/mock/preview-songs.ts")).toBe(
+      true,
+    );
+    expect(isPreviewCatalogModule("/repo/src/mock/preview-songs.ts?t=1")).toBe(
+      true,
+    );
+    expect(
+      isPreviewCatalogModule(String.raw`C:\repo\src\mock\preview-songs.ts`),
+    ).toBe(true);
+    expect(isPreviewCatalogModule("/repo/src/lib/i18n.ts")).toBe(false);
+  });
+
+  test("strips inline cover art and raw lyrics payloads", () => {
+    const slimed = slimPreviewCatalogSource(`
+      cover_art_base64: "/9j/4AAQSkZJRg==",
+      raw_lrc: '[00:00.39] For real\\n[00:05.79] this time',
+      raw_ttml: 'keep',
+    `);
+    expect(slimed).toContain('cover_art_base64: ""');
+    expect(slimed).toContain("raw_lrc: ''");
+    expect(slimed).toContain("raw_ttml: 'keep'");
+    expect(slimed).not.toContain("/9j/");
+    expect(slimed).not.toContain("For real");
+  });
+
+  test("strips a single-quoted TTML payload that contains escaped quotes", () => {
+    const slimed = slimPreviewCatalogSource(
+      "raw_lrc: '<tt>you\\'ll ever know</tt>',",
+    );
+    expect(slimed).toBe("raw_lrc: '',");
+  });
+});

--- a/tests/ci/website-preview-pointer-contract.test.ts
+++ b/tests/ci/website-preview-pointer-contract.test.ts
@@ -137,4 +137,49 @@ describe("website preview pointer contract", () => {
     expect(window.getComputedStyle(songSwitch).pointerEvents).not.toBe("none");
     expect(window.getComputedStyle(blocked).pointerEvents).toBe("none");
   });
+
+  test("playback slider stays clickable in the preview", () => {
+    const { window } = new JSDOM(
+      `<!doctype html>
+      <html>
+        <head><style>${siteCss}</style></head>
+        <body>
+          <div class="product-preview">
+            <div data-preview-interaction-mode="playlist-only">
+              <div role="slider" data-preview-playback-interactive="true"></div>
+              <input type="range" />
+            </div>
+          </div>
+        </body>
+      </html>`,
+      { pretendToBeVisual: true },
+    );
+    const slider = window.document.querySelector("[role='slider']");
+    const blocked = window.document.querySelector("input");
+    expect(slider).toBeTruthy();
+    expect(blocked).toBeTruthy();
+    expect(window.getComputedStyle(slider!).pointerEvents).not.toBe("none");
+    expect(window.getComputedStyle(blocked!).pointerEvents).toBe("none");
+  });
+
+  test("lyrics-interactive romanize control stays clickable in the preview", () => {
+    const { window } = new JSDOM(
+      `<!doctype html>
+      <html>
+        <head><style>${siteCss}</style></head>
+        <body>
+          <div class="product-preview">
+            <div data-preview-interaction-mode="playlist-only">
+              <button type="button" data-preview-lyrics-interactive="true">Romanize</button>
+              <button type="button">Separate</button>
+            </div>
+          </div>
+        </body>
+      </html>`,
+      { pretendToBeVisual: true },
+    );
+    const [romanize, blocked] = window.document.querySelectorAll("button");
+    expect(window.getComputedStyle(romanize).pointerEvents).not.toBe("none");
+    expect(window.getComputedStyle(blocked).pointerEvents).toBe("none");
+  });
 });

--- a/tests/ci/website-preview-romanizer.test.ts
+++ b/tests/ci/website-preview-romanizer.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "vitest";
+import { romanizeLyricsLines } from "../../website/src/preview-romanizer";
+
+describe("preview romanizer stub", () => {
+  test("returns the supplied lines without starting a worker", async () => {
+    const { result, requestId } = await romanizeLyricsLines(
+      ["忘れたくないこと"],
+      "japanese",
+    );
+    expect(result).toEqual(["忘れたくないこと"]);
+    expect(requestId).toBe(-1);
+  });
+});

--- a/tests/e2e/lyrics-follow.spec.ts
+++ b/tests/e2e/lyrics-follow.spec.ts
@@ -46,6 +46,25 @@ async function readScrollTop(page: import("@playwright/test").Page) {
   return page.locator(VIEWPORT).evaluate((el) => el.scrollTop);
 }
 
+async function waitForBrowseSnapSettle(
+  page: import("@playwright/test").Page,
+): Promise<number> {
+  // Browse scroll coasts, then snaps onto a line. Wait for that landing
+  // before asserting the viewport stays put.
+  await expect
+    .poll(
+      async () => {
+        const first = await readScrollTop(page);
+        await page.waitForTimeout(80);
+        const second = await readScrollTop(page);
+        return Math.abs(first - second) < 2 ? second : null;
+      },
+      { timeout: 1500, intervals: [80, 120, 200] },
+    )
+    .not.toBeNull();
+  return readScrollTop(page);
+}
+
 async function emitLayoutDrivenScroll(page: import("@playwright/test").Page) {
   await page.locator(VIEWPORT).evaluate((el) => {
     // Model the bare scroll event WKWebView can emit when active-line layout
@@ -234,11 +253,9 @@ test.describe("Lyrics auto-follow", () => {
 
     // State assertion (built-in retry): unlocking pins the Follow button.
     await expect(followButton).toHaveAttribute("data-visible", "true");
-    const unlockedTop = await readScrollTop(page);
+    const unlockedTop = await waitForBrowseSnapSettle(page);
     expect(unlockedTop).toBeGreaterThan(400);
 
-    // This bounded retry allows WebKit to settle one pending animation frame
-    // while remaining well inside the user's four-second browse window.
     await expect
       .poll(
         async () => Math.abs((await readScrollTop(page)) - unlockedTop) < 2,
@@ -280,7 +297,7 @@ test.describe("Lyrics auto-follow", () => {
 
     const followButton = page.locator("[data-testid='lyrics-follow-playing']");
     await expect(followButton).toHaveAttribute("data-visible", "true");
-    const unlockedTop = await readScrollTop(page);
+    const unlockedTop = await waitForBrowseSnapSettle(page);
     expect(unlockedTop).toBeGreaterThan(400);
 
     await expect(followButton).toHaveAttribute("data-visible", "false", {

--- a/tests/e2e/lyrics-visual-check.spec.ts
+++ b/tests/e2e/lyrics-visual-check.spec.ts
@@ -138,16 +138,27 @@ test.describe("Lyrics visual check", () => {
     await expect(first.getByText("人")).toBeVisible();
     await expect(wordRomans).toHaveCount(4);
 
-    const wipe = await page.evaluate(() => {
-      const fills = [
-        ...document.querySelectorAll<HTMLElement>(
-          "[data-lyrics-line-index='0'] [data-karaoke-fill]",
-        ),
-      ];
-      return fills.map(
-        (el) => el.style.webkitMaskPosition || el.style.maskPosition,
-      );
-    });
+    let wipe: string[] = [];
+    await expect
+      .poll(
+        async () => {
+          wipe = await page.evaluate(() => {
+            const fills = [
+              ...document.querySelectorAll<HTMLElement>(
+                "[data-lyrics-line-index='0'] [data-karaoke-fill]",
+              ),
+            ];
+            return fills.map(
+              (el) => el.style.webkitMaskPosition || el.style.maskPosition,
+            );
+          });
+          const first = wipe[0] ?? "";
+          const last = wipe[3] ?? "";
+          return first !== last && last.includes("-");
+        },
+        { timeout: 2000, intervals: [50, 80, 120] },
+      )
+      .toBe(true);
     expect(wipe[0] ?? "").not.toBe(wipe[3] ?? "");
     expect(wipe[3] ?? "").toContain("-");
     const boxes = await wordRomans.evaluateAll((nodes) =>

--- a/tests/e2e/lyrics.spec.ts
+++ b/tests/e2e/lyrics.spec.ts
@@ -61,6 +61,7 @@ test.describe("Lyrics display", () => {
 test.describe("AMLL preview song", () => {
   test("One Last Kiss plays Word-timed Japanese lyrics from the shared catalog", async ({
     page,
+    tauriMock,
   }) => {
     await page.goto("/");
     await expect(page.getByText("One Last Kiss")).toBeVisible();
@@ -69,6 +70,13 @@ test.describe("AMLL preview song", () => {
       timeout: 10_000,
     });
     await expect(page.getByText("忘れられない人").first()).toBeVisible();
+    // Karaoke fill only mounts on the active word-timed line. E2E play
+    // starts at 0, and the first sung line is at 20.686s.
+    await tauriMock.setPlaybackSnapshot({
+      is_playing: true,
+      state: "playing",
+      position_ms: 21_100,
+    });
     await expect(page.locator("[data-karaoke-fill]").first()).toBeVisible();
   });
 });

--- a/website/src/AppPreview.tsx
+++ b/website/src/AppPreview.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from "@/components/Overlay/Tooltip";
 import i18next from "@/lib/i18n";
 import { MOCK_DATA } from "@/mock/tauri-mock-data";
 import { createTauriMock } from "@/mock/tauri-mock-impl";
+import { PREVIEW_COVER_URLS } from "./preview-covers";
 import { useLayoutStore } from "@/stores/layout-store";
 import { usePlaylistStore } from "@/stores/playlist-store";
 import { useSettingsStore } from "@/stores/settings-store";
@@ -16,7 +17,23 @@ import type { PlaylistSong } from "@/lib/backend";
 // drift apart.
 function ensureTauriMock() {
   if (!window.__TAURI_INTERNALS__) {
-    const { internals, eventPluginInternals } = createTauriMock(MOCK_DATA);
+    const { internals, eventPluginInternals } = createTauriMock({
+      ...MOCK_DATA,
+      songs: MOCK_DATA.songs.map((song) => ({ ...song, cover_art: null })),
+      coverArtUrls: PREVIEW_COVER_URLS,
+      // Finished four-stem library. MOCK_DATA stays two_stem for E2E
+      // playback-bar geometry fixtures.
+      stemsCompleted: true,
+      settings: {
+        ...MOCK_DATA.settings,
+        stem_mode: "four_stem",
+      },
+      playbackSnapshot: {
+        ...MOCK_DATA.playbackSnapshot,
+        has_stems: true,
+        stem_mode: "four_stem",
+      },
+    });
     window.__TAURI_INTERNALS__ = internals;
     window.__TAURI_EVENT_PLUGIN_INTERNALS__ = eventPluginInternals;
   }

--- a/website/src/preview-aliases.ts
+++ b/website/src/preview-aliases.ts
@@ -1,0 +1,22 @@
+export const UNUSED_PREVIEW_MODULES = [
+  "components/Settings/SettingsOverlay",
+  "components/Settings/LibrarySetup",
+  "components/Settings/ConfirmationDialog",
+  "components/Settings/InputDialog",
+  "components/Player/QueuePanel",
+  "components/Lyrics/LyricsEditDialog",
+  "components/Layout/UpdateBanner",
+  "components/Layout/GlobalProgressBar",
+  "components/Layout/ToastContainer",
+  "components/Library/ImportCdgChoiceDialog",
+  "components/Bootstrap/ModelBootstrapBanner",
+  "components/Bootstrap/RuntimeUpdateBanner",
+] as const;
+
+export function escapeRegExpLiteral(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function previewUnusedModulePattern(modulePath: string): RegExp {
+  return new RegExp(`^@/${escapeRegExpLiteral(modulePath)}$`);
+}

--- a/website/src/preview-aliases.ts
+++ b/website/src/preview-aliases.ts
@@ -1,3 +1,6 @@
+export const PREVIEW_ROMANIZER_MODULE_PATTERN = /^@\/lib\/lyrics-romanizer$/;
+export const PREVIEW_I18N_MODULE_PATTERN = /^@\/lib\/i18n$/;
+
 export const UNUSED_PREVIEW_MODULES = [
   "components/Settings/SettingsOverlay",
   "components/Settings/LibrarySetup",

--- a/website/src/preview-covers.ts
+++ b/website/src/preview-covers.ts
@@ -1,0 +1,12 @@
+const coverModules = import.meta.glob<string>("../../src/mock/covers/*.jpg", {
+  eager: true,
+  query: "?url",
+  import: "default",
+});
+
+export const PREVIEW_COVER_URLS: Record<string, string> = Object.fromEntries(
+  Object.entries(coverModules).map(([path, url]) => {
+    const file = path.slice(path.lastIndexOf("/") + 1);
+    return [file.slice(0, -".jpg".length), url];
+  }),
+);

--- a/website/src/preview-i18n.ts
+++ b/website/src/preview-i18n.ts
@@ -1,27 +1,19 @@
 import i18next from "i18next";
 import { initReactI18next } from "react-i18next";
-import { createLanguageTable } from "./i18n-language";
+import { createLanguageTable } from "../../src/lib/i18n-language";
+import en from "../../src/locales/en.json";
+import zhCN from "../../src/locales/zh-CN.json";
 
 export type {
   SupportedLanguage,
   SupportedLanguageCode,
   SupportedLanguageNameKey,
-} from "./i18n-language";
+} from "../../src/lib/i18n-language";
 
-const localeModules = import.meta.glob<Record<string, unknown>>(
-  "../locales/*.json",
-  { eager: true, import: "default" },
-);
-
-function codeFromPath(path: string): string {
-  const file = path.slice(path.lastIndexOf("/") + 1);
-  return file.slice(0, -".json".length);
-}
-
-const translations: Record<string, Record<string, unknown>> = {};
-for (const [path, data] of Object.entries(localeModules)) {
-  translations[codeFromPath(path)] = data;
-}
+const translations = {
+  en,
+  "zh-CN": zhCN,
+} as const;
 
 export const { SUPPORTED_LANGUAGES, detectSystemLanguage, resolveAppLanguage } =
   createLanguageTable(Object.keys(translations));

--- a/website/src/preview-romanizer.ts
+++ b/website/src/preview-romanizer.ts
@@ -1,0 +1,8 @@
+import type { SongLanguage } from "@/components/Library/song-list-item-menu";
+
+export async function romanizeLyricsLines(
+  lines: readonly string[],
+  _language?: SongLanguage | null,
+): Promise<{ result: string[]; requestId: number }> {
+  return { result: [...lines], requestId: -1 };
+}

--- a/website/src/preview-unused.ts
+++ b/website/src/preview-unused.ts
@@ -1,0 +1,51 @@
+export function SettingsOverlay() {
+  return null;
+}
+
+export function LibrarySetup() {
+  return null;
+}
+
+export function ConfirmationDialog() {
+  return null;
+}
+
+export function InputDialog() {
+  return null;
+}
+
+export function QueuePanel() {
+  return null;
+}
+
+export function LyricsEditDialog() {
+  return null;
+}
+
+export function UpdateBanner() {
+  return null;
+}
+
+export function GlobalProgressBar() {
+  return null;
+}
+
+export function TaskProgressBar() {
+  return null;
+}
+
+export function ToastContainer() {
+  return null;
+}
+
+export function ImportCdgChoiceDialog() {
+  return null;
+}
+
+export function ModelBootstrapBanner() {
+  return null;
+}
+
+export function RuntimeUpdateBanner() {
+  return null;
+}

--- a/website/src/site.css
+++ b/website/src/site.css
@@ -445,11 +445,15 @@ a {
     [data-preview-lyrics-interactive="true"]
   ):not([data-preview-sidebar-toggle="true"]):not(
     [data-preview-play-toggle="true"]
-  ):not([data-preview-song-switch="true"]),
-.product-preview [data-preview-interaction-mode="playlist-only"] input,
+  ):not([data-preview-playback-interactive="true"]):not(
+    [data-preview-song-switch="true"]
+  ),
 .product-preview
   [data-preview-interaction-mode="playlist-only"]
-  [role="slider"] {
+  input:not([data-preview-playback-interactive="true"]),
+.product-preview
+  [data-preview-interaction-mode="playlist-only"]
+  [role="slider"]:not([data-preview-playback-interactive="true"]) {
   pointer-events: none;
   cursor: default;
 }
@@ -465,8 +469,30 @@ a {
   [data-preview-play-toggle="true"],
 .product-preview
   [data-preview-interaction-mode="playlist-only"]
+  [data-preview-playback-interactive="true"],
+.product-preview
+  [data-preview-interaction-mode="playlist-only"]
   [data-preview-song-switch="true"] {
   cursor: pointer;
+}
+
+.product-preview
+  [data-preview-interaction-mode="playlist-only"]
+  [data-preview-playback-interactive="true"],
+.product-preview
+  [data-preview-interaction-mode="playlist-only"]
+  [data-preview-playback-interactive="true"]
+  button,
+.product-preview
+  [data-preview-interaction-mode="playlist-only"]
+  [data-preview-playback-interactive="true"]
+  input,
+.product-preview
+  [data-preview-interaction-mode="playlist-only"]
+  [data-preview-playback-interactive="true"]
+  [role="slider"] {
+  pointer-events: auto !important;
+  cursor: pointer !important;
 }
 
 /* Lyrics utility controls (font size, offset) are wrapped in containers

--- a/website/src/slim-preview-catalog.ts
+++ b/website/src/slim-preview-catalog.ts
@@ -1,0 +1,11 @@
+export function isPreviewCatalogModule(id: string): boolean {
+  const normalized = id.replace(/\\/g, "/").split("?")[0];
+  return normalized.endsWith("/src/mock/preview-songs.ts");
+}
+
+export function slimPreviewCatalogSource(code: string): string {
+  return code
+    .replace(/cover_art_base64:\s*"[^"]*"/g, 'cover_art_base64: ""')
+    .replace(/raw_lrc:\s*'(?:\\.|[^'\\])*'/g, "raw_lrc: ''")
+    .replace(/raw_lrc:\s*"(?:\\.|[^"\\])*"/g, 'raw_lrc: ""');
+}

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -3,28 +3,13 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { fileURLToPath, URL } from "node:url";
 import {
+  UNUSED_PREVIEW_MODULES,
+  previewUnusedModulePattern,
+} from "./src/preview-aliases";
+import {
   isPreviewCatalogModule,
   slimPreviewCatalogSource,
 } from "./src/slim-preview-catalog";
-
-const unusedPreviewModules = [
-  "components/Settings/SettingsOverlay",
-  "components/Settings/LibrarySetup",
-  "components/Settings/ConfirmationDialog",
-  "components/Settings/InputDialog",
-  "components/Player/QueuePanel",
-  "components/Lyrics/LyricsEditDialog",
-  "components/Layout/UpdateBanner",
-  "components/Layout/GlobalProgressBar",
-  "components/Layout/ToastContainer",
-  "components/Library/ImportCdgChoiceDialog",
-  "components/Bootstrap/ModelBootstrapBanner",
-  "components/Bootstrap/RuntimeUpdateBanner",
-];
-
-function escapeRegExpLiteral(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
 
 function slimPreviewCatalogPlugin(): Plugin {
   return {
@@ -62,8 +47,8 @@ export default defineConfig({
           new URL("./src/preview-i18n.ts", import.meta.url),
         ),
       },
-      ...unusedPreviewModules.map((modulePath) => ({
-        find: new RegExp(`^@/${escapeRegExpLiteral(modulePath)}$`),
+      ...UNUSED_PREVIEW_MODULES.map((modulePath) => ({
+        find: previewUnusedModulePattern(modulePath),
         replacement: fileURLToPath(
           new URL("./src/preview-unused.ts", import.meta.url),
         ),

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -3,6 +3,8 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { fileURLToPath, URL } from "node:url";
 import {
+  PREVIEW_I18N_MODULE_PATTERN,
+  PREVIEW_ROMANIZER_MODULE_PATTERN,
   UNUSED_PREVIEW_MODULES,
   previewUnusedModulePattern,
 } from "./src/preview-aliases";
@@ -36,13 +38,13 @@ export default defineConfig({
   resolve: {
     alias: [
       {
-        find: /^@\/lib\/lyrics-romanizer$/,
+        find: PREVIEW_ROMANIZER_MODULE_PATTERN,
         replacement: fileURLToPath(
           new URL("./src/preview-romanizer.ts", import.meta.url),
         ),
       },
       {
-        find: /^@\/lib\/i18n$/,
+        find: PREVIEW_I18N_MODULE_PATTERN,
         replacement: fileURLToPath(
           new URL("./src/preview-i18n.ts", import.meta.url),
         ),

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -22,6 +22,10 @@ const unusedPreviewModules = [
   "components/Bootstrap/RuntimeUpdateBanner",
 ];
 
+function escapeRegExpLiteral(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function slimPreviewCatalogPlugin(): Plugin {
   return {
     name: "slim-preview-catalog",
@@ -59,7 +63,7 @@ export default defineConfig({
         ),
       },
       ...unusedPreviewModules.map((modulePath) => ({
-        find: new RegExp(`^@\\/${modulePath.replace(/\//g, "\\/")}$`),
+        find: new RegExp(`^@/${escapeRegExpLiteral(modulePath)}$`),
         replacement: fileURLToPath(
           new URL("./src/preview-unused.ts", import.meta.url),
         ),

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -1,7 +1,41 @@
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { fileURLToPath, URL } from "node:url";
+import {
+  isPreviewCatalogModule,
+  slimPreviewCatalogSource,
+} from "./src/slim-preview-catalog";
+
+const unusedPreviewModules = [
+  "components/Settings/SettingsOverlay",
+  "components/Settings/LibrarySetup",
+  "components/Settings/ConfirmationDialog",
+  "components/Settings/InputDialog",
+  "components/Player/QueuePanel",
+  "components/Lyrics/LyricsEditDialog",
+  "components/Layout/UpdateBanner",
+  "components/Layout/GlobalProgressBar",
+  "components/Layout/ToastContainer",
+  "components/Library/ImportCdgChoiceDialog",
+  "components/Bootstrap/ModelBootstrapBanner",
+  "components/Bootstrap/RuntimeUpdateBanner",
+];
+
+function slimPreviewCatalogPlugin(): Plugin {
+  return {
+    name: "slim-preview-catalog",
+    transform(code, id) {
+      if (!isPreviewCatalogModule(id)) {
+        return null;
+      }
+      return {
+        code: slimPreviewCatalogSource(code),
+        map: null,
+      };
+    },
+  };
+}
 
 export default defineConfig({
   root: fileURLToPath(new URL(".", import.meta.url)),
@@ -9,11 +43,32 @@ export default defineConfig({
   // No CNAME → no custom domain redirect. The xyz domain stays registered for
   // Dropbox app configuration but no longer serves the site.
   base: "/OpenKara/",
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), slimPreviewCatalogPlugin()],
   resolve: {
-    alias: {
-      "@": fileURLToPath(new URL("../src", import.meta.url)),
-    },
+    alias: [
+      {
+        find: /^@\/lib\/lyrics-romanizer$/,
+        replacement: fileURLToPath(
+          new URL("./src/preview-romanizer.ts", import.meta.url),
+        ),
+      },
+      {
+        find: /^@\/lib\/i18n$/,
+        replacement: fileURLToPath(
+          new URL("./src/preview-i18n.ts", import.meta.url),
+        ),
+      },
+      ...unusedPreviewModules.map((modulePath) => ({
+        find: new RegExp(`^@\\/${modulePath.replace(/\//g, "\\/")}$`),
+        replacement: fileURLToPath(
+          new URL("./src/preview-unused.ts", import.meta.url),
+        ),
+      })),
+      {
+        find: "@",
+        replacement: fileURLToPath(new URL("../src", import.meta.url)),
+      },
+    ],
   },
   server: {
     host: "0.0.0.0",


### PR DESCRIPTION
## What changed

Centered lyrics now browse more like Apple Music: a flick keeps inertia, then the viewport settles on a lyric line at the focus slot instead of an arbitrary Y. Discrete mouse wheels step one line. The focus stage also tightens karaoke contrast, 38% alignment, and neighbor scale/blur.

The landing preview still mounts the real App. Website-only aliases drop the romanizer worker, extra locales, and unused overlays, and strip inline catalog payloads. JPEG covers load through `get_cover_art`. Play, seek, volume, and four-stem mixers stay interactive. Demo songs look already four-stem separated.

`.grok/` is gitignored so local agent workspace files stay out of the tree.

## Standards

- Profile: [Interaction and accessibility](docs/references/standards/interaction-and-accessibility.md)
- Evidence: lyrics-scroll / lyrics-engine / LyricLine / karaoke-fill unit tests; preview pointer contract, AppLayout preview tests, catalog slim tests; live play/seek/volume smoke on the landing preview
- IPC contracts: unchanged

## Verification

- [x] `pnpm lint` — PASS
- [x] `pnpm build` — PASS
- [x] `pnpm test` — PASS (210 files, 2338 tests)
- [x] pre-push patch coverage 86.5% (target 80%)
- [ ] `pnpm tauri build` / `cargo test` — SKIPPED (no Rust change)

## Residual risk

Browsing lyrics still relocks to the playing line after a few idle seconds. Scroll-to-seek is not part of this change. Landing preview playback remains mock audio with a position clock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added inertial lyric scrolling with line snapping, discrete wheel navigation, focus-stage alignment, and reduced-motion support.
- Updated lyric focus styling with improved contrast, scale, blur, spacing, and typography.
- Kept karaoke masks only on active lines and reset masks when lines deactivate.
- Enabled interactive playback controls in the landing preview.
- Slimmed preview data by removing embedded artwork and lyric payloads.
- Added JPEG cover-art loading and completed four-stem preview data.
- Added preview fallbacks for romanization, i18n, and unused application surfaces.
- Centralized language detection and persisted-language resolution.
- Escaped regular-expression metacharacters when matching preview aliases.
- Ignored local `.grok/` workspace files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->