### PR TITLE
fix(settings): serialize optimistic preference writes

### DIFF
--- a/src/lib/lyrics-line-runtime.test.ts
+++ b/src/lib/lyrics-line-runtime.test.ts
@@ -194,14 +194,15 @@ describe("LyricsLineRuntime", () => {
     const runtime = new LyricsLineRuntime();
     const live = document.createElement("div");
     const stale = document.createElement("div");
+    const liveKaraoke = { update: vi.fn() };
+    const detachedKaraoke = { update: vi.fn() };
     runtime.registerWrapper(0, live);
     runtime.registerWrapper(1, stale);
-    runtime.registerKaraoke(0, {
-      update: vi.fn(),
-    } as unknown as KaraokeFillController);
-    runtime.registerKaraoke(1, {
-      update: vi.fn(),
-    } as unknown as KaraokeFillController);
+    runtime.registerKaraoke(0, liveKaraoke as unknown as KaraokeFillController);
+    runtime.registerKaraoke(
+      1,
+      detachedKaraoke as unknown as KaraokeFillController,
+    );
     runtime.unregisterWrapper(1);
 
     runtime.clearUnmounted();
@@ -215,6 +216,18 @@ describe("LyricsLineRuntime", () => {
     });
     expect(live.style.transform).toContain("scale(");
     expect(stale.style.transform).toBe("");
+    expect(liveKaraoke.update).toHaveBeenCalledWith(0, true);
+
+    liveKaraoke.update.mockClear();
+    runtime.tick({
+      activeLineIndex: 1,
+      adjustedMs: 800,
+      isPlaying: true,
+      dt: 0.05,
+      isPlainText: false,
+    });
+    expect(detachedKaraoke.update).not.toHaveBeenCalled();
+    expect(liveKaraoke.update).not.toHaveBeenCalled();
   });
 
   test("re-registering an existing wrapper only updates the element pointer", () => {

--- a/src/lib/settings-controller/settings-controller.test.ts
+++ b/src/lib/settings-controller/settings-controller.test.ts
@@ -787,6 +787,45 @@ describe("preferences", () => {
     expect(harness.view().preferences.lyricsBlurInactive).toBe(false);
   });
 
+  test("overlapping lyrics blur writes keep the last requested value", async () => {
+    let stored = appSettings();
+    let releaseFirst: ((settings: AppSettings) => void) | undefined;
+    const firstWrite = new Promise<AppSettings>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const setLyricsBlurInactive = vi
+      .fn<(value: boolean) => Promise<AppSettings>>()
+      .mockImplementationOnce(() => firstWrite)
+      .mockImplementation(async (value: boolean) => {
+        stored = { ...stored, lyrics_blur_inactive: value };
+        return stored;
+      });
+    const harness = createSettingsHarness({
+      overrides: {
+        settings: { setLyricsBlurInactive },
+      },
+    });
+
+    const first = harness.controller.preferences.set({
+      lyricsBlurInactive: true,
+    });
+    const second = harness.controller.preferences.set({
+      lyricsBlurInactive: false,
+    });
+
+    await vi.waitFor(() => {
+      expect(setLyricsBlurInactive).toHaveBeenCalledTimes(1);
+    });
+    expect(setLyricsBlurInactive).toHaveBeenCalledWith(true);
+
+    releaseFirst?.({ ...stored, lyrics_blur_inactive: true });
+    await first;
+    await second;
+
+    expect(setLyricsBlurInactive).toHaveBeenNthCalledWith(2, false);
+    expect(harness.view().preferences.lyricsBlurInactive).toBe(false);
+  });
+
   test("the equaliser clamps gains to ±12 dB", async () => {
     const setEqGains = vi.fn(async () =>
       appSettings({ eq_gains_db: [12, -12, 0, 0, 0] }),

--- a/src/lib/settings-controller/settings-controller.ts
+++ b/src/lib/settings-controller/settings-controller.ts
@@ -347,27 +347,49 @@ export function createSettingsController({
     }
   };
 
+  const optimisticWriteByKey = new Map<string, Promise<void>>();
+
+  const enqueueOptimisticWrite = (
+    keys: string[],
+    task: () => Promise<void>,
+  ): Promise<void> => {
+    const pending = keys
+      .map((key) => optimisticWriteByKey.get(key))
+      .filter((write): write is Promise<void> => write !== undefined);
+    const run =
+      pending.length === 0 ? task() : Promise.all(pending).then(task, task);
+    const settled = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    for (const key of keys) {
+      optimisticWriteByKey.set(key, settled);
+    }
+    return run;
+  };
+
   const writeOptimisticPreference = async (
     patch: Partial<AppSettingsSnapshot>,
     write: () => Promise<AppSettings>,
   ) => {
-    const previous = stores.preferences.getSnapshot();
-    stores.preferences.patch(patch);
-    syncStores();
-    try {
-      stores.preferences.hydrate(await write());
-    } catch (error) {
-      const rollback = Object.fromEntries(
-        (Object.keys(patch) as Array<keyof AppSettingsSnapshot>).map((key) => [
-          key,
-          previous[key],
-        ]),
-      ) as Partial<AppSettingsSnapshot>;
-      stores.preferences.patch(rollback);
-      notifyError(error);
-    } finally {
+    await enqueueOptimisticWrite(Object.keys(patch), async () => {
+      const previous = stores.preferences.getSnapshot();
+      stores.preferences.patch(patch);
       syncStores();
-    }
+      try {
+        stores.preferences.hydrate(await write());
+      } catch (error) {
+        const rollback = Object.fromEntries(
+          (Object.keys(patch) as Array<keyof AppSettingsSnapshot>).map(
+            (key) => [key, previous[key]],
+          ),
+        ) as Partial<AppSettingsSnapshot>;
+        stores.preferences.patch(rollback);
+        notifyError(error);
+      } finally {
+        syncStores();
+      }
+    });
   };
 
   const writeStorePreference = async (write: () => Promise<void>) => {


### PR DESCRIPTION
## What changed

Follow-up to #416 CodeRabbit comments.

`clearUnmounted` now has a regression check that a detached karaoke controller is not ticked. Optimistic preference writes for the same key are queued so a late success or rollback cannot overwrite a newer value.

## Standards

- Profile: [Interaction and accessibility](docs/references/standards/interaction-and-accessibility.md)
- Evidence: settings-controller overlapping-write test; lyrics-line-runtime detached karaoke assertion
- IPC contracts: unchanged

## Verification

- [x] `pnpm lint` — PASS
- [x] targeted vitest — PASS
- [x] pre-push patch coverage 95.4% (target 80%)
- [ ] `pnpm build` / `pnpm test` full suite — covered by CI
- [ ] `pnpm tauri build` — SKIPPED (no Rust/packaging change)

## Residual risk

Writes for different preference keys can still run in parallel. That is intentional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- `clearUnmounted` no longer updates detached karaoke controllers.
- Optimistic preference writes for the same key now execute in order. Late responses cannot overwrite newer values.
- Writes for different preference keys continue in parallel.
- Failed writes still roll back and report errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->