### PR TITLE
ci: run lightweight jobs on ubuntu-slim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,7 +516,7 @@ jobs:
     if: |
       !cancelled() &&
       needs.triage.outputs.run_workflow-lint == 'true'
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
   # Windows #284 core. See docs/CI_LAYERS.md.
   triage:
     name: Triage
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:
       contents: read
@@ -262,7 +262,7 @@ jobs:
   conventional-commits:
     name: Conventional commits
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     timeout-minutes: 5
 
     steps:
@@ -280,7 +280,7 @@ jobs:
     if: |
       !cancelled() &&
       needs.triage.outputs.run_standards-reference == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     timeout-minutes: 5
 
     steps:
@@ -516,7 +516,7 @@ jobs:
     if: |
       !cancelled() &&
       needs.triage.outputs.run_workflow-lint == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     timeout-minutes: 5
 
     permissions:

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   mirror:
     name: Mirror
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   mirror:
     name: Mirror
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -45,7 +45,7 @@ jobs:
   # truth shared with the main CI workflow.
   triage:
     name: Triage
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     outputs:
       packaging_inputs: ${{ steps.classify.outputs.packaging_inputs }}


### PR DESCRIPTION
Moves triage, conventional-commits, standards-reference, workflow-lint, packaging triage, and Codeberg mirror onto `ubuntu-slim`. Rust/Tauri/Playwright jobs stay on full runners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## CI runner updates

- Run lightweight triage, conventional-commits, standards-reference, and packaging triage jobs on `ubuntu-slim`.
- Keep Docker-dependent mirror and workflow-lint jobs on `ubuntu-latest`.
- Keep Rust, Tauri, and Playwright jobs on full runners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->